### PR TITLE
add csi resizer sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+* Support volume resizing with newer CSI versions.
 
 ### Removed
 

--- a/charts/piraeus/crds/piraeus.linbit.com_linstorcsidrivers_crd.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstorcsidrivers_crd.yaml
@@ -58,6 +58,9 @@ spec:
             csiProvisionerImage:
               description: Name of the CSI external provisioner image. See https://kubernetes-csi.github.io/docs/external-provisioner.html
               type: string
+            csiResizerImage:
+              description: Name of the CSI external resizer image. See https://kubernetes-csi.github.io/docs/external-resizer.html
+              type: string
             csiSnapshotterImage:
               description: Name of the CSI external snapshotter image. See https://kubernetes-csi.github.io/docs/external-snapshotter.html
               type: string

--- a/charts/piraeus/templates/csi-controller-rbac.yml
+++ b/charts/piraeus/templates/csi-controller-rbac.yml
@@ -2,9 +2,10 @@
 # CSI controller pod
 #
 # This file was manually merged from the following sources:
-# external-attacher v2.2.0: https://raw.githubusercontent.com/kubernetes-csi/external-attacher/v2.2.0/deploy/kubernetes/rbac.yaml
-# external-provisioner v1.6.0: https://raw.githubusercontent.com/kubernetes-csi/external-provisioner/v1.6.0/deploy/kubernetes/rbac.yaml
-# external-snapshotter v2.1.1: https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v2.1.1/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml
+# external-attacher     v2.2.0: https://raw.githubusercontent.com/kubernetes-csi/external-attacher/v2.2.0/deploy/kubernetes/rbac.yaml
+# external-provisioner  v1.6.0: https://raw.githubusercontent.com/kubernetes-csi/external-provisioner/v1.6.0/deploy/kubernetes/rbac.yaml
+# external-snapshotter  v2.1.1: https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v2.1.1/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml
+# external-resizer      v0.5.0: https://raw.githubusercontent.com/kubernetes-csi/external-resizer/v0.5.0/deploy/kubernetes/rbac.yaml
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -118,4 +119,35 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: external-snapshotter-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-resizer-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-resizer-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-controller
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: external-resizer-runner
   apiGroup: rbac.authorization.k8s.io

--- a/pkg/apis/piraeus/v1alpha1/linstorcsidriver_types.go
+++ b/pkg/apis/piraeus/v1alpha1/linstorcsidriver_types.go
@@ -40,6 +40,11 @@ type LinstorCSIDriverSpec struct {
 	// +optional
 	CSISnapshotterImage string `json:"csiSnapshotterImage"`
 
+	// Name of the CSI external resizer image.
+	// See https://kubernetes-csi.github.io/docs/external-resizer.html
+	// +optional
+	CSIResizerImage string `json:"csiResizerImage"`
+
 	// Name of a secret with authentication details for the `LinstorPluginImage` registry
 	ImagePullSecret string `json:"imagePullSecret"`
 	// Image that contains the linstor-csi driver plugin

--- a/pkg/controller/linstorcsidriver/const.go
+++ b/pkg/controller/linstorcsidriver/const.go
@@ -5,4 +5,5 @@ const (
 	DefaultNodeDriverRegistrarImage = "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
 	DefaultProvisionerImage         = "quay.io/k8scsi/csi-provisioner:v1.5.0"
 	DefaultSnapshotterImage         = "quay.io/k8scsi/csi-snapshotter:v2.0.1"
+	DefaultResizerImage             = "quay.io/k8scsi/csi-resizer:v0.5.0"
 )


### PR DESCRIPTION
add support for volume resizing via LINSTOR CSI

The two requirements for this:
* the [`external-resizer`] sidecar container needs to be added to the CSI controller pod
* the CSI controller service account needs a new role

The user needs a compatible storage class:
```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: linstor
provisioner: linstor.csi.linbit.com
allowVolumeExpansion: true
```
This needs to be documented on release in the LINSTOR docs.

Note: Relevant CSI change https://github.com/piraeusdatastore/linstor-csi/pull/70