### PR TITLE
requeue reconcile loop at expected wait points

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,6 +74,7 @@ linters:
     - gochecknoglobals
     - gochecknoinits
     - dupl
+    - goerr113
   fast: false
 
   # Excluding configuration per-path, per-linter, per-text and per-source

--- a/pkg/k8s/reconcileutil/error.go
+++ b/pkg/k8s/reconcileutil/error.go
@@ -1,0 +1,108 @@
+package reconcileutil
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// an error implementing the error interface, that has multiple sources.
+type CombinedError struct {
+	Sources []error
+}
+
+func (e *CombinedError) Error() string {
+	return "multiple errors: " + strings.Join(ErrorStrings(e.Sources...), "|")
+}
+
+// convert a list of errors into a list of string.
+func ErrorStrings(errs ...error) []string {
+	s := make([]string, 0)
+	for _, err := range errs {
+		if err != nil {
+			s = append(s, err.Error())
+		}
+	}
+
+	return s
+}
+
+// convert a list of errors into a result as returned by reconcile.Reconciler.
+func ToReconcileResult(errs ...error) (reconcile.Result, error) {
+	var filteredErrors []error = nil
+	var reconcileResults []reconcile.Result = nil
+
+	for _, item := range errs {
+		if item != nil {
+			filteredErrors = append(filteredErrors, item)
+		}
+
+		if err, ok := item.(*TemporaryError); ok {
+			reconcileResults = append(reconcileResults, err.ToReconcileResult())
+		}
+	}
+
+	if len(reconcileResults) != 0 {
+		return CombineReconcileResults(reconcileResults...), nil
+	}
+
+	if len(filteredErrors) != 0 {
+		return reconcile.Result{}, &CombinedError{Sources: filteredErrors}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// wrapper around an error that may be solved after waiting some time.
+type TemporaryError struct {
+	Source       error
+	RequeueAfter time.Duration
+}
+
+// Methods for the error (and errors.Is and errors.Unwrap) interface on TemporaryError
+
+func (e *TemporaryError) Error() string {
+	return fmt.Sprintf("temporary error: timeout=%d, error=%v", e.RequeueAfter, e.Source)
+}
+
+func (e *TemporaryError) Is(target error) bool {
+	return errors.Is(e.Source, target)
+}
+
+func (e *TemporaryError) Unwrap() error {
+	return e.Source
+}
+
+func (e *TemporaryError) ToReconcileResult() reconcile.Result {
+	return reconcile.Result{
+		Requeue:      true,
+		RequeueAfter: e.RequeueAfter,
+	}
+}
+
+// Given a list of reconcile results, returns the one with the closest restart time.
+func CombineReconcileResults(results ...reconcile.Result) reconcile.Result {
+	combined := reconcile.Result{}
+
+	for _, res := range results {
+		if res.Requeue && res.RequeueAfter == 0 {
+			// immediate requeue, no need to check the other results, this will always trump the rest
+			return res
+		}
+
+		if res.RequeueAfter == 0 {
+			// no requeue from this result, can't change our combined result
+			continue
+		}
+
+		if combined.RequeueAfter == 0 || res.RequeueAfter < combined.RequeueAfter {
+			// new result with shorter requeue time
+			combined.RequeueAfter = res.RequeueAfter
+		}
+	}
+
+	return combined
+}

--- a/pkg/k8s/reconcileutil/error_test.go
+++ b/pkg/k8s/reconcileutil/error_test.go
@@ -1,0 +1,178 @@
+package reconcileutil_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/piraeusdatastore/piraeus-operator/pkg/k8s/reconcileutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestErrorStrings(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		errors   []error
+		expected []string
+	}{
+		{
+			name:     "empty",
+			errors:   nil,
+			expected: []string{},
+		},
+		{
+			name: "multiple",
+			errors: []error{
+				fmt.Errorf("error #1"),
+				fmt.Errorf("error #2"),
+			},
+			expected: []string{
+				"error #1",
+				"error #2",
+			},
+		},
+	}
+	for _, item := range cases {
+		test := item
+		t.Run(test.name, func(t *testing.T) {
+			actual := reconcileutil.ErrorStrings(test.errors...)
+
+			if len(test.expected) != len(actual) {
+				t.Errorf("expected: %v, actual: %v", test.expected, actual)
+			}
+
+			for i := range test.expected {
+				if test.expected[i] != actual[i] {
+					t.Errorf("expected: %v, actual: %v", test.expected, actual)
+				}
+			}
+		})
+	}
+}
+
+func TestToReconcileResult(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name           string
+		errors         []error
+		expectedResult reconcile.Result
+		hasError       bool
+	}{
+		{
+			name:           "empty produces success",
+			errors:         nil,
+			expectedResult: reconcile.Result{},
+			hasError:       false,
+		},
+		{
+			name:           "nil errors are ignored",
+			errors:         []error{nil},
+			expectedResult: reconcile.Result{},
+			hasError:       false,
+		},
+		{
+			name:           "nil errors are ignored #2",
+			errors:         []error{nil, fmt.Errorf("error"), nil},
+			expectedResult: reconcile.Result{},
+			hasError:       true,
+		},
+		{
+			name: "temporary-error produces requeue",
+			errors: []error{
+				fmt.Errorf("error #1"),
+				&reconcileutil.TemporaryError{
+					Source:       fmt.Errorf("error #2"),
+					RequeueAfter: 10,
+				},
+			},
+			expectedResult: reconcile.Result{
+				RequeueAfter: 10,
+			},
+			hasError: false,
+		},
+		{
+			name: "only unknown-error produce error",
+			errors: []error{
+				fmt.Errorf("error #1"),
+				fmt.Errorf("error #2"),
+			},
+			expectedResult: reconcile.Result{},
+			hasError:       true,
+		},
+	}
+	for _, item := range cases {
+		test := item
+		t.Run(test.name, func(t *testing.T) {
+			actualResult, actualError := reconcileutil.ToReconcileResult(test.errors...)
+
+			if test.expectedResult != actualResult {
+				t.Errorf("expected: %v, actual: %v", test.expectedResult, actualResult)
+			}
+
+			if test.hasError != (actualError != nil) {
+				t.Errorf("expected error: %t, actual: %v", test.hasError, actualError)
+			}
+		})
+	}
+}
+
+func TestCombineReconcileResults(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name           string
+		results        []reconcile.Result
+		expectedResult reconcile.Result
+	}{
+		{
+			name:           "empty produces success",
+			results:        nil,
+			expectedResult: reconcile.Result{},
+		},
+		{
+			name: "single entry returns itself",
+			results: []reconcile.Result{
+				{RequeueAfter: 10},
+			},
+			expectedResult: reconcile.Result{
+				RequeueAfter: 10,
+			},
+		},
+		{
+			name: "select minimal requeue time",
+			results: []reconcile.Result{
+				{RequeueAfter: 100},
+				{RequeueAfter: 20},
+				{RequeueAfter: 50},
+			},
+			expectedResult: reconcile.Result{
+				RequeueAfter: 20,
+			},
+		},
+		{
+			name: "immediate requeue works",
+			results: []reconcile.Result{
+				{RequeueAfter: 100},
+				{RequeueAfter: 20},
+				{RequeueAfter: 50},
+				{Requeue: true},
+			},
+			expectedResult: reconcile.Result{
+				Requeue:      true,
+				RequeueAfter: 0,
+			},
+		},
+	}
+	for _, item := range cases {
+		test := item
+		t.Run(test.name, func(t *testing.T) {
+			actualResult := reconcileutil.CombineReconcileResults(test.results...)
+
+			if test.expectedResult != actualResult {
+				t.Errorf("expected: %v, actual: %v", test.expectedResult, actualResult)
+			}
+		})
+	}
+}


### PR DESCRIPTION
At some points we need to wait for specific resource to come online.
* Pods need to be scheduled
* Services need to come online (and responsive)

This change adds a new TemporaryError wrapper around a standard error.
It can be converted to a reconcile result, that automatically requeues
the reconcile loop after a given duration elapsed. We currently use it in:

* the controller, waiting until the pod is running (_NOT_ ready)
* the controller, waiting until the controller responds
* the nodeset, waiting until the controller is reachable
* the nodeset, waiting until the node is online in the controller

A few helper methods are also added, to deal with mixed temporary and
"normal" errors. A temporary error takes precedence over normal errors,
i.e. if in a collection of errors a temporary one exists, the combined
return value with be (`<requeue>`, `<no-error>`)