### PR TITLE
crds: make optional luksSecret nullable

### DIFF
--- a/charts/piraeus/crds/operator-controllerset-crd.yaml
+++ b/charts/piraeus/crds/operator-controllerset-crd.yaml
@@ -47,6 +47,7 @@ spec:
             luksSecret:
               description: Name of the secret containing the master passphrase for LUKS devices as `MASTER_PASSPHRASE`
               type: string
+              nullable: true
             sslSecret:
               description: Name of k8s secret that holds the SSL key for a node (called `keystore.jks`) and
                 the trusted certificates (called `certificates.jks`)


### PR DESCRIPTION
helm expands its values to something like:
```yaml
luksSecret:
```
which is a mapping of "luksSecret" => nil
in yaml. When loading this in go, it would correctly be
transformed into the nil of string, the empty string "".