### PR TITLE
simplify image selection by using plain strings

### DIFF
--- a/charts/piraeus/crds/operator-controllerset-crd.yaml
+++ b/charts/piraeus/crds/operator-controllerset-crd.yaml
@@ -43,11 +43,7 @@ spec:
                 holds the credential for the DRBD repositories
               type: string
             controllerImage:
-              description: controllerImage is the image location for the LINSTOR
-                controller/server container
-              type: string
-            controllerVersion:
-              description: controllerVersion is the image tag/version for the LINSTOR
+              description: controllerImage is the image (location + tag) for the LINSTOR
                 controller/server container
               type: string
           required:
@@ -55,7 +51,6 @@ spec:
           - dbConnectionURL
           - drbdRepoCred
           - controllerImage
-          - controllerVersion
           type: object
         status:
           description: LinstorControllerSetStatus defines the observed state of LinstorControllerSet

--- a/charts/piraeus/crds/operator-nodeset-crd.yaml
+++ b/charts/piraeus/crds/operator-nodeset-crd.yaml
@@ -87,19 +87,11 @@ spec:
                 holds the credential for the DRBD repositories
               type: string
             satelliteImage:
-              description: satelliteImage is the image location for the LINSTOR
-                satellite container
-              type: string
-            satelliteVersion:
-              description: satelliteVersion is the image tag/version for the LINSTOR
+              description: satelliteImage is the image (location + tag) for the LINSTOR
                 satellite container
               type: string
             kernelModImage:
-              description: kernelModImage is the image location for the LINSTOR/
-                DRBD kernel module injector container
-              type: string
-            kernelModVersion:
-              description: kernelModVersion is the image tag/version for the LINSTOR/
+              description: kernelModImage is the image (location + tag) for the LINSTOR/
                 DRBD kernel module injector container
               type: string
           required:
@@ -107,9 +99,7 @@ spec:
           - drbdKernelModuleInjectionMode
           - drbdRepoCred
           - satelliteImage
-          - satelliteVersion
           - kernelModImage
-          - kernelModVersion
           type: object
         status:
           description: LinstorNodeSetStatus defines the observed state of LinstorNodeSet

--- a/charts/piraeus/templates/csi-controller.yaml
+++ b/charts/piraeus/templates/csi-controller.yaml
@@ -71,7 +71,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: linstor-csi-plugin
-          image: {{ .Values.csi.image.repo }}/{{ .Values.csi.image.name }}:{{ .Values.csi.image.version }}
+          image: {{ .Values.csi.image }}
           args:
             - "--csi-endpoint=$(CSI_ENDPOINT)"
             - "--node=$(KUBE_NODE_NAME)"

--- a/charts/piraeus/templates/csi-node.yaml
+++ b/charts/piraeus/templates/csi-node.yaml
@@ -48,7 +48,7 @@ spec:
             - name: registration-dir
               mountPath: /registration/
         - name: linstor-csi-plugin
-          image: {{ .Values.csi.image.repo }}/{{ .Values.csi.image.name }}:{{ .Values.csi.image.version }}
+          image: {{ .Values.csi.image }}
           args:
             - "--csi-endpoint=$(CSI_ENDPOINT)"
             - "--node=$(KUBE_NODE_NAME)"

--- a/charts/piraeus/templates/operator-controllerset.yaml
+++ b/charts/piraeus/templates/operator-controllerset.yaml
@@ -7,4 +7,3 @@ spec:
   dbConnectionURL:  {{ .Values.operator.controllerSet.spec.dbConnectionURL | default (print "etcd://" .Release.Name "-etcd:2379") }}
   drbdRepoCred: {{ .Values.drbdRepoCred }}
   controllerImage: {{ .Values.operator.controllerSet.spec.controllerImage }}
-  controllerVersion: {{ .Values.operator.controllerSet.spec.controllerVersion }}

--- a/charts/piraeus/templates/operator-deployment.yaml
+++ b/charts/piraeus/templates/operator-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: {{ template "operator.fullname" . }}-operator
       containers:
         - name: piraeus-operator
-          image: {{ .Values.operator.image.repo }}/{{ .Values.operator.image.name }}:{{ .Values.operator.image.version }}
+          image: {{ .Values.operator.image }}
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/charts/piraeus/templates/operator-nodeset.yaml
+++ b/charts/piraeus/templates/operator-nodeset.yaml
@@ -7,9 +7,7 @@ spec:
   drbdKernelModuleInjectionMode: {{ .Values.operator.nodeSet.spec.drbdKernelModuleInjectionMode }}
   drbdRepoCred: {{ .Values.drbdRepoCred }}
   satelliteImage: {{ .Values.operator.nodeSet.spec.satelliteImage }}
-  satelliteVersion: {{ .Values.operator.nodeSet.spec.satelliteVersion }}
   kernelModImage: {{ .Values.operator.nodeSet.spec.kernelModImage }}
