### PR TITLE
remove redundant constants

### DIFF
--- a/pkg/controller/linstornodeset/linstornodeset_controller.go
+++ b/pkg/controller/linstornodeset/linstornodeset_controller.go
@@ -150,7 +150,19 @@ func (r *ReconcileLinstorNodeSet) Reconcile(request reconcile.Request) (reconcil
 	}
 
 	if pns.Spec.DrbdRepoCred == "" {
-		pns.Spec.DrbdRepoCred = kubeSpec.DrbdRepoCred
+		return reconcile.Result{}, fmt.Errorf("NS Reconcile: missing required parameter drbdRepoCred: outdated schema")
+	}
+
+	if pns.Spec.PriorityClassName == "" {
+		return reconcile.Result{}, fmt.Errorf("NS Reconcile: missing required parameter priorityClassName: outdated schema")
+	}
+
+	if pns.Spec.SatelliteImage == "" {
+		return reconcile.Result{}, fmt.Errorf("NS Reconcile: missing required parameter satelliteImage: outdated schema")
+	}
+
+	if pns.Spec.KernelModImage == "" {
+		return reconcile.Result{}, fmt.Errorf("NS Reconcile: missing required parameter kernelModImage: outdated schema")
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -481,18 +493,6 @@ func (r *ReconcileLinstorNodeSet) reconcileStoragePoolsOnNode(sat *piraeusv1alph
 func newDaemonSetforPNS(pns *piraeusv1alpha1.LinstorNodeSet) *apps.DaemonSet {
 	labels := pnsLabels(pns)
 	controllerName := pns.Name[0:len(pns.Name)-3] + "-cs"
-
-	if pns.Spec.PriorityClassName == "" {
-		pns.Spec.PriorityClassName = kubeSpec.PiraeusNSPriorityClassName
-	}
-
-	if pns.Spec.SatelliteImage == "" {
-		pns.Spec.SatelliteImage = kubeSpec.PiraeusSatelliteImage
-	}
-
-	if pns.Spec.KernelModImage == "" {
-		pns.Spec.KernelModImage = kubeSpec.PiraeusKernelModImage
-	}
 
 	ds := &apps.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/k8s/spec/const.go
+++ b/pkg/k8s/spec/const.go
@@ -51,26 +51,3 @@ var (
 var (
 	Privileged = true
 )
-
-// Fallback config values
-const (
-	// PiraeusCSPriorityClassName is the name of the PriorityClass for the
-	// controller set.
-	PiraeusCSPriorityClassName = "piraeus-cs-priority-class"
-	// PiraeusNSPriorityClassName is the name of the PriorityClass for the
-	// node set.
-	PiraeusNSPriorityClassName = "piraeus-ns-priority-class"
-
-	// PiraeusControllerImage is the repo/tag for linstor-server
-	PiraeusControllerImage = "quay.io/piraeusdatastore/piraeus-server:v1.4.2"
-
-	// PiraeusSatelliteImage is the repo/tag for LINSTOR Satellite contaier.
-	PiraeusSatelliteImage = "quay.io/piraeusdatastore/piraeus-server:v1.4.2"
-
-	// PiraeusKernelModImage is the worker (aka satellite) image for each node
-	PiraeusKernelModImage = "quay.io/piraeusdatastore/drbd9-centos7:v9.0.21"
-
-	// DrbdRepoCred is the name of the kubernetes secret that holds the repo
-	// credentials for the DRBD related repositories
-	DrbdRepoCred = "drbdiocred"
-)


### PR DESCRIPTION
All removed constants are required according to the schema,
so they were never used.

From my understanding, these code paths were effectively unreachable, so no user facing changes here.