### PR TITLE
shorten names of CSI driver resources by removing suffixes

### DIFF
--- a/charts/piraeus/templates/operator-csi-driver.yaml
+++ b/charts/piraeus/templates/operator-csi-driver.yaml
@@ -2,7 +2,7 @@
 apiVersion: piraeus.linbit.com/v1alpha1
 kind: LinstorCSIDriver
 metadata:
-  name: {{ template "operator.fullname" . }}-csi-driver
+  name: {{ template "operator.fullname" . }}
 spec:
   enabled: {{ .Values.csi.enabled }}
   imagePullSecret: {{ .Values.drbdRepoCred | quote }}

--- a/pkg/controller/linstorcsidriver/linstorcsidriver_controller.go
+++ b/pkg/controller/linstorcsidriver/linstorcsidriver_controller.go
@@ -831,7 +831,7 @@ func getPriorityClassName(csiResource *piraeusv1alpha1.LinstorCSIDriver) string 
 
 func getLinstorControllerServiceName(csiResource *piraeusv1alpha1.LinstorCSIDriver) types.NamespacedName {
 	return types.NamespacedName{
-		Name:      csiResource.Name[:len(csiResource.Name)-len("-csi-driver")] + "-cs",
+		Name:      csiResource.Name + "-cs",
 		Namespace: csiResource.Namespace,
 	}
 }
@@ -905,17 +905,17 @@ type GCRuntimeObject interface {
 }
 
 const (
-	NodeServiceAccount       = "-csi-node-sa"
-	ControllerServiceAccount = "-csi-controller-sa"
-	PriorityClass            = "-csi-priority-class"
-	NodeDaemonSet            = "-csi-node-daemonset"
-	SnapshotterRole          = "-csi-snapshotter-role"
-	ProvisionerRole          = "-csi-provisioner-role"
-	DriverRegistrarRole      = "-csi-driver-registrar-role"
-	AttacherRole             = "-csi-attacher-role"
-	AttacherBinding          = "-csi-attacher-binding"
-	DriverRegistrarBinding   = "-csi-driver-registrar-binding"
-	ProvisionerBinding       = "-csi-provisioner-binding"
-	SnapshotterBinding       = "-csi-snapshotter-binding"
-	ControllerDeployment     = "-csi-controller-deployment"
+	NodeServiceAccount       = "-csi-node"
+	ControllerServiceAccount = "-csi-controller"
+	PriorityClass            = "-csi"
+	NodeDaemonSet            = "-csi-node"
+	SnapshotterRole          = "-csi-snapshotter"
+	ProvisionerRole          = "-csi-provisioner"
+	DriverRegistrarRole      = "-csi-driver-registrar"
+	AttacherRole             = "-csi-attacher"
+	AttacherBinding          = "-csi-attacher"
+	DriverRegistrarBinding   = "-csi-driver-registrar"
+	ProvisionerBinding       = "-csi-provisioner"
+	SnapshotterBinding       = "-csi-snapshotter"
+	ControllerDeployment     = "-csi-controller"
 )

--- a/pkg/controller/linstorcsidriver/linstorcsidriver_controller_test.go
+++ b/pkg/controller/linstorcsidriver/linstorcsidriver_controller_test.go
@@ -26,31 +26,31 @@ var (
 	CSIDriverPodInfoOnMount = true
 	DefaultNodeDaemonSet    = appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo-csi-driver-csi-node-daemonset",
+			Name:      "foo-csi-node",
 			Namespace: "bar",
 		},
 	}
 	DefaultControllerDeployment = appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo-csi-driver-csi-controller-deployment",
+			Name:      "foo-csi-controller",
 			Namespace: "bar",
 		},
 	}
 	DefaultNodeServiceAccount = corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo-csi-driver-csi-node-sa",
+			Name:      "foo-csi-node",
 			Namespace: "bar",
 		},
 	}
 	DefaulControllerServiceAccount = corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo-csi-driver-csi-controller-sa",
+			Name:      "foo-csi-controller",
 			Namespace: "bar",
 		},
 	}
 	DefaultPriorityClass = schedv1.PriorityClass{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo-csi-driver-csi-priority-class",
+			Name:      "foo-csi",
 			Namespace: "bar",
 		},
 	}
@@ -92,7 +92,7 @@ func TestReconcileLinstorCSIDriver_Reconcile(t *testing.T) {
 			initialResources: []runtime.Object{
 				&piraeusv1alpha1.LinstorCSIDriver{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo-csi-driver",
+						Name:      "foo",
 						Namespace: "bar",
 					},
 					Spec: piraeusv1alpha1.LinstorCSIDriverSpec{},
@@ -120,7 +120,7 @@ func TestReconcileLinstorCSIDriver_Reconcile(t *testing.T) {
 
 			reconciler := ReconcileLinstorCSIDriver{controllerClient, scheme.Scheme}
 
-			_, err := reconciler.Reconcile(reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo-csi-driver", Namespace: "bar"}})
+			_, err := reconciler.Reconcile(reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo", Namespace: "bar"}})
 			if testcase.withError {
 				if err == nil {
 					t.Errorf("expected error, got no error")


### PR DESCRIPTION
Suffixes indicating the type of a resource are not idiomatic Kubernetes style.

@WanzenBug 