### PR TITLE
linstor: bind-mount /sys/ in satellites for NVMe support

### DIFF
--- a/pkg/controller/linstornodeset/linstornodeset_controller.go
+++ b/pkg/controller/linstornodeset/linstornodeset_controller.go
@@ -551,6 +551,10 @@ func newDaemonSetforPNS(pns *piraeusv1alpha1.LinstorNodeSet, config *corev1.Conf
 									MountPath: kubeSpec.DevDir,
 								},
 								{
+									Name: kubeSpec.SysDirName,
+									MountPath: kubeSpec.SysDir,
+								},
+								{
 									Name:             kubeSpec.ModulesDirName,
 									MountPath:        kubeSpec.ModulesDir,
 									MountPropagation: &kubeSpec.MountPropagationBidirectional,
@@ -594,14 +598,27 @@ func newDaemonSetforPNS(pns *piraeusv1alpha1.LinstorNodeSet, config *corev1.Conf
 							VolumeSource: corev1.VolumeSource{
 								HostPath: &corev1.HostPathVolumeSource{
 									Path: kubeSpec.DevDir,
-								}}},
+								},
+							},
+						},
+						{
+							Name: kubeSpec.SysDirName,
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: kubeSpec.SysDir,
+									Type: &kubeSpec.HostPathDirectoryType,
+								},
+							},
+						},
 						{
 							Name: kubeSpec.ModulesDirName,
 							VolumeSource: corev1.VolumeSource{
 								HostPath: &corev1.HostPathVolumeSource{
 									Path: kubeSpec.ModulesDir,
 									Type: &kubeSpec.HostPathDirectoryOrCreateType,
-								}}},
+								},
+							},
+						},
 					},
 					ImagePullSecrets: []corev1.LocalObjectReference{
 						{

--- a/pkg/k8s/spec/const.go
+++ b/pkg/k8s/spec/const.go
@@ -33,6 +33,8 @@ const (
 	ModulesDirName             = "modules-dir"
 	SrcDir                     = "/usr/src"
 	SrcDirName                 = "src-dir"
+	SysDir                     = "/sys/"
+	SysDirName                 = "sys-dir"
 	LinstorSatelliteConfigFile = "linstor_satellite.toml"
 )
 


### PR DESCRIPTION
linstor satellites supporting NVMe need access to:
* `/sys/kernel/config/nvmet/`
* `/sys/devices/virtual/nvme-fabrics/ctl/nvme`
While the second entry is mounted from `sysfs`, which is already
present in the container, the first entry is part of the `configfs`
mount `/sys/kernel/config`, which is not mounted by default.

With this change, linstor-satellite will bind-mount `/sys` from the host.
As long as the host has the required kernel modules loaded for NVMe,
linstor will be able to control the NVMe layer.

This is needed for #3 