### PR TITLE
etcd-auth: add option to authenticate on etcd with certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   controller and satellite
 * Secure storage with LUKS: You can specify the master passphrase used by Linstor when creating encrypted volumes
   when installing via Helm.
+* Authentication with etcd using TLS client certificates.
 
 ### Removed
 

--- a/charts/piraeus/crds/operator-controllerset-crd.yaml
+++ b/charts/piraeus/crds/operator-controllerset-crd.yaml
@@ -44,6 +44,11 @@ spec:
                 PEM format
               type: string
               nullable: true
+            dbUseClientCert:
+              description: Use a TLS client certificate for authentication with the database (etcd). If set to true,
+                `dbCertSecret` must be set and contain two additional entries "client.cert" (PEM encoded)
+                and "client.key" (PKCS8 encoded, without passphrase).
+              type: boolean
             luksSecret:
               description: Name of the secret containing the master passphrase for LUKS devices as `MASTER_PASSPHRASE`
               type: string

--- a/charts/piraeus/templates/operator-controllerset.yaml
+++ b/charts/piraeus/templates/operator-controllerset.yaml
@@ -8,5 +8,6 @@ spec:
   luksSecret: {{ .Values.operator.controllerSet.luksSecret }}
   sslSecret: {{ .Values.operator.controllerSet.sslSecret }}
   dbCertSecret: {{ .Values.operator.controllerSet.dbCertSecret | default "" }}
+  dbUseClientCert: {{ .Values.operator.controllerSet.dbUseClientCert }}
   drbdRepoCred: {{ .Values.drbdRepoCred }}
   controllerImage: {{ .Values.operator.controllerSet.controllerImage }}

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -20,6 +20,7 @@ operator:
     controllerImage: "quay.io/piraeusdatastore/piraeus-server:v1.7.0"
     luksSecret: ""
     dbCertSecret: ""
+    dbUseClientCert: false
     sslSecret: ""
   nodeSet:
     drbdKernelModuleInjectionMode: Compile

