### PR TITLE
replace gitlab with github links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ suitable for testing and development.
 This Operator is currently under heavy development: documentation and examples
 will change frequently. Always use the latest release.
 
-If you'd like to contribute, please visit https://gitlab.com/linbit/piraeus-operator
-and look through the issues to see if there something you'd like to work on. If
+If you'd like to contribute, please visit https://github.com/piraeusdatastore/piraeus-operator
+and look through the issues to see if there is something you'd like to work on. If
 you'd like to contribute something not in an existing issue, please open a new
 issue beforehand.
 
 If you'd like to report an issue, please use the issues interface in this
-project's gitlab page.
+project's github page.
 
 ## Building and Development
 


### PR DESCRIPTION
Just a small update on the README, replacing the old gitlab references with github.