### PR TITLE
ensure that StoragePoolStatuses is not nil

### DIFF
--- a/pkg/controller/linstornodeset/linstornodeset_controller.go
+++ b/pkg/controller/linstornodeset/linstornodeset_controller.go
@@ -345,7 +345,8 @@ func (r *ReconcileLinstorNodeSet) reconcileSatNodes(pns *piraeusv1alpha1.Linstor
 		log.Debug("NS reconcileSatNodes: reconciling node")
 
 		sat := &piraeusv1alpha1.SatelliteStatus{
-			NodeStatus: piraeusv1alpha1.NodeStatus{NodeName: pod.Spec.NodeName},
+			NodeStatus:          piraeusv1alpha1.NodeStatus{NodeName: pod.Spec.NodeName},
+			StoragePoolStatuses: make([]*piraeusv1alpha1.StoragePoolStatus, 0),
 		}
 		pns.Status.SatelliteStatuses[i] = sat
 


### PR DESCRIPTION
This causes problems with serialization:
time="2020-06-03T07:46:44Z" level=error msg="LinstorNodeSet.piraeus.linbit.com \"piraeus-op-ns\" is invalid: status.SatelliteStatuses.storagePoolStatus: Invalid value: \"null\": status.SatelliteStatuses.storagePoolStatus in body must be of type array: \"null\"NS Reconcile: Failed to update LinstorNodeSet status"

@WanzenBug 