### PR TITLE
update golinstor dependency for better toml writing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/LINBIT/golinstor v0.25.0
+	github.com/LINBIT/golinstor v0.25.1
 	github.com/operator-framework/operator-sdk v0.16.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -29,10 +29,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20190822182118-27a4ced34534/go.mod h1:iroGtC8B3tQiqtds1l+mgk/BBOrxbqjH+eUfFQYRc14=
 github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5hodBMJ5+l/7J4xAyMeuM2PNuepvHlGs8yilUCA=
-github.com/LINBIT/golinstor v0.16.4 h1:1v/AEuzdCDGf8JHFF9MKgCzkG7OB+V5w+nEUJorzZOE=
-github.com/LINBIT/golinstor v0.16.4/go.mod h1:p2V1Y5ppce3isjO7IBiZGOwY8R8oIm+nYZqOa77bpXM=
-github.com/LINBIT/golinstor v0.25.0 h1:lXtRDNphu0IZGPh4S74Bhte+hvThk1oh20XoGI+a86I=
-github.com/LINBIT/golinstor v0.25.0/go.mod h1:p2V1Y5ppce3isjO7IBiZGOwY8R8oIm+nYZqOa77bpXM=
+github.com/LINBIT/golinstor v0.25.1 h1:/8X4i7lpuWDQbm0TzUbNj6GSOFa2EX7gK30MVTxEzMo=
+github.com/LINBIT/golinstor v0.25.1/go.mod h1:p2V1Y5ppce3isjO7IBiZGOwY8R8oIm+nYZqOa77bpXM=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/MakeNowJust/heredoc v0.0.0-20171113091838-e9091a26100e/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=


### PR DESCRIPTION
golinstor v0.25.1 includes toml tags for ControllerConfig.
Previously, the serialized TOML would contain every item with
a default value. However, LINSTOR does not care that these are
placeholders and so tries to load all values as given.

Interestingly, LINSTOR is able to start with these settings, but
for it will start using an in-memory database, as the "in_memory" field
is non-empty.

The changes: https://github.com/LINBIT/golinstor/compare/v0.25.0...v0.25.1