--- a/doc/security.md
+++ b/doc/security.md
@@ -13,6 +13,22 @@ The secret can then be passed to the controller by passing the following argumen
 --set operator.controllerSet.dbCertSecret=<secret name>
 ```
 
+### Authentication with `etcd` using certificates
+
+If you want to use TLS certificates to authenticate with an `etcd` database, you need to set the following option on
+helm install:
+```
+--set operator.controllerSet.dbUseClientCert=true
+```
+
+If this option is active, the secret specified in the above section must contain two additional keys:
+* `client.cert` PEM formatted certificate presented to `etcd` for authentication
+* `client.key` private key **in PKCS8 format**, matching the above client certificate.
+  Keys can be converted into PKCS8 format using `openssl`:
+  ```
+  openssl pkcs8 -topk8 -nocrypt -in client-key.pem -out client-key.pkcs8
+  ```
+
 ## Configuring secure communication between LINSTOR components
 
 The default communication between LINSTOR components is not secured by TLS. If this is needed for your setup,

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/LINBIT/golinstor v0.25.1
+	github.com/LINBIT/golinstor v0.25.2-0.20200519080100-e76435b8971a
 	github.com/operator-framework/operator-sdk v0.16.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20190822182118-27a4ced34534/go.mod h1:iroGtC8B3tQiqtds1l+mgk/BBOrxbqjH+eUfFQYRc14=
 github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5hodBMJ5+l/7J4xAyMeuM2PNuepvHlGs8yilUCA=
-github.com/LINBIT/golinstor v0.25.1 h1:/8X4i7lpuWDQbm0TzUbNj6GSOFa2EX7gK30MVTxEzMo=
-github.com/LINBIT/golinstor v0.25.1/go.mod h1:p2V1Y5ppce3isjO7IBiZGOwY8R8oIm+nYZqOa77bpXM=
+github.com/LINBIT/golinstor v0.25.2-0.20200519080100-e76435b8971a h1:+XlOMKg3xD3ks6JawUo37Wdy/LjR5buRK7oUN37sFkU=
+github.com/LINBIT/golinstor v0.25.2-0.20200519080100-e76435b8971a/go.mod h1:p2V1Y5ppce3isjO7IBiZGOwY8R8oIm+nYZqOa77bpXM=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/MakeNowJust/heredoc v0.0.0-20171113091838-e9091a26100e/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=

--- a/pkg/apis/piraeus/v1alpha1/linstorcontrollerset_types.go
+++ b/pkg/apis/piraeus/v1alpha1/linstorcontrollerset_types.go
@@ -35,6 +35,10 @@ type LinstorControllerSetSpec struct {
 
 	DBConnectionURL string `json:"dbConnectionURL"`
 	DBCertSecret    string `json:"dbCertSecret"`
+	// Use a TLS client certificate for authentication with the database (etcd). If set to true,
+	// `dbCertSecret` must be set and contain two additional entries "client.cert" (PEM encoded)
+	// and "client.key" (PKCS8 encoded, without passphrase).
+	DBUseClientCert bool `json:"dbUseClientCert"`
 	// Name of the secret containing the master passphrase for LUKS devices as `MASTER_PASSPHRASE`
 	LuksSecret		string `json:"luksSecret"`
 	// Configuration options for secure communication between nodes and controllers

--- a/pkg/controller/linstorcontrollerset/linstorcontrollerset_controller.go
+++ b/pkg/controller/linstorcontrollerset/linstorcontrollerset_controller.go
@@ -240,7 +240,7 @@ func (r *ReconcileLinstorControllerSet) Reconcile(request reconcile.Request) (re
 	}).Debug("CS Reconcile: CS already exists")
 
 	// Define a configmap for the controller.
-	configMap, err := newConfigMapForPCS(pcs)
+	configMap, err := NewConfigMapForPCS(pcs)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -685,16 +685,24 @@ func newServiceForPCS(pcs *piraeusv1alpha1.LinstorControllerSet) *corev1.Service
 	}
 }
 
-func newConfigMapForPCS(pcs *piraeusv1alpha1.LinstorControllerSet) (*corev1.ConfigMap, error) {
+func NewConfigMapForPCS(pcs *piraeusv1alpha1.LinstorControllerSet) (*corev1.ConfigMap, error) {
 	certificatePath := ""
+	clientCertPath := ""
+	clientKeyPath := ""
 	if pcs.Spec.DBCertSecret != "" {
 		certificatePath = kubeSpec.LinstorCertDir + "/ca.pem"
+		if pcs.Spec.DBUseClientCert {
+			clientCertPath = kubeSpec.LinstorCertDir + "/client.cert"
+			clientKeyPath = kubeSpec.LinstorCertDir + "/client.key"
+		}
 	}
 
 	linstorConfig := lapi.ControllerConfig{
 		Db: lapi.ControllerConfigDb{
 			ConnectionUrl: pcs.Spec.DBConnectionURL,
 			CaCertificate: certificatePath,
+			ClientCertificate: clientCertPath,
+			ClientKeyPkcs8Pem: clientKeyPath,
 		},
 	}
 

--- a/pkg/controller/linstorcontrollerset/linstorcontrollerset_controller_test.go
+++ b/pkg/controller/linstorcontrollerset/linstorcontrollerset_controller_test.go
@@ -1,0 +1,155 @@
+package linstorcontrollerset
+
+import (
+	piraeusv1alpha1 "github.com/piraeusdatastore/piraeus-operator/pkg/apis/piraeus/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	"testing"
+)
+
+func TestNewConfigMapForPCS(t *testing.T) {
+	testcases := []struct {
+		name     string
+		spec     *piraeusv1alpha1.LinstorControllerSet
+		expected *corev1.ConfigMap
+	}{
+		{
+			name: "default-settings",
+			spec: &piraeusv1alpha1.LinstorControllerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default-ns",
+				},
+				Spec: piraeusv1alpha1.LinstorControllerSetSpec{
+					DBConnectionURL: "etcd://etcd.svc:5000/",
+					DBCertSecret:    "",
+				},
+			},
+			expected: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-config",
+					Namespace: "default-ns",
+				},
+				Data: map[string]string{
+					"linstor.toml": `[config]
+
+[debug]
+
+[log]
+
+[db]
+  connection_url = "etcd://etcd.svc:5000/"
+  [db.etcd]
+
+[http]
+
+[https]
+
+[ldap]
+`,
+				},
+			},
+		},
+		{
+			name: "with-ssl-without-client-cert",
+			spec: &piraeusv1alpha1.LinstorControllerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default-ns",
+				},
+				Spec: piraeusv1alpha1.LinstorControllerSetSpec{
+					DBConnectionURL: "etcd://secure.etcd.svc:443/",
+					DBCertSecret:    "mysecret",
+				},
+			},
+			expected: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-config",
+					Namespace: "default-ns",
+				},
+				Data: map[string]string{
+					"linstor.toml": `[config]
+
+[debug]
+
+[log]
+
+[db]
+  connection_url = "etcd://secure.etcd.svc:443/"
+  ca_certificate = "/etc/linstor/certs/ca.pem"
+  [db.etcd]
+
+[http]
+
+[https]
+
+[ldap]
+`,
+				},
+			},
+		},
+		{
+			name: "with-ssl-with-client-cert",
+			spec: &piraeusv1alpha1.LinstorControllerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default-ns",
+				},
+				Spec: piraeusv1alpha1.LinstorControllerSetSpec{
+					DBConnectionURL: "etcd://secure.etcd.svc:443/",
+					DBCertSecret:    "mysecret",
+					DBUseClientCert: true,
+				},
+			},
+			expected: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-config",
+					Namespace: "default-ns",
+				},
+				Data: map[string]string{
+					"linstor.toml": `[config]
+
+[debug]
+
+[log]
+
+[db]
+  connection_url = "etcd://secure.etcd.svc:443/"
+  ca_certificate = "/etc/linstor/certs/ca.pem"
+  client_certificate = "/etc/linstor/certs/client.cert"
+  client_key_pkcs8_pem = "/etc/linstor/certs/client.key"
+  [db.etcd]
+
+[http]
+
+[https]
+
+[ldap]
+`,
+				},
+			},
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			actualCM, err := NewConfigMapForPCS(test.spec)
+			if err != nil {
+				t.Fatalf("config map creation failed: %v", err)
+			}
+
+			if actualCM.Name != test.expected.Name {
+				t.Errorf("cm: name does not match, expected: '%s', actual: '%s'", test.expected.Name, actualCM.Name)
+			}
+
+			if actualCM.Namespace != test.expected.Namespace {
+				t.Errorf("cm: namespace does not match, expected: '%s', actual: '%s'", test.expected.Namespace, actualCM.Namespace)
+			}
+
+			if !reflect.DeepEqual(actualCM.Data, test.expected.Data) {
+				t.Errorf("cm: data does not match, expected: '%v', actual: '%v'", test.expected.Data, actualCM.Data)
+			}
+		})
+	}
+}


### PR DESCRIPTION
etcd supports client authentication when HTTPS is enabled. The client is
expected to present a valid certificate, where CN is set to the user name.

This commit enables authenticating LINSTOR against a etcd instance using
these client certificates.

Addresses part of #5 