### PR TITLE
remove redundant spec key in helm values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* helm: `operator.nodeSet.spec` and `operator.controllerSet.spec` are replaced by just
+        `operator.nodeSet` and `operator.controllerSet`.
+
 ## [v0.2.2] - 2020-04-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The Helm chart can be configured to use this database instead of deploying an
 etcd cluster by adding the following to the Helm install command:
 
 ```
---set etcd.enabled=false --set "operator.controllerSet.spec.dbConnectionURL=jdbc:postgresql://postgres/postgresdb?user=postgresadmin&password=admin123"
+--set etcd.enabled=false --set "operator.controllerSet.dbConnectionURL=jdbc:postgresql://postgres/postgresdb?user=postgresadmin&password=admin123"
 ```
 
 ### Configuring storage pool creation
@@ -129,19 +129,18 @@ There are two ways to configure storage pools
 
 #### At install time
 
-At install time, by setting the value of `operator.nodeSet.spec.storagePools` when running helm install.
+At install time, by setting the value of `operator.nodeSet.storagePools` when running helm install.
 
 First create a file with the storage configuration like:
 
 ```yaml
 operator:
   nodeSet:
-    spec:
-      storagePools:
-        lvmPools:
-        - name: lvm-thick
-          volumeGroup: drbdpool
-        ..
+    storagePools:
+      lvmPools:
+      - name: lvm-thick
+        volumeGroup: drbdpool
+    ..
 ```
 
 This file can be passed to the helm installation like this:

--- a/charts/piraeus/templates/operator-controllerset.yaml
+++ b/charts/piraeus/templates/operator-controllerset.yaml
@@ -4,6 +4,6 @@ metadata:
   name: {{ template "operator.fullname" . }}-cs
 spec:
   priorityClassName: {{ template "operator.fullname" . }}-cs-priority-class
-  dbConnectionURL:  {{ .Values.operator.controllerSet.spec.dbConnectionURL | default (print "etcd://" .Release.Name "-etcd:2379") }}
+  dbConnectionURL:  {{ .Values.operator.controllerSet.dbConnectionURL | default (print "etcd://" .Release.Name "-etcd:2379") }}
   drbdRepoCred: {{ .Values.drbdRepoCred }}
-  controllerImage: {{ .Values.operator.controllerSet.spec.controllerImage }}
+  controllerImage: {{ .Values.operator.controllerSet.controllerImage }}

--- a/charts/piraeus/templates/operator-nodeset.yaml
+++ b/charts/piraeus/templates/operator-nodeset.yaml
@@ -4,11 +4,11 @@ metadata:
   name: {{ template "operator.fullname" . }}-ns
 spec:
   priorityClassName: {{ template "operator.fullname" . }}-cs-priority-class
-  drbdKernelModuleInjectionMode: {{ .Values.operator.nodeSet.spec.drbdKernelModuleInjectionMode }}
+  drbdKernelModuleInjectionMode: {{ .Values.operator.nodeSet.drbdKernelModuleInjectionMode }}
   drbdRepoCred: {{ .Values.drbdRepoCred }}
-  satelliteImage: {{ .Values.operator.nodeSet.spec.satelliteImage }}
-  kernelModImage: {{ .Values.operator.nodeSet.spec.kernelModImage }}
-  {{- if .Values.operator.nodeSet.spec.storagePools }}
+  satelliteImage: {{ .Values.operator.nodeSet.satelliteImage }}
+  kernelModImage: {{ .Values.operator.nodeSet.kernelModImage }}
+  {{- if .Values.operator.nodeSet.storagePools }}
   storagePools:
-{{ toYaml .Values.operator.nodeSet.spec.storagePools | indent 4 }}
+{{ toYaml .Values.operator.nodeSet.storagePools | indent 4 }}
   {{- end }}

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -16,11 +16,9 @@ drbdRepoCred: drbdiocred     # <- Specify the kubernetes secret name here
 operator:
   image: "quay.io/piraeusdatastore/piraeus-operator:v0.2.2"
   controllerSet:
-    spec:
-      controllerImage: "quay.io/piraeusdatastore/piraeus-server:v1.6.1"
+    controllerImage: "quay.io/piraeusdatastore/piraeus-server:v1.6.1"
   nodeSet:
-    spec:
-      drbdKernelModuleInjectionMode: Compile
-      satelliteImage: "quay.io/piraeusdatastore/piraeus-server:v1.6.1"
-      kernelModImage: "quay.io/piraeusdatastore/drbd9-bionic:v9.0.22"
-      storagePools: null
+    drbdKernelModuleInjectionMode: Compile
+    satelliteImage: "quay.io/piraeusdatastore/piraeus-server:v1.6.1"
+    kernelModImage: "quay.io/piraeusdatastore/drbd9-bionic:v9.0.22"
+    storagePools: null


### PR DESCRIPTION
`operator.nodeSet.spec` and `operator.controllerSet.spec` are replaced by just
`operator.nodeSet` and `operator.controllerSet` in helm chart.