### PR TITLE
create rbac rules outside of operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * PriorityClasses are not automatically created. When not specified, the priority class is:
   * "system-node-critical", if deployed in "kube-system" namespace
   * default PriorityClass in other namespaces
-
+* RBAC rules for CSI: creation moved to deployment step (Helm/OLM). ServiceAccounts should be specified in CSI resource.
+  If no ServiceAccounts are named, the implicitly created accounts from previous deployments will be used.
 
 ## [v0.3.0] - 2020-05-08
 

--- a/charts/piraeus/crds/piraeus.linbit.com_linstorcsidrivers_crd.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstorcsidrivers_crd.yaml
@@ -45,8 +45,15 @@ spec:
             csiAttacherImage:
               description: Name of the CSI external attacher image. See https://kubernetes-csi.github.io/docs/external-attacher.html
               type: string
+            csiControllerServiceAccountName:
+              description: Name of the service account used by the CSI controller
+                pods
+              type: string
             csiNodeDriverRegistrarImage:
               description: Name of the CSI node driver registrar image. See https://kubernetes-csi.github.io/docs/node-driver-registrar.html
+              type: string
+            csiNodeServiceAccountName:
+              description: Name of the service account used by the CSI node pods
               type: string
             csiProvisionerImage:
               description: Name of the CSI external provisioner image. See https://kubernetes-csi.github.io/docs/external-provisioner.html

--- a/charts/piraeus/templates/csi-controller-rbac.yml
+++ b/charts/piraeus/templates/csi-controller-rbac.yml
@@ -1,0 +1,121 @@
+# This YAML file contains all RBAC objects that are necessary to run a
+# CSI controller pod
+#
+# This file was manually merged from the following sources:
+# external-attacher v2.2.0: https://raw.githubusercontent.com/kubernetes-csi/external-attacher/v2.2.0/deploy/kubernetes/rbac.yaml
+# external-provisioner v1.6.0: https://raw.githubusercontent.com/kubernetes-csi/external-provisioner/v1.6.0/deploy/kubernetes/rbac.yaml
+# external-snapshotter v2.1.1: https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v2.1.1/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-controller
+  namespace: {{ .Release.Namespace }}
+---
+# Attacher must be able to work with PVs, CSINodes and VolumeAttachments
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-attacher-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-attacher-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-controller
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: external-attacher-runner
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-provisioner-runner
+rules:
+  # The following rule should be uncommented for plugins that require secrets
+  # for provisioning.
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-provisioner-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-controller
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: external-provisioner-runner
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-snapshotter-runner
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-snapshotter-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-controller
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: external-snapshotter-runner
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/piraeus/templates/csi-node-rbac.yml
+++ b/charts/piraeus/templates/csi-node-rbac.yml
@@ -1,0 +1,11 @@
+# This YAML file contains all RBAC objects that are necessary to run a
+# CSI controller pod
+#
+# This file was created by looking at the documentation for:
+# node-driver-registrar v1.3.0: https://github.com/kubernetes-csi/node-driver-registrar/tree/v1.3.0#required-permissions
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-node
+  namespace: {{ .Release.Namespace }}

--- a/charts/piraeus/templates/operator-csi-driver.yaml
+++ b/charts/piraeus/templates/operator-csi-driver.yaml
@@ -7,6 +7,8 @@ spec:
   enabled: {{ .Values.csi.enabled }}
   imagePullSecret: {{ .Values.drbdRepoCred | quote }}
   linstorPluginImage: {{ .Values.csi.pluginImage | quote }}
+  csiControllerServiceAccountName: csi-controller
+  csiNodeServiceAccountName: csi-node
   csiAttacherImage: {{ .Values.csi.csiAttacherImage | quote }}
   csiNodeDriverRegistrarImage: {{ .Values.csi.csiNodeDriverRegistrarImage | quote }}
   csiProvisionerImage: {{ .Values.csi.csiProvisionerImage | quote }}

--- a/charts/piraeus/templates/operator-deployment.yaml
+++ b/charts/piraeus/templates/operator-deployment.yaml
@@ -14,7 +14,7 @@ spec:
       labels:
         name: {{ template "operator.fullname" . }}-operator
     spec:
-      serviceAccountName: {{ template "operator.fullname" . }}-service-account
+      serviceAccountName: {{ template "operator.fullname" . }}
       containers:
         - name: piraeus-operator
           image: {{ .Values.operator.image }}

--- a/charts/piraeus/templates/operator-serviceaccount.yaml
+++ b/charts/piraeus/templates/operator-serviceaccount.yaml
@@ -1,17 +1,15 @@
 ---
-# The service account used by the operator to make API calls
+  # The service account used by the operator to make API calls
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "operator.fullname" . }}-service-account
----
-# Roles assigned to the service account (and by extension: the operator).
+  name: {{ template "operator.fullname" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ template "operator.fullname" . }}-roles
+  name: piraeus-operator
 rules:
   - apiGroups:
       - ""
@@ -108,177 +106,36 @@ rules:
       - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ template "operator.fullname" . }}-cluster-watches
