### PR TITLE
set linstor master passphrase on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   certificate to switch from HTTP to HTTPS communication.
 * Secured connection between Linstor components: You can specify TLS keys to secure the communication between
   controller and satellite
+* Secure storage with LUKS: You can specify the master passphrase used by Linstor when creating encrypted volumes
+  when installing via Helm.
 
 ### Removed
 

--- a/charts/piraeus/crds/operator-controllerset-crd.yaml
+++ b/charts/piraeus/crds/operator-controllerset-crd.yaml
@@ -44,6 +44,9 @@ spec:
                 PEM format
               type: string
               nullable: true
+            luksSecret:
+              description: Name of the secret containing the master passphrase for LUKS devices as `MASTER_PASSPHRASE`
+              type: string
             sslSecret:
               description: Name of k8s secret that holds the SSL key for a node (called `keystore.jks`) and
                 the trusted certificates (called `certificates.jks`)

--- a/charts/piraeus/templates/operator-controllerset.yaml
+++ b/charts/piraeus/templates/operator-controllerset.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   priorityClassName: {{ template "operator.fullname" . }}-cs-priority-class
   dbConnectionURL:  {{ .Values.operator.controllerSet.dbConnectionURL | default (print "etcd://" .Release.Name "-etcd:2379") }}
+  luksSecret: {{ .Values.operator.controllerSet.luksSecret }}
   sslSecret: {{ .Values.operator.controllerSet.sslSecret }}
   dbCertSecret: {{ .Values.operator.controllerSet.dbCertSecret | default "" }}
   drbdRepoCred: {{ .Values.drbdRepoCred }}

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -17,6 +17,7 @@ operator:
   image: "quay.io/piraeusdatastore/piraeus-operator:v0.3.0"
   controllerSet:
     controllerImage: "quay.io/piraeusdatastore/piraeus-server:v1.7.0"
+    luksSecret: ""
     dbCertSecret: ""
     sslSecret: ""
   nodeSet:

--- a/doc/security.md
+++ b/doc/security.md
@@ -42,3 +42,18 @@ follow these steps:
 
 :warning: It is currently **NOT** possible to change the keystore password. LINSTOR expects the passwords to be
 `linstor`. This is a current limitation of LINSTOR.
+
+## Automatically set the passphrase for encrypted volumes
+
+Linstor can be used to create encrypted volumes using LUKS. The passphrase used when creating these volumes can
+be set via a secret:
+
+```
+kubectl create secret generic linstor-pass --from-literal=MASTER_PASSPHRASE=<password>
+```
+
+On install, add the following arguments to the helm command:
+
+```
+--set operator.controllerSet.luksSecret=linstor-pass
+```

--- a/pkg/apis/piraeus/v1alpha1/linstorcontrollerset_types.go
+++ b/pkg/apis/piraeus/v1alpha1/linstorcontrollerset_types.go
@@ -35,6 +35,8 @@ type LinstorControllerSetSpec struct {
 
 	DBConnectionURL string `json:"dbConnectionURL"`
 	DBCertSecret    string `json:"dbCertSecret"`
+	// Name of the secret containing the master passphrase for LUKS devices as `MASTER_PASSPHRASE`
+	LuksSecret		string `json:"luksSecret"`
 	// Configuration options for secure communication between nodes and controllers
 	SslConfig       *LinstorSSLConfig `json:"sslSecret"`
 	DrbdRepoCred    string            `json:"drbdRepoCred"`

--- a/pkg/k8s/spec/const.go
+++ b/pkg/k8s/spec/const.go
@@ -43,6 +43,11 @@ const (
 	LinstorKernelModShippedModules = "shipped_modules"
 )
 
+// Special strings when configuring Linstor
+const (
+	LinstorLUKSPassphraseEnvName = "MASTER_PASSPHRASE"
+)
+
 // Shared consts common to container volumes. These need to be vars, so they
 // are addressible.
 var (


### PR DESCRIPTION
automatically set the passpharse used by LINSTOR to create encrypted
volumes on controller startup.

