### PR TITLE
Allow external DB instead of always installing etcd

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,27 @@ Lastly, edit the storage nodes' LVM VG and LV names in examples/piraeus-operator
 kubectl create -f examples/piraeus-operator-part-2.yaml
 ```
 
+## Upgrading
+
+While the API version remains at `v1alpha1`, this project does not maintain
+stability of or provide conversion of the Custom Resource Definitions.
+
+If you are using the Helm deployment, you may find that upgrades fail with
+errors similar to the following:
+
+```
+UPGRADE FAILED: cannot patch "piraeus-op-cs" with kind LinstorControllerSet: LinstorControllerSet.piraeus.linbit.com "piraeus-op-cs" is invalid: spec.etcdURL: Required value
+```
+
+The simplest solution in this case is to manually replace the CRD:
+
+```
+kubectl replace -f charts/piraeus/crds/operator-controllerset-crd.yaml
+```
+
+Then continue with the Helm upgrade. Values that are lost during the
+replacement will be set again by Helm.
+
 ## License
 
 Apache 2.0

--- a/README.md
+++ b/README.md
@@ -90,6 +90,24 @@ Persistence for etcd is enabled by default. The
 `etcd.volumePermissions.enabled` key in the Helm values is also set so that the
 `hostPath` volumes have appropriate permissions.
 
+### Using an existing database
+
+LINSTOR can connect to an existing PostgreSQL, MariaDB or etcd database. For
+instance, for a PostgresSQL instance with the following configuration:
+
+```
+POSTGRES_DB: postgresdb
+POSTGRES_USER: postgresadmin
+POSTGRES_PASSWORD: admin123
+```
+
+The Helm chart can be configured to use this database instead of deploying an
+etcd cluster by adding the following to the Helm install command:
+
+```
+--set etcd.enabled=false --set "operator.controllerSet.spec.dbConnectionURL=jdbc:postgresql://postgres/postgresdb?user=postgresadmin&password=admin123"
+```
+
 ### Terminating Helm deployment
 
 The Piraeus deployment can be terminated with:

--- a/charts/piraeus/Chart.yaml
+++ b/charts/piraeus/Chart.yaml
@@ -9,3 +9,4 @@ dependencies:
   - name: "etcd"
     version: "4.4.10"
     repository: "https://charts.bitnami.com/bitnami"
+    condition: etcd.enabled

--- a/charts/piraeus/crds/operator-controllerset-crd.yaml
+++ b/charts/piraeus/crds/operator-controllerset-crd.yaml
@@ -35,8 +35,8 @@ spec:
             priorityClassName:
               description: priorityClassName is the name of the PriorityClass for the controller set
               type: string
-            etcdURL:
-              description: EtcdURL is the URL of the ETCD endpoint for LINSTOR Controller
+            dbConnectionURL:
+              description: DBConnectionURL is the URL of the ETCD endpoint for LINSTOR Controller
               type: string
             drbdRepoCred:
               description: DrbdRepoCred is the name of the kubernetes secret that
@@ -52,7 +52,7 @@ spec:
               type: string
           required:
           - priorityClassName
-          - etcdURL
+          - dbConnectionURL
           - drbdRepoCred
           - controllerImage
           - controllerVersion

--- a/charts/piraeus/templates/operator-controllerset.yaml
+++ b/charts/piraeus/templates/operator-controllerset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "operator.fullname" . }}-cs
 spec:
   priorityClassName: {{ template "operator.fullname" . }}-cs-priority-class
-  etcdURL: etcd://{{ .Release.Name }}-etcd:2379 
+  dbConnectionURL:  {{ .Values.operator.controllerSet.spec.dbConnectionURL | default (print "etcd://" .Release.Name "-etcd:2379") }}
   drbdRepoCred: {{ .Values.drbdRepoCred }}
   controllerImage: {{ .Values.operator.controllerSet.spec.controllerImage }}
   controllerVersion: {{ .Values.operator.controllerSet.spec.controllerVersion }}

--- a/pkg/apis/piraeus/v1alpha1/linstorcontrollerset_types.go
+++ b/pkg/apis/piraeus/v1alpha1/linstorcontrollerset_types.go
@@ -33,7 +33,7 @@ type LinstorControllerSetSpec struct {
 	// PriorityClassName is the name of the PriorityClass for the controller set
 	PriorityClassName string `json:"priorityClassName"`
 
-	EtcdURL           string `json:"etcdURL"`
+	DBConnectionURL   string `json:"dbConnectionURL"`
 	DrbdRepoCred      string `json:"drbdRepoCred"`
 	ControllerImage   string `json:"controllerImage"`
 	ControllerVersion string `json:"controllerVersion"`

--- a/pkg/controller/linstorcontrollerset/linstorcontrollerset_controller.go
+++ b/pkg/controller/linstorcontrollerset/linstorcontrollerset_controller.go
@@ -599,11 +599,11 @@ func newServiceForPCS(pcs *piraeusv1alpha1.LinstorControllerSet) *corev1.Service
 
 func newConfigMapForPCS(pcs *piraeusv1alpha1.LinstorControllerSet) *corev1.ConfigMap {
 
-	if pcs.Spec.EtcdURL == "" {
+	if pcs.Spec.DBConnectionURL == "" {
 		if pcs.Name[len(pcs.Name)-3:len(pcs.Name)] == "-cs" {
-			pcs.Spec.EtcdURL = "etcd://" + pcs.Name[0:len(pcs.Name)-3] + "-etcd:2379"
+			pcs.Spec.DBConnectionURL = "etcd://" + pcs.Name[0:len(pcs.Name)-3] + "-etcd:2379"
 		} else {
-			pcs.Spec.EtcdURL = "etcd://" + pcs.Name + "-etcd:2379"
+			pcs.Spec.DBConnectionURL = "etcd://" + pcs.Name + "-etcd:2379"
 		}
 	}
 
@@ -617,7 +617,7 @@ func newConfigMapForPCS(pcs *piraeusv1alpha1.LinstorControllerSet) *corev1.Confi
 				`
 				[db]
 					connection_url = "%s"
-				`, pcs.Spec.EtcdURL)},
+				`, pcs.Spec.DBConnectionURL)},
 	}
 
 	return cm


### PR DESCRIPTION
This requires LINSTOR v1.6.0+.

### Usage

Set up a postgres DB with service name "postgres" and the following configuration:

```
  POSTGRES_DB: postgresdb
  POSTGRES_USER: postgresadmin
  POSTGRES_PASSWORD: admin123
```

Add this to the helm install command:

```
--set "operator.controllerSet.spec.dbConnectionURL=jdbc:postgresql://postgres/postgresdb?user=postgresadmin&password=admin123" --set etcd.enabled=false
```