### PR TITLE
allow customizing linstor controller endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   when installing via Helm.
 * Authentication with etcd using TLS client certificates.
 * Secured connection between linstor-client and controller (HTTPS). More in the [security guide](./doc/security.md#configuring-secure-communications-for-the-linstor-api)
+* Linstor controller endpoint can now be customized for all resources. If not specified, the old default values will be
+  filled in.
 
 ### Removed
 

--- a/charts/piraeus/crds/piraeus.linbit.com_linstorcsidrivers_crd.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstorcsidrivers_crd.yaml
@@ -38,6 +38,10 @@ spec:
         spec:
           description: LinstorCSIDriverSpec defines the desired state of LinstorCSIDriver
           properties:
+            controllerEndpoint:
+              description: Cluster URL of the linstor controller. If not set, will
+                be determined from the current resource name.
+              type: string
             csiAttacherImage:
               description: Name of the CSI external attacher image. See https://kubernetes-csi.github.io/docs/external-attacher.html
               type: string

--- a/charts/piraeus/crds/piraeus.linbit.com_linstornodesets_crd.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstornodesets_crd.yaml
@@ -31,6 +31,10 @@ spec:
         spec:
           description: LinstorNodeSetSpec defines the desired state of LinstorNodeSet
           properties:
+            controllerEndpoint:
+              description: Cluster URL of the linstor controller. If not set, will
+                be determined from the current resource name.
+              type: string
             drbdKernelModuleInjectionMode:
               description: drbdKernelModuleInjectionMode selects the source for the
                 DRBD kernel module

--- a/charts/piraeus/templates/operator-csi-driver.yaml
+++ b/charts/piraeus/templates/operator-csi-driver.yaml
@@ -13,4 +13,9 @@ spec:
   csiSnapshotterImage: {{ .Values.csi.csiSnapshotterImage | quote }}
   linstorHttpsClientSecret: {{ .Values.linstorHttpsClientSecret | quote }}
   priorityClassName: {{ .Values.priorityClassName | default "" | quote }}
+  {{- if empty .Values.linstorHttpsClientSecret }}
+  controllerEndpoint: http://{{ template "operator.fullname" . }}-cs.{{ .Release.Namespace }}.svc:3370
+  {{- else }}
+  controllerEndpoint: https://{{ template "operator.fullname" . }}-cs.{{ .Release.Namespace }}.svc:3371
+  {{- end }}
   {{- end }}

--- a/charts/piraeus/templates/operator-nodeset.yaml
+++ b/charts/piraeus/templates/operator-nodeset.yaml
@@ -10,6 +10,11 @@ spec:
   satelliteImage: {{ .Values.operator.nodeSet.satelliteImage }}
   kernelModImage: {{ .Values.operator.nodeSet.kernelModImage }}
   linstorHttpsClientSecret: {{ .Values.linstorHttpsClientSecret | quote }}
+  {{- if empty .Values.linstorHttpsClientSecret }}
+  controllerEndpoint: http://{{ template "operator.fullname" . }}-cs.{{ .Release.Namespace }}.svc:3370
+  {{- else }}
+  controllerEndpoint: https://{{ template "operator.fullname" . }}-cs.{{ .Release.Namespace }}.svc:3371
+  {{- end }}
   {{- if .Values.operator.nodeSet.storagePools }}
   storagePools:
 {{ toYaml .Values.operator.nodeSet.storagePools | indent 4 }}

--- a/pkg/apis/piraeus/v1alpha1/linstorcsidriver_types.go
+++ b/pkg/apis/piraeus/v1alpha1/linstorcsidriver_types.go
@@ -49,6 +49,11 @@ type LinstorCSIDriverSpec struct {
 	// +optional
 	PriorityClassName PriorityClassName `json:"priorityClassName"`
 
+	// Cluster URL of the linstor controller.
+	// If not set, will be determined from the current resource name.
+	// +optional
+	ControllerEndpoint string `json:"controllerEndpoint"`
+
 	LinstorClientConfig `json:",inline"`
 }
 

--- a/pkg/apis/piraeus/v1alpha1/linstornodeset_types.go
+++ b/pkg/apis/piraeus/v1alpha1/linstornodeset_types.go
@@ -57,6 +57,11 @@ type LinstorNodeSetSpec struct {
 	// kernelModImage is the image (location + tag) for the LINSTOR/DRBD kernel module injector container
 	KernelModImage string `json:"kernelModImage"`
 
+	// Cluster URL of the linstor controller.
+	// If not set, will be determined from the current resource name.
+	// +optional
+	ControllerEndpoint string `json:"controllerEndpoint"`
+
 	LinstorClientConfig `json:",inline"`
 }
 

--- a/pkg/controller/linstorcontrollerset/linstorcontrollerset_controller_test.go
+++ b/pkg/controller/linstorcontrollerset/linstorcontrollerset_controller_test.go
@@ -1,11 +1,12 @@
 package linstorcontrollerset
 
 import (
+	"reflect"
+	"testing"
+
 	piraeusv1alpha1 "github.com/piraeusdatastore/piraeus-operator/pkg/apis/piraeus/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"reflect"
-	"testing"
 )
 
 func TestNewConfigMapForPCS(t *testing.T) {
@@ -22,8 +23,9 @@ func TestNewConfigMapForPCS(t *testing.T) {
 					Namespace: "default-ns",
 				},
 				Spec: piraeusv1alpha1.LinstorControllerSetSpec{
-					DBConnectionURL: "etcd://etcd.svc:5000/",
-					DBCertSecret:    "",
+					DBConnectionURL:     "etcd://etcd.svc:5000/",
+					DBCertSecret:        "",
+					LinstorClientConfig: piraeusv1alpha1.LinstorClientConfig{},
 				},
 			},
 			expected: &corev1.ConfigMap{
@@ -63,8 +65,9 @@ controllers = http://test.default-ns.svc:3370
 					Namespace: "default-ns",
 				},
 				Spec: piraeusv1alpha1.LinstorControllerSetSpec{
-					DBConnectionURL: "etcd://secure.etcd.svc:443/",
-					DBCertSecret:    "mysecret",
+					DBConnectionURL:     "etcd://secure.etcd.svc:443/",
+					DBCertSecret:        "mysecret",
+					LinstorClientConfig: piraeusv1alpha1.LinstorClientConfig{},
 				},
 			},
 			expected: &corev1.ConfigMap{
@@ -105,9 +108,10 @@ controllers = http://test.default-ns.svc:3370
 					Namespace: "default-ns",
 				},
 				Spec: piraeusv1alpha1.LinstorControllerSetSpec{
-					DBConnectionURL: "etcd://secure.etcd.svc:443/",
-					DBCertSecret:    "mysecret",
-					DBUseClientCert: true,
+					DBConnectionURL:     "etcd://secure.etcd.svc:443/",
+					DBCertSecret:        "mysecret",
+					DBUseClientCert:     true,
+					LinstorClientConfig: piraeusv1alpha1.LinstorClientConfig{},
 				},
 			},
 			expected: &corev1.ConfigMap{
@@ -150,8 +154,8 @@ controllers = http://test.default-ns.svc:3370
 					Namespace: "default-ns",
 				},
 				Spec: piraeusv1alpha1.LinstorControllerSetSpec{
-					DBConnectionURL: "etcd://etcd.svc:5000/",
-					DBCertSecret:    "",
+					DBConnectionURL:              "etcd://etcd.svc:5000/",
+					DBCertSecret:                 "",
 					LinstorHttpsControllerSecret: "controller-secret",
 					LinstorClientConfig: piraeusv1alpha1.LinstorClientConfig{
 						LinstorHttpsClientSecret: "secret",


### PR DESCRIPTION
Adds an optional (for now) "controllerEndpoint" field to all resources. If
not given, the default value will be filled and the resource updated.

This allows pointing nodesets and CSI components at different controllers if
needed. Also determening the controller URL is made much simpler.