### PR TITLE
helm: replace etcd chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Changed
+* Replaced `bitnami/etcd` dependency with vendored custom version
+  Some important keys for the `etcd` helm chart have changed:
+  * `statefulset.replicaCount` -> `replicas`
+  * `persistence.enabled` -> `persistentVolume.enabled`
+  * `persistence.size` -> `persistentVolume.storage`
+  * `àuth.rbac` was removed: use [tls certificates](./doc/security.md#authentication-with-etcd-using-certificates)
+  * `auth.peer.useAutoTLS` was removed
+  * `envVarsConfigMap` was removed
+  * When using etcd with TLS enabled:
+    * For peer communication, peers need valid certificates for `*.<release-name>-etcd` (was `.<release-name>>-etcd-headless.<namespace>.svc.cluster.local`)
+    * For client communication, servers need valid certificates for `*.<release-name>-etcd`  (was `.<release-name>>-etcd.<namespace>.svc.cluster.local`)
 
 ## [v0.4.1] - 2020-06-10
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The operator can be deployed with Helm v3 chart in /charts as follows:
   * Use an existing storage provisioner with a default `StorageClass`.
   * [Use `hostPath` volumes](#linstor-etcd-hostpath-persistence).
   * Disable persistence for basic testing. This can be done by adding `--set
-    etcd.persistence.enabled=false` to the `helm install` command below.
+    etcd.persistentVolume.enabled=false` to the `helm install` command below.
 
 - Configure a basic storage setup for LINSTOR:
   * Create storage pools from available devices. Recommended for simple set ups. [Guide](doc/storage.md#preparing-physical-devices)
@@ -73,7 +73,6 @@ The operator can be deployed with Helm v3 chart in /charts as follows:
   everything.
 
     ```
-    helm dependency update ./charts/piraeus
     helm install piraeus-op ./charts/piraeus
     ```
 
@@ -90,9 +89,7 @@ accordingly in the `nodes=` option:
 helm install linstor-etcd ./charts/pv-hostpath --set "nodes={<NODE0>,<NODE1>,<NODE2>}"
 ```
 
-Persistence for etcd is enabled by default. The
-`etcd.volumePermissions.enabled` key in the Helm values is also set so that the
-`hostPath` volumes have appropriate permissions.
+Persistence for etcd is enabled by default.
 
 ### Using an existing database
 
@@ -176,8 +173,7 @@ A simple in-memory etcd cluster can be set up using helm:
 
 ```
 kubectl create -f examples/etcd-env-vars.yaml
-helm repo add bitnami https://charts.bitnami.com/bitnami
-helm install piraeus-etcd bitnami/etcd --set statefulset.replicaCount=3 -f examples/etcd-values.yaml
+helm install piraeus-etcd charts/piraeus/charts/etcd --set replicas=3 -f examples/etcd-values.yaml
 ```
 
 If you are using Helm 2 and encountering difficulties with the above steps, you

--- a/charts/piraeus/Chart.lock
+++ b/charts/piraeus/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: etcd
-  repository: https://charts.bitnami.com/bitnami
-  version: 4.4.10
+  repository: ""
+  version: 0.7.4
 - name: csi-snapshotter
   repository: ""
   version: 1.0.0
-digest: sha256:55610ea8b4bbd94dd9990c68af9111eef69c7a04dd7611303d37c3519c86e896
-generated: "2020-06-16T09:04:06.160781829+02:00"
+digest: sha256:cf21a04c22738a1cf06166ce1515f9ffe0558483c043e4432d19fbcd15307682
+generated: "2020-06-17T11:17:16.759913497+02:00"

--- a/charts/piraeus/Chart.yaml
+++ b/charts/piraeus/Chart.yaml
@@ -7,8 +7,7 @@ appVersion: 0.4.1  # Application Version
 
 dependencies:
   - name: "etcd"
-    version: "4.4.10"
-    repository: "https://charts.bitnami.com/bitnami"
+    version: "0.7.4"
     condition: etcd.enabled
   - name: "csi-snapshotter"
     version: "1.0.0"

--- a/charts/piraeus/charts/etcd/.helmignore
+++ b/charts/piraeus/charts/etcd/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/piraeus/charts/etcd/Chart.yaml
+++ b/charts/piraeus/charts/etcd/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+appVersion: 3.4.9
+description: Distributed reliable key-value store for the most critical data of a
+  distributed system.
+home: https://github.com/coreos/etcd
+icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png
+maintainers:
+- email: lachlan@deis.com
+  name: lachie83
+name: etcd
+sources:
+- https://github.com/coreos/etcd
+version: 0.7.4

--- a/charts/piraeus/charts/etcd/README.md
+++ b/charts/piraeus/charts/etcd/README.md
@@ -1,0 +1,187 @@
+# Etcd Helm Chart
+
+Credit to https://github.com/ingvagabund. This is an implementation of that work
+
+* https://github.com/kubernetes/contrib/pull/1295
+
+## Prerequisites Details
+* Kubernetes 1.5 (for `StatefulSets` support)
+* PV support on the underlying infrastructure
+* ETCD version >= 3.0.0
+
+## StatefulSet Details
+* https://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/
+
+## StatefulSet Caveats
+* https://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/#limitations
+
+## Chart Details
+This chart will do the following:
+
+* Implemented a dynamically scalable etcd cluster using Kubernetes StatefulSets
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release etcd
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the etcd chart and their default values.
+
+| Parameter                           | Description                          | Default                                            |
+| ----------------------------------- | ------------------------------------ | -------------------------------------------------- |
+| `image.repository`                  | Container image repository           | `gcr.io/etcd-development/etcd`                     |
+| `image.tag`                         | Container image tag                  | `v3.4.9`                                           |
+| `image.pullPolicy`                  | Container pull policy                | `IfNotPresent`                                     |
+| `replicas`                          | k8s statefulset replicas             | `3`                                                |
+| `resources`                         | container required resources         | `{}`                                               |
+| `clientPort`                        | k8s service port                     | `2379`                                             |
+| `peerPorts`                         | Container listening port             | `2380`                                             |
+| `storage`                           | Persistent volume size               | `1Gi`                                              |
+| `storageClass`                      | Persistent volume storage class      | `anything`                                         |
+| `affinity`                          | affinity settings for pod assignment | `<only one pod per node>`                          |
+| `nodeSelector`                      | Node labels for pod assignment       | `{}`                                               |
+| `tolerations`                       | Toleration labels for pod assignment | `[]`                                               |
+| `extraEnv`                          | Optional environment variables       | `[]`                                               |
+| `memoryMode`                        | Using memory as backend storage      | `false`                                            |
+| `auth.client.existingSecret`        | Secret for securing the client API. Required keys: `cert.pem`, `key.pem`, `ca.crt` | `<none>` |
+| `auth.client.enableAuthentication`  | Enables host authentication using TLS certificates. Existing secret is required.    | `false` |
+| `auth.client.secureTransport`       | Enables encryption of client communication using TLS certificates | `false` |
+| `auth.peer.existingSecret`          | Secret for securing the peer communication. Required keys: `cert.pem`, `key.pem`, `ca.crt` | `<none>` |
+| `auth.peer.secureTransport`         | Enables encryption peer communication using TLS certificates **(At the moment works only with Auto TLS)** | `false` |
+| `auth.peer.enableAuthentication`    | Enables host authentication using TLS certificates. Existing secret required | `false` |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml incubator/etcd
+```
+> **Tip**: You can use the default [values.yaml](values.yaml)
+# To install the chart with secure transport enabled
+First you must create a secret which would contain the client certificates: cert, key and the CA which was to used to sign them.
+Create the secret using this command:
+```bash
+$ kubectl create secret generic etcd-client-certs --from-file=ca.crt=path/to/ca.crt --from-file=cert.pem=path/to/cert.pem --from-file=key.pem=path/to/key.pem
+$ kubectl create secret generic etcd-peer-certs --from-file=ca.crt=path/to/peer-ca.crt --from-file=cert.pem=path/to/peer-cert.pem --from-file=key.pem=path/to/peer-key.pem
+```
+Deploy the chart with the following flags enabled:
+```bash
+$ helm install --name my-release --set auth.client.secureTransport=true --set auth.client.enableAuthentication=true --set auth.client.existingSecret=etcd-client-certs set auth.peer.secureTransport=true --set auth.peer.enableAuthentication=true --set auth.peer.existingSecret=etcd-peer-certs incubator/etcd
+```
+Reference to how to generate the needed certificate:
+> Ref: https://coreos.com/os/docs/latest/generate-self-signed-certificates.html
+
+# Deep dive
+
+## Cluster Health
+
+```
+$ for i in <0..n>; do kubectl exec <release-podname-$i> -- sh -c 'etcdctl cluster-health'; done
+```
+eg.
+```
+$ for i in {0..9}; do kubectl exec named-lynx-etcd-$i --namespace=etcd -- sh -c 'etcdctl cluster-health'; done
+member 7878c44dabe58db is healthy: got healthy result from http://named-lynx-etcd-7.named-lynx-etcd:2379
+member 19d2ab7b415341cc is healthy: got healthy result from http://named-lynx-etcd-4.named-lynx-etcd:2379
+member 6b627d1b92282322 is healthy: got healthy result from http://named-lynx-etcd-3.named-lynx-etcd:2379
+member 6bb377156d9e3fb3 is healthy: got healthy result from http://named-lynx-etcd-0.named-lynx-etcd:2379
+member 8ebbb00c312213d6 is healthy: got healthy result from http://named-lynx-etcd-8.named-lynx-etcd:2379
+member a32e3e8a520ff75f is healthy: got healthy result from http://named-lynx-etcd-5.named-lynx-etcd:2379
+member dc83003f0a226816 is healthy: got healthy result from http://named-lynx-etcd-2.named-lynx-etcd:2379
+member e3dc94686f60465d is healthy: got healthy result from http://named-lynx-etcd-6.named-lynx-etcd:2379
+member f5ee1ca177a88a58 is healthy: got healthy result from http://named-lynx-etcd-1.named-lynx-etcd:2379
+cluster is healthy
+```
+
+## Failover
+
+If any etcd member fails it gets re-joined eventually.
+You can test the scenario by killing process of one of the replicas:
+
+```shell
+$ ps aux | grep etcd-1
+$ kill -9 ETCD_1_PID
+```
+
+```shell
+$ kubectl get pods -l "release=${RELEASE-NAME},app=etcd"
+NAME                 READY     STATUS        RESTARTS   AGE
+etcd-0               1/1       Running       0          54s
+etcd-2               1/1       Running       0          51s
+```
+
+After a while:
+
+```shell
+$ kubectl get pods -l "release=${RELEASE-NAME},app=etcd"
+NAME                 READY     STATUS    RESTARTS   AGE
+etcd-0               1/1       Running   0          1m
+etcd-1               1/1       Running   0          20s
+etcd-2               1/1       Running   0          1m
+```
+
+You can check state of re-joining from ``etcd-1``'s logs:
+
+```shell
+$ kubectl logs etcd-1
+Waiting for etcd-0.etcd to come up
+Waiting for etcd-1.etcd to come up
+ping: bad address 'etcd-1.etcd'
+Waiting for etcd-1.etcd to come up
+Waiting for etcd-2.etcd to come up
+Re-joining etcd member
+Updated member with ID 7fd61f3f79d97779 in cluster
+2016-06-20 11:04:14.962169 I | etcdmain: etcd Version: 2.2.5
+2016-06-20 11:04:14.962287 I | etcdmain: Git SHA: bc9ddf2
+...
+```
+
+## Scaling using kubectl
+
+This is for reference. Scaling should be managed by `helm upgrade`
+
+The etcd cluster can be scale up by running ``kubectl patch`` or ``kubectl edit``. For instance,
+
+```sh
+$ kubectl get pods -l "release=${RELEASE-NAME},app=etcd"
+NAME      READY     STATUS    RESTARTS   AGE
+etcd-0    1/1       Running   0          7m
+etcd-1    1/1       Running   0          7m
+etcd-2    1/1       Running   0          6m
+
+$ kubectl patch statefulset/etcd -p '{"spec":{"replicas": 5}}'
+"etcd" patched
+
+$ kubectl get pods -l "release=${RELEASE-NAME},app=etcd"
+NAME      READY     STATUS    RESTARTS   AGE
+etcd-0    1/1       Running   0          8m
+etcd-1    1/1       Running   0          8m
+etcd-2    1/1       Running   0          8m
+etcd-3    1/1       Running   0          4s
+etcd-4    1/1       Running   0          1s
+```
+
+Scaling-down is similar. For instance, changing the number of replicas to ``4``:
+
+```sh
+$ kubectl edit statefulset/etcd
+statefulset "etcd" edited
+
+$ kubectl get pods -l "release=${RELEASE-NAME},app=etcd"
+NAME      READY     STATUS    RESTARTS   AGE
+etcd-0    1/1       Running   0          8m
+etcd-1    1/1       Running   0          8m
+etcd-2    1/1       Running   0          8m
+etcd-3    1/1       Running   0          4s
+```
+
+Once a replica is terminated (either by running ``kubectl delete pod etcd-ID`` or scaling down),
+content of ``/var/run/etcd/`` directory is cleaned up.
+If any of the etcd pods restarts (e.g. caused by etcd failure or any other),
+the directory is kept untouched so the pod can recover from the failure.

--- a/charts/piraeus/charts/etcd/templates/NOTES.txt
+++ b/charts/piraeus/charts/etcd/templates/NOTES.txt
@@ -1,0 +1,1 @@
+etcd has been installed.

--- a/charts/piraeus/charts/etcd/templates/_helpers.tpl
+++ b/charts/piraeus/charts/etcd/templates/_helpers.tpl
@@ -1,0 +1,69 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "etcd.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "etcd.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper etcd peer protocol
+*/}}
+{{- define "etcd.peerProtocol" -}}
+{{- if .Values.auth.peer.secureTransport -}}
+{{- print "https" -}}
+{{- else -}}
+{{- print "http" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper etcd client protocol
+*/}}
+{{- define "etcd.clientProtocol" -}}
+{{- if .Values.auth.client.secureTransport -}}
+{{- print "https" -}}
+{{- else -}}
+{{- print "http" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper etcdctl authentication options
+*/}}
+{{- define "etcd.authOptions" -}}
+{{- $certsOption := " --cert=\"$ETCD_CERT_FILE\" --key=\"$ETCD_KEY_FILE\"" -}}
+{{- $caOption := " --cacert=\"$ETCD_TRUSTED_CA_FILE\"" -}}
+{{- if .Values.auth.client.secureTransport -}}
+{{- printf "%s" $certsOption -}}
+{{- end -}}
+{{- if .Values.auth.client.enableAuthentication -}}
+{{- printf "%s" $caOption -}}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "etcd.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/piraeus/charts/etcd/templates/service.yaml
+++ b/charts/piraeus/charts/etcd/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+metadata:
+  name: {{ template "etcd.fullname" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "etcd.name" . }}
+spec:
+  ports:
+  - port: {{ .Values.peerPort }}
+    name: etcd-server
+  - port: {{ .Values.clientPort }}
+    name: etcd-client
+  clusterIP: None
+  selector:
+    app: {{ template "etcd.name" . }}
+    release: {{ .Release.Name | quote }}

--- a/charts/piraeus/charts/etcd/templates/statefulset.yaml
+++ b/charts/piraeus/charts/etcd/templates/statefulset.yaml
@@ -1,0 +1,284 @@
+{{- $etcdPeerProtocol := include "etcd.peerProtocol" . }}
+{{- $etcdClientProtocol := include "etcd.clientProtocol" . }}
+{{- $etcdAuthOptions := include "etcd.authOptions" . }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "etcd.fullname" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "etcd.name" . }}
+    app.kubernetes.io/name: {{ template "etcd.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "etcd.name" . }}
+      #app.kubernetes.io/instance: {{ .Release.Name }}
+  serviceName: {{ template "etcd.fullname" . }}
+  replicas: {{ .Values.replicas }}
+  template:
+    metadata:
+      name: {{ template "etcd.fullname" . }}
+      labels:
+        heritage: {{ .Release.Service | quote }}
+        release: {{ .Release.Name | quote }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        app: {{ template "etcd.name" . }}
+    spec:
+{{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- end }}
+      containers:
+      - name: {{ template "etcd.fullname" . }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+        ports:
+        - containerPort: {{ .Values.peerPort }}
+          name: peer
+        - containerPort: {{ .Values.clientPort }}
+          name: client
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        env:
+        - name: ETCDCTL_API
+          value: "3"
+        - name: INITIAL_CLUSTER_SIZE
+          value: {{ .Values.replicas | quote }}
+        - name: SET_NAME
+          value: {{ template "etcd.fullname" . }}
+        {{- if and .Values.auth.peer.secureTransport }}
+        - name: ETCD_PEER_CERT_FILE
+          value: "/opt/etcd/certs/peer/cert.pem"
+        - name: ETCD_PEER_KEY_FILE
+          value: "/opt/etcd/certs/peer/key.pem"
+        {{- if .Values.auth.peer.enableAuthentication }}
+        - name: ETCD_PEER_CLIENT_CERT_AUTH
+          value: "true"
+        - name: ETCD_PEER_TRUSTED_CA_FILE
+          value: "/opt/etcd/certs/peer/ca.crt"
+        {{- end }}
+        {{- end }}
+        {{- if .Values.auth.client.secureTransport }}
+        - name: ETCD_CERT_FILE
+          value: "/opt/etcd/certs/client/cert.pem"
+        - name: ETCD_KEY_FILE
+          value: "/opt/etcd/certs/client/key.pem"
+        {{- if .Values.auth.client.enableAuthentication }}
+        - name: ETCD_CLIENT_CERT_AUTH
+          value: "true"
+        - name: ETCD_TRUSTED_CA_FILE
+          value: "/opt/etcd/certs/client/ca.crt"
+        {{- end }}
+        {{- end }}
+{{- if .Values.extraEnv }}
+{{ toYaml .Values.extraEnv | indent 8 }}
+{{- end }}
+        volumeMounts:
+        - name: datadir
+          mountPath: /var/run/etcd
+        {{- if .Values.auth.client.secureTransport }}
+        - name: etcd-client-certs
+          mountPath: /opt/etcd/certs/client/
+          readOnly: true
+        {{- end }}
+        {{- if .Values.auth.peer.secureTransport }}
+        - name: etcd-peer-certs
+          mountPath: /opt/etcd/certs/peer/
+          readOnly: true
+        {{- end }}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+                - "/bin/sh"
+                - "-ec"
+                - |
+                  EPS=""
+                  for i in $(seq 0 $((${INITIAL_CLUSTER_SIZE} - 1))); do
+                      EPS="${EPS}${EPS:+,}{{ $etcdPeerProtocol }}://${SET_NAME}-${i}.${SET_NAME}:2379"
+                  done
+
+                  HOSTNAME=$(hostname)
+                  AUTH_OPTIONS="{{ $etcdAuthOptions }}"
+
+                  member_hash() {
+                      etcdctl $AUTH_OPTIONS member list | grep {{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380 | cut -d ',' -f1
+                  }
+
+                  SET_ID=${HOSTNAME##*[^0-9]}
+
+                  if [ "${SET_ID}" -ge ${INITIAL_CLUSTER_SIZE} ]; then
+                      echo "Removing ${HOSTNAME} from etcd cluster"
+                      ETCDCTL_ENDPOINT=${EPS} etcdctl $AUTH_OPTIONS member remove $(member_hash)
+                      if [ $? -eq 0 ]; then
+                          # Remove everything otherwise the cluster will no longer scale-up
+                          rm -rf /var/run/etcd/*
+                      fi
+                  fi
+        command:
+          - "/bin/sh"
+          - "-ec"
+          - |
+            HOSTNAME=$(hostname)
+            AUTH_OPTIONS="{{ $etcdAuthOptions }}"
+            # store member id into PVC for later member replacement
+            collect_member() {
+                while ! etcdctl $AUTH_OPTIONS member list > /dev/null 2>&1; do sleep 1; done
+                etcdctl $AUTH_OPTIONS member list | grep {{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380 | cut -d ',' -f1 > /var/run/etcd/member_id
+                exit 0
+            }
+
+            eps() {
+                EPS=""
+                for i in $(seq 0 $((${INITIAL_CLUSTER_SIZE} - 1))); do
+                    EPS="${EPS}${EPS:+,}{{ $etcdPeerProtocol }}://${SET_NAME}-${i}.${SET_NAME}:2379"
+                done
+                echo ${EPS}
+            }
+
+            member_hash() {
+                etcdctl $AUTH_OPTIONS member list | grep {{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380 | cut -d ',' -f1
+            }
+
+            # In case of disaster recovery, we want to be able to intervene in the normal startup process
+            while [ -e /var/run/etcd/nostart ]; do
+                echo "'/var/run/etcd/nostart' present, delaying startup"
+                sleep 5
+            done
+
+            # we should wait for other pods to be up before trying to join
+            # otherwise we got "no such host" errors when trying to resolve other members
+            for i in $(seq 0 $((${INITIAL_CLUSTER_SIZE} - 1))); do
+                while true; do
+                    echo "Waiting for ${SET_NAME}-${i}.${SET_NAME} to come up"
+                    ping -W 1 -c 1 ${SET_NAME}-${i}.${SET_NAME} > /dev/null && break
+                    sleep 1s
+                done
+            done
+
+            # re-joining after failure?
+            if [ -e /var/run/etcd/default.etcd -a -e /var/run/etcd/member_id ]; then
+                echo "Re-joining etcd member"
+                member_id=$(cat /var/run/etcd/member_id)
+
+                # re-join member
+                ETCDCTL_ENDPOINTS=$(eps) etcdctl $AUTH_OPTIONS member update ${member_id} "--peer-urls={{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380" | true
+                exec etcd --name ${HOSTNAME} \
+                    --listen-peer-urls {{ $etcdPeerProtocol }}://0.0.0.0:2380 \
+                    --listen-client-urls {{ $etcdClientProtocol }}://0.0.0.0:2379\
+                    --advertise-client-urls {{ $etcdClientProtocol }}://${HOSTNAME}.${SET_NAME}:2379 \
+                    --data-dir /var/run/etcd/default.etcd
+            fi
+
+            # etcd-SET_ID
+            SET_ID=${HOSTNAME##*[^0-9]}
+
+            # adding a new member to existing cluster (assuming all initial pods are available)
+            if [ "${SET_ID}" -ge ${INITIAL_CLUSTER_SIZE} ]; then
+                export ETCDCTL_ENDPOINTS=$(eps)
+
+                # member already added?
+                MEMBER_HASH=$(member_hash)
+                if [ -n "${MEMBER_HASH}" ]; then
+                    # the member hash exists but for some reason etcd failed
+                    # as the datadir has not be created, we can remove the member
+                    # and retrieve new hash
+                    etcdctl $AUTH_OPTIONS member remove ${MEMBER_HASH}
+                fi
+
+                echo "Adding new member"
+                etcdctl $AUTH_OPTIONS member add ${HOSTNAME} "--peer-urls={{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380" | grep "^ETCD_" > /var/run/etcd/new_member_envs
+
+                if [ $? -ne 0 ]; then
+                    echo "Exiting"
+                    rm -f /var/run/etcd/new_member_envs
+                    exit 1
+                fi
+
+                cat /var/run/etcd/new_member_envs
+                source /var/run/etcd/new_member_envs
+
+                collect_member &
+
+                exec etcd --name ${HOSTNAME} \
+                    --listen-peer-urls {{ $etcdPeerProtocol }}://0.0.0.0:2380 \
+                    --listen-client-urls {{ $etcdClientProtocol }}://0.0.0.0:2379 \
+                    --advertise-client-urls {{ $etcdClientProtocol }}://${HOSTNAME}.${SET_NAME}:2379 \
+                    --data-dir /var/run/etcd/default.etcd \
+                    --initial-advertise-peer-urls {{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380 \
+                    --initial-cluster ${ETCD_INITIAL_CLUSTER} \
+                    --initial-cluster-state ${ETCD_INITIAL_CLUSTER_STATE}
+
+            fi
+
+            PEERS=""
+            for i in $(seq 0 $((${INITIAL_CLUSTER_SIZE} - 1))); do
+                PEERS="${PEERS}${PEERS:+,}${SET_NAME}-${i}={{ $etcdPeerProtocol }}://${SET_NAME}-${i}.${SET_NAME}:2380"
+            done
+
+            collect_member &
+
+            # join member
+            exec etcd --name ${HOSTNAME} \
+                --initial-advertise-peer-urls {{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380 \
+                --listen-peer-urls {{ $etcdPeerProtocol }}://0.0.0.0:2380 \
+                --listen-client-urls {{ $etcdClientProtocol }}://0.0.0.0:2379 \
+                --advertise-client-urls {{ $etcdClientProtocol }}://${HOSTNAME}.${SET_NAME}:2379 \
+                --initial-cluster-token etcd-cluster-1 \
+                --initial-cluster ${PEERS} \
+                --initial-cluster-state new \
+                --data-dir /var/run/etcd/default.etcd
+      volumes:
+      {{- if .Values.auth.client.secureTransport }}
+      - name: etcd-client-certs
+        secret:
+          secretName: {{ required "A secret containinig the client certificates is required" .Values.auth.client.existingSecret }}
+          defaultMode: 256
+      {{- end }}
+      {{- if .Values.auth.peer.secureTransport }}
+      - name: etcd-peer-certs
+        secret:
+          secretName: {{ required "A secret containinig the peer certificates is required" .Values.auth.peer.existingSecret }}
+          defaultMode: 256
+      {{- end }}
+      {{- if not .Values.persistentVolume.enabled }}
+      {{- if .Values.memoryMode }}
+      - name: datadir
+        emptyDir:
+          medium: Memory
+      {{- else }}
+      - name: datadir
+        emptyDir: {}
+      {{- end }}
+      {{- end}}
+  {{- if .Values.persistentVolume.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: datadir
+    spec:
+      accessModes:
+        - "ReadWriteOnce"
+      resources:
+        requests:
+          # upstream recommended max is 700M
+          storage: "{{ .Values.persistentVolume.storage }}"
+    {{- if .Values.persistentVolume.storageClass }}
+    {{- if (eq "-" .Values.persistentVolume.storageClass) }}
+      storageClassName: ""
+    {{- else }}
+      storageClassName: "{{ .Values.persistentVolume.storageClass }}"
+    {{- end }}
+    {{- end }}
+  {{- end }}

--- a/charts/piraeus/charts/etcd/values.yaml
+++ b/charts/piraeus/charts/etcd/values.yaml
@@ -1,0 +1,78 @@
+# Default values for etcd.
+# This is a YAML-formatted file.
+# Declare name/value pairs to be passed into your templates.
+# name: value
+
+peerPort: 2380
+clientPort: 2379
+component: "etcd"
+replicas: 3
+image:
+  repository: "gcr.io/etcd-development/etcd"
+  tag: "v3.4.9"
+  pullPolicy: "IfNotPresent"
+resources: {}
+# We usually recommend not to specify default resources and to leave this as a conscious
+# choice for the user. This also increases chances charts run on environments with little
+# resources, such as Minikube. If you do want to specify resources, uncomment the following
+# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+# limits:
+#  cpu: 100m
+#  memory: 128Mi
+# requests:
+#  cpu: 100m
+#  memory: 128Mi
+
+# Authentication parameters
+##
+auth:
+  client:
+    ## Switch to encrypt client communication using TLS certificates
+    secureTransport: false
+    ## Switch to enable host authentication using TLS certificates. Requires existing secret.
+    enableAuthentication: false
+    ## Name of the existing secret containing cert files for client communication.
+    existingSecret:
+
+  peer:
+    ## Switch to encrypt peer communication using TLS certificates
+    secureTransport: false
+    ## Switch to enable host authentication using TLS certificates. Requires existing secret.
+    enableAuthentication: false
+    ## Name of the existing secret containing cert files for client communication.
+    existingSecret:
+
+persistentVolume:
+  enabled: false
+  storage: "1Gi"
+  ## etcd data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  storageClass: ""
+
+## This is only available when persistentVolume is false:
+## If persistentVolume is not enabled, one can choose to use memory mode for ETCD by setting memoryMode to "true".
+## The system will create a volume with "medium: Memory"
+memoryMode: false
+
+## Node labels and tolerations for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+nodeSelector: {}
+tolerations: []
+affinity:
+  # Ensures only one pod is scheduled per node
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: app
+              operator: In
+              values:
+                - etcd
+        topologyKey: "kubernetes.io/hostname"
+extraEnv: []

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -1,15 +1,9 @@
 etcd:
-  persistence:
+  persistentVolume:
     enabled: true
-    size: 1Gi
-  volumePermissions:
-    enabled: true
-  auth:
-    rbac:
-      enabled: false
-  statefulset:
-    replicaCount: 3
-  envVarsConfigMap: "etcd-env-vars"
+    storage: 1Gi
+  replicas: 1 # How many instances of etcd will be added to the initial cluster.
+
 csi-snapshotter:
   enabled: true # <- enable to add k8s snapshotting CRDs and controller. Needed for CSI snapshotting
 csi:

--- a/examples/etcd-values.yaml
+++ b/examples/etcd-values.yaml
@@ -1,6 +1,2 @@
-persistence:
+persistentVolume:
   enabled: false
-auth:
-  rbac:
-    enabled: false
-envVarsConfigMap: "etcd-env-vars"


### PR DESCRIPTION
Use a custom version of the incubator/etcd chart.
Ongoing issues with bitnami/etcd [1] meant a node failure basically
permanently killed the etcd. The new chart taken from [2], updated
for our use-case, is able to recover from node failures

[1]: https://github.com/bitnami/charts/issues/1908
[2]: https://github.com/helm/charts/tree/master/incubator/etcd