-  kernelModVersion: {{ .Values.operator.nodeSet.spec.kernelModVersion }}
   {{- if .Values.operator.nodeSet.spec.storagePools }}
   storagePools:
 {{ toYaml .Values.operator.nodeSet.spec.storagePools | indent 4 }}

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -11,25 +11,16 @@ etcd:
     replicaCount: 3
   envVarsConfigMap: "etcd-env-vars"
 csi:
-  image:
-    repo: "quay.io/piraeusdatastore"
-    name: "piraeus-csi"
-    version: "v0.7.4"
+  image: "quay.io/piraeusdatastore/piraeus-csi:v0.7.4"
 drbdRepoCred: drbdiocred     # <- Specify the kubernetes secret name here
 operator:
-  image:
-    repo: "quay.io/piraeusdatastore"
-    name: "piraeus-operator"
-    version: "v0.2.2"
+  image: "quay.io/piraeusdatastore/piraeus-operator:v0.2.2"
   controllerSet:
     spec:
-      controllerImage: "quay.io/piraeusdatastore/piraeus-server"
-      controllerVersion: "v1.6.1"
+      controllerImage: "quay.io/piraeusdatastore/piraeus-server:v1.6.1"
   nodeSet:
     spec:
       drbdKernelModuleInjectionMode: Compile
-      satelliteImage: "quay.io/piraeusdatastore/piraeus-server"
-      satelliteVersion: "v1.6.1"
-      kernelModImage: "quay.io/piraeusdatastore/drbd9-bionic"
-      kernelModVersion: "v9.0.22"
+      satelliteImage: "quay.io/piraeusdatastore/piraeus-server:v1.6.1"
+      kernelModImage: "quay.io/piraeusdatastore/drbd9-bionic:v9.0.22"
       storagePools: null

--- a/examples/piraeus-operator-part-2.yaml
+++ b/examples/piraeus-operator-part-2.yaml
@@ -11,9 +11,8 @@ spec:
   # K8s secret for repo credential
   drbdRepoCred: "drbdiocred"
 
-  # LINSTOR Controller source and tag/version
-  controllerImage: "quay.io/piraeusdatastore/piraeus-server"
-  controllerVersion: "v1.4.3"
+  # LINSTOR Controller image
+  controllerImage: "quay.io/piraeusdatastore/piraeus-server:v1.4.3"
 ---
 apiVersion: piraeus.linbit.com/v1alpha1
 kind: LinstorNodeSet
@@ -27,13 +26,11 @@ spec:
   # K8s secret for repo credential
   drbdRepoCred: "drbdiocred"
 
-  # LINSTOR Satellite image source and tag/version
-  satelliteImage: "quay.io/piraeusdatastore/piraeus-server"
-  satelliteVersion: "v1.4.3"
+  # LINSTOR Satellite image
+  satelliteImage: "quay.io/piraeusdatastore/piraeus-server:v1.4.3"
 
-  # DRBD kernel injection image source and tag/version
-  kernelModImage: "quay.io/piraeusdatastore/drbd9-bionic"
-  kernelModVersion: "v9.0.21"
+  # DRBD kernel injection image
+  kernelModImage: "quay.io/piraeusdatastore/drbd9-bionic:v9.0.21"
 
   # StoragePools for the NodeSet to manage.
   storagePools:

--- a/pkg/apis/piraeus/v1alpha1/linstorcontrollerset_types.go
+++ b/pkg/apis/piraeus/v1alpha1/linstorcontrollerset_types.go
@@ -36,7 +36,6 @@ type LinstorControllerSetSpec struct {
 	DBConnectionURL   string `json:"dbConnectionURL"`
 	DrbdRepoCred      string `json:"drbdRepoCred"`
 	ControllerImage   string `json:"controllerImage"`
-	ControllerVersion string `json:"controllerVersion"`
 }
 
 // LinstorControllerSetStatus defines the observed state of LinstorControllerSet

--- a/pkg/apis/piraeus/v1alpha1/linstornodeset_types.go
+++ b/pkg/apis/piraeus/v1alpha1/linstornodeset_types.go
@@ -42,15 +42,11 @@ type LinstorNodeSetSpec struct {
 	//DrbdRepoCred is the name of the k8s secret with the repo credential
 	DrbdRepoCred string `json:"drbdRepoCred"`
 
-	//SatelliteImage is the LINSTOR Satellite image location
+	//SatelliteImage is the LINSTOR Satellite image (location + tag)
 	SatelliteImage string `json:"satelliteImage"`
 
-	//SatelliteVersion is the LINSTOR Satellite image location
-	SatelliteVersion string `json:"satelliteVersion"`
-
-	//KernelModImage & Version  is the DRBD Kernel injection image location and version/tag
+	//KernelModImage is the DRBD Kernel injection image (location + tag)
 	KernelModImage   string `json:"kernelModImage"`
-	KernelModVersion string `json:"kernelModVersion"`
 }
 
 // KernelModuleInjectionMode describes the source for injecting a kernel module

