### PR TITLE
Make CSI images configurable

### DIFF
--- a/charts/piraeus/crds/piraeus.linbit.com_linstorcsidrivers_crd.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstorcsidrivers_crd.yaml
@@ -38,6 +38,18 @@ spec:
         spec:
           description: LinstorCSIDriverSpec defines the desired state of LinstorCSIDriver
           properties:
+            csiAttacherImage:
+              description: Name of the CSI external attacher image. See https://kubernetes-csi.github.io/docs/external-attacher.html
+              type: string
+            csiNodeDriverRegistrarImage:
+              description: Name of the CSI node driver registrar image. See https://kubernetes-csi.github.io/docs/node-driver-registrar.html
+              type: string
+            csiProvisionerImage:
+              description: Name of the CSI external provisioner image. See https://kubernetes-csi.github.io/docs/external-provisioner.html
+              type: string
+            csiSnapshotterImage:
+              description: Name of the CSI external snapshotter image. See https://kubernetes-csi.github.io/docs/external-snapshotter.html
+              type: string
             imagePullSecret:
               description: Name of a secret with authentication details for the `LinstorPluginImage`
                 registry

--- a/charts/piraeus/templates/operator-csi-driver.yaml
+++ b/charts/piraeus/templates/operator-csi-driver.yaml
@@ -8,4 +8,8 @@ spec:
   imagePullSecret: {{ .Values.drbdRepoCred | quote }}
   linstorControllerAddress: http://{{ template "operator.fullname" . }}-cs:3370/
   linstorPluginImage: {{ .Values.csi.pluginImage | quote }}
+  csiAttacherImage: {{ .Values.csi.csiAttacherImage | quote }}
+  csiNodeDriverRegistrarImage: {{ .Values.csi.csiNodeDriverRegistrarImage | quote }}
+  csiProvisionerImage: {{ .Values.csi.csiProvisionerImage | quote }}
+  csiSnapshotterImage: {{ .Values.csi.csiSnapshotterImage | quote }}
 {{- end }}

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -13,6 +13,10 @@ etcd:
 csi:
   enabled: true
   pluginImage: "quay.io/piraeusdatastore/piraeus-csi:v0.7.4"
+  csiAttacherImage: ""
+  csiNodeDriverRegistrarImage: ""
+  csiProvisionerImage: ""
+  csiSnapshotterImage: ""
 drbdRepoCred: drbdiocred     # <- Specify the kubernetes secret name here
 operator:
   image: "quay.io/piraeusdatastore/piraeus-operator:v0.3.0"

--- a/pkg/apis/piraeus/v1alpha1/linstorcsidriver_types.go
+++ b/pkg/apis/piraeus/v1alpha1/linstorcsidriver_types.go
@@ -23,6 +23,23 @@ import (
 
 // LinstorCSIDriverSpec defines the desired state of LinstorCSIDriver
 type LinstorCSIDriverSpec struct {
+	// Name of the CSI external attacher image.
+	// See https://kubernetes-csi.github.io/docs/external-attacher.html
+	// +kubebuilder:validation:Optional
+	CSIAttacherImage               string `json:"csiAttacherImage"`
+	// Name of the CSI node driver registrar image.
+	// See https://kubernetes-csi.github.io/docs/node-driver-registrar.html
+	// +kubebuilder:validation:Optional
+	CSINodeDriverRegistrarImage    string `json:"csiNodeDriverRegistrarImage"`
+	// Name of the CSI external provisioner image.
+	// See https://kubernetes-csi.github.io/docs/external-provisioner.html
+	// +kubebuilder:validation:Optional
+	CSIProvisionerImage            string `json:"csiProvisionerImage"`
+	// Name of the CSI external snapshotter image.
+	// See https://kubernetes-csi.github.io/docs/external-snapshotter.html
+	// +kubebuilder:validation:Optional
+	CSISnapshotterImage            string `json:"csiSnapshotterImage"`
+
 	// Name of a secret with authentication details for the `LinstorPluginImage` registry
 	ImagePullSecret string `json:"imagePullSecret"`
 	// Image that contains the linstor-csi driver plugin

--- a/pkg/controller/linstorcsidriver/const.go
+++ b/pkg/controller/linstorcsidriver/const.go
@@ -1,0 +1,8 @@
+package linstorcsidriver
+
+const (
+	DefaultAttacherImage            = "quay.io/k8scsi/csi-attacher:v2.1.1"
+	DefaultNodeDriverRegistrarImage = "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
+	DefaultProvisionerImage         = "quay.io/k8scsi/csi-provisioner:v1.5.0"
+	DefaultSnapshotterImage         = "quay.io/k8scsi/csi-snapshotter:v2.0.1"
+)


### PR DESCRIPTION
The various sidecar images are now configurable via the LinstorCSIDriver resource.
To stay backwards compatible, the values are not required and the resource will automatically
be updated with the defaults