-rules:
-  # Potential watches from the CSI controller
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterroles
-      - clusterrolebindings
-    verbs:
-      - get
-      - list
-      - watch
----
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ template "operator.fullname" . }}-roles-binding
+  name: piraeus-operator
 subjects:
   - kind: ServiceAccount
-    name: {{ template "operator.fullname" . }}-service-account
+    name: {{ template "operator.fullname" . }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ template "operator.fullname" . }}-roles
+  name: piraeus-operator
   apiGroup: rbac.authorization.k8s.io
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ template "operator.fullname" . }}-cluster-watches-binding
-subjects:
-  - kind: ServiceAccount
-    name: {{ template "operator.fullname" . }}-service-account
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: ClusterRole
-  name: {{ template "operator.fullname" . }}-cluster-watches
-  apiGroup: rbac.authorization.k8s.io
----
-{{- if .Values.csi.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "operator.fullname" . }}-csi-node-service-account-creator
+  name: csi-driver-registrar
 rules:
-  # Roles needed to create a service account and assign the required roles to it
-  - apiGroups: [""]
-    resources: ["serviceaccounts"]
-    verbs: ["create", "patch", "get", "list", "delete", "watch", "update"]
-  - apiGroups: ["rbac.authorization.k8s.io"]
-    resources: ["clusterroles", "clusterrolebindings"]
-    verbs: ["create", "patch", "get", "list", "delete", "watch", "update"]
-  # These are the roles granted to the CSI nodeServiceAccount. If the operator should create the service account
-  # it needs permission for them too.
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ template "operator.fullname" . }}-csi-node-service-account-creator-binding
-subjects:
-  - kind: ServiceAccount
-    name: {{ template "operator.fullname" . }}-service-account
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: ClusterRole
-  name: {{ template "operator.fullname" . }}-csi-node-service-account-creator
-  apiGroup: rbac.authorization.k8s.io
----
-# Operator needs roles to create CSI controller service account if non was specified
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ template "operator.fullname" . }}-csi-controller-service-account-creator
-rules:
-  # Roles needed to create a service account and assign the required roles to it
-  - apiGroups: [""]
-    resources: ["serviceaccounts"]
-    verbs: ["create", "patch", "get", "list", "delete", "watch", "update"]
-  - apiGroups: ["rbac.authorization.k8s.io"]
-    resources: ["clusterroles", "clusterrolebindings"]
-    verbs: ["create", "patch", "get", "list", "delete", "watch", "update"]
-  # These are the roles granted to the CSI controller ServiceAccount. If the operator should create the service account
-  # it needs permission for them too.
-  - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["csi.storage.k8s.io"]
-    resources: ["csinodeinfos"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update", "patch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["csinodes"]
-    verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csidrivers"]
     verbs: ["create", "get", "list", "watch", "delete"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list"]
-  - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "create", "delete"]
-  - apiGroups: [""]
-    resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch", "update"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshots"]
-    verbs: ["get", "list"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshotcontents"]
-    verbs: ["get", "list"]
-  - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch", "update"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["list", "watch", "create", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshotclasses"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshotcontents"]
-    verbs: ["create", "get", "list", "watch", "update", "delete"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshots"]
-    verbs: ["get", "list", "watch", "update"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
-    resources:
-    - volumesnapshots/status
-    - volumesnapshotcontents/status
-    verbs: ["update"]
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["create", "list", "watch", "delete", "get", "update"]
 ---
-kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
-  name: {{ template "operator.fullname" . }}-csi-controller-service-account-creator-binding
+  name: csi-driver-registrar
 subjects:
   - kind: ServiceAccount
-    name: {{ template "operator.fullname" . }}-service-account
+    name: {{ template "operator.fullname" . }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ template "operator.fullname" . }}-csi-controller-service-account-creator
+  name: csi-driver-registrar
   apiGroup: rbac.authorization.k8s.io
-{{- end }}

--- a/pkg/apis/piraeus/v1alpha1/linstorcsidriver_types.go
+++ b/pkg/apis/piraeus/v1alpha1/linstorcsidriver_types.go
@@ -45,6 +45,14 @@ type LinstorCSIDriverSpec struct {
 	// Image that contains the linstor-csi driver plugin
 	LinstorPluginImage string `json:"linstorPluginImage"`
 
+	// Name of the service account used by the CSI node pods
+	// +optional
+	CSINodeServiceAccountName string `json:"csiNodeServiceAccountName"`
+
+	// Name of the service account used by the CSI controller pods
+	// +optional
+	CSIControllerServiceAccountName string `json:"csiControllerServiceAccountName"`
+
 	// priorityClassName is the name of the PriorityClass for the csi driver pods
 	// +optional
 	PriorityClassName PriorityClassName `json:"priorityClassName"`


### PR DESCRIPTION
RBAC can be handled by all recommended deployment tools, namely:
* helm
* OLM
This commit removes all RBAC related rules from the CSI operator and
moves creation to Helm.