--- a/pkg/controller/linstorcontrollerset/linstorcontrollerset_controller.go
+++ b/pkg/controller/linstorcontrollerset/linstorcontrollerset_controller.go
@@ -491,10 +491,6 @@ func newStatefulSetForPCS(pcs *piraeusv1alpha1.LinstorControllerSet) *appsv1.Sta
 		pcs.Spec.ControllerImage = kubeSpec.PiraeusControllerImage
 	}
 
-	if pcs.Spec.ControllerVersion == "" {
-		pcs.Spec.ControllerVersion = kubeSpec.PiraeusControllerVersion
-	}
-
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pcs.Name + "-controller",
@@ -515,7 +511,7 @@ func newStatefulSetForPCS(pcs *piraeusv1alpha1.LinstorControllerSet) *appsv1.Sta
 					Containers: []corev1.Container{
 						{
 							Name:            "linstor-controller",
-							Image:           pcs.Spec.ControllerImage + ":" + pcs.Spec.ControllerVersion,
+							Image:           pcs.Spec.ControllerImage,
 							Args:            []string{"startController"}, // Run linstor-controller.
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							SecurityContext: &corev1.SecurityContext{Privileged: &kubeSpec.Privileged},

--- a/pkg/controller/linstornodeset/linstornodeset_controller.go
+++ b/pkg/controller/linstornodeset/linstornodeset_controller.go
@@ -490,16 +490,8 @@ func newDaemonSetforPNS(pns *piraeusv1alpha1.LinstorNodeSet) *apps.DaemonSet {
 		pns.Spec.SatelliteImage = kubeSpec.PiraeusSatelliteImage
 	}
 
-	if pns.Spec.SatelliteVersion == "" {
-		pns.Spec.SatelliteVersion = kubeSpec.PiraeusSatelliteVersion
-	}
-
 	if pns.Spec.KernelModImage == "" {
 		pns.Spec.KernelModImage = kubeSpec.PiraeusKernelModImage
-	}
-
-	if pns.Spec.KernelModVersion == "" {
-		pns.Spec.KernelModVersion = kubeSpec.PiraeusKernelModVersion
 	}
 
 	ds := &apps.DaemonSet{
@@ -540,7 +532,7 @@ func newDaemonSetforPNS(pns *piraeusv1alpha1.LinstorNodeSet) *apps.DaemonSet {
 					Containers: []corev1.Container{
 						{
 							Name:            "linstor-satellite",
-							Image:           pns.Spec.SatelliteImage + ":" + pns.Spec.SatelliteVersion,
+							Image:           pns.Spec.SatelliteImage,
 							Args:            []string{"startSatellite"}, // Run linstor-satellite.
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							SecurityContext: &corev1.SecurityContext{Privileged: &kubeSpec.Privileged},
@@ -662,7 +654,7 @@ func daemonSetWithDRBDKernelModuleInjection(ds *apps.DaemonSet, pns *piraeusv1al
 	ds.Spec.Template.Spec.InitContainers = []corev1.Container{
 		{
 			Name:            "drbd-kernel-module-injector",
-			Image:           pns.Spec.KernelModImage + ":" + pns.Spec.KernelModVersion,
+			Image:           pns.Spec.KernelModImage,
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			SecurityContext: &corev1.SecurityContext{Privileged: &kubeSpec.Privileged},
 			Env: []corev1.EnvVar{

--- a/pkg/k8s/spec/const.go
+++ b/pkg/k8s/spec/const.go
@@ -62,20 +62,13 @@ const (
 	PiraeusNSPriorityClassName = "piraeus-ns-priority-class"
 
 	// PiraeusControllerImage is the repo/tag for linstor-server
-	PiraeusControllerImage = "quay.io/piraeusdatastore/piraeus-server"
-	// PiraeusControllerVersion must match PiraeusSatelliteVersion since the
-	// linstor controller and satellite versions must also match exactly
-	PiraeusControllerVersion = "v1.4.2"
+	PiraeusControllerImage = "quay.io/piraeusdatastore/piraeus-server:v1.4.2"
 
 	// PiraeusSatelliteImage is the repo/tag for LINSTOR Satellite contaier.
-	PiraeusSatelliteImage = "quay.io/piraeusdatastore/piraeus-server"
-	// PiraeusSatelliteVersion is the release tag for the above image
-	PiraeusSatelliteVersion = "v1.4.2"
+	PiraeusSatelliteImage = "quay.io/piraeusdatastore/piraeus-server:v1.4.2"
 
 	// PiraeusKernelModImage is the worker (aka satellite) image for each node
-	PiraeusKernelModImage = "quay.io/piraeusdatastore/drbd9-centos7"
-	// PiraeusKernelModVersion is the release tag for the above image
-	PiraeusKernelModVersion = "v9.0.21"
+	PiraeusKernelModImage = "quay.io/piraeusdatastore/drbd9-centos7:v9.0.21"
 
 	// DrbdRepoCred is the name of the kubernetes secret that holds the repo
 	// credentials for the DRBD related repositories


### PR DESCRIPTION
remove the separation between image repo, name, and tag.
A specific image is identified by a single string.

* Update helm charts
* Update CRDs
* Update go models
* Update go operator