### PR TITLE
fix for upscaling issue on new etcd

### DIFF
--- a/charts/piraeus/charts/etcd/templates/statefulset.yaml
+++ b/charts/piraeus/charts/etcd/templates/statefulset.yaml
@@ -136,20 +136,20 @@ spec:
             # store member id into PVC for later member replacement
             collect_member() {
                 while ! etcdctl $AUTH_OPTIONS member list > /dev/null 2>&1; do sleep 1; done
-                etcdctl $AUTH_OPTIONS member list | grep {{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380 | cut -d ',' -f1 > /var/run/etcd/member_id
+                etcdctl $AUTH_OPTIONS member list | grep "{{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380" | cut -d ',' -f1 > /var/run/etcd/member_id
                 exit 0
             }
 
             eps() {
                 EPS=""
-                for i in $(seq 0 $((${INITIAL_CLUSTER_SIZE} - 1))); do
+                for i in $(seq 0 $((INITIAL_CLUSTER_SIZE - 1))); do
                     EPS="${EPS}${EPS:+,}{{ $etcdPeerProtocol }}://${SET_NAME}-${i}.${SET_NAME}:2379"
                 done
-                echo ${EPS}
+                echo "${EPS}"
             }
 
             member_hash() {
-                etcdctl $AUTH_OPTIONS member list | grep {{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380 | cut -d ',' -f1
+                etcdctl $AUTH_OPTIONS member list | grep "{{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380" | cut -d ',' -f1
             }
 
             # In case of disaster recovery, we want to be able to intervene in the normal startup process
@@ -160,25 +160,32 @@ spec:
 
             # we should wait for other pods to be up before trying to join
             # otherwise we got "no such host" errors when trying to resolve other members
-            for i in $(seq 0 $((${INITIAL_CLUSTER_SIZE} - 1))); do
+            for i in $(seq 0 $((INITIAL_CLUSTER_SIZE - 1))); do
                 while true; do
                     echo "Waiting for ${SET_NAME}-${i}.${SET_NAME} to come up"
-                    ping -W 1 -c 1 ${SET_NAME}-${i}.${SET_NAME} > /dev/null && break
+                    ping -W 1 -c 1 "${SET_NAME}-${i}.${SET_NAME}" > /dev/null && break
                     sleep 1s
                 done
             done
 
+            # we should also wait for our own pod to be available in the cluster
+            while true; do
+                echo "Waiting for ${HOSTNAME}.${SET_NAME} to come up"
+                ping -W 1 -c 1 "${HOSTNAME}.${SET_NAME}" > /dev/null && break
+                sleep 1s
+            done
+
             # re-joining after failure?
-            if [ -e /var/run/etcd/default.etcd -a -e /var/run/etcd/member_id ]; then
+            if [ -e /var/run/etcd/default.etcd ] && [ -e /var/run/etcd/member_id ]; then
                 echo "Re-joining etcd member"
                 member_id=$(cat /var/run/etcd/member_id)
 
                 # re-join member
-                ETCDCTL_ENDPOINTS=$(eps) etcdctl $AUTH_OPTIONS member update ${member_id} "--peer-urls={{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380" | true
-                exec etcd --name ${HOSTNAME} \
-                    --listen-peer-urls {{ $etcdPeerProtocol }}://0.0.0.0:2380 \
-                    --listen-client-urls {{ $etcdClientProtocol }}://0.0.0.0:2379\
-                    --advertise-client-urls {{ $etcdClientProtocol }}://${HOSTNAME}.${SET_NAME}:2379 \
+                ETCDCTL_ENDPOINTS=$(eps) etcdctl $AUTH_OPTIONS member update "${member_id}" "--peer-urls={{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380" || true
+                exec etcd --name "${HOSTNAME}" \
+                    --listen-peer-urls "{{ $etcdPeerProtocol }}://0.0.0.0:2380" \
+                    --listen-client-urls "{{ $etcdClientProtocol }}://0.0.0.0:2379" \
+                    --advertise-client-urls "{{ $etcdClientProtocol }}://${HOSTNAME}.${SET_NAME}:2379" \
                     --data-dir /var/run/etcd/default.etcd
             fi
 
@@ -186,58 +193,58 @@ spec:
             SET_ID=${HOSTNAME##*[^0-9]}
 
             # adding a new member to existing cluster (assuming all initial pods are available)
-            if [ "${SET_ID}" -ge ${INITIAL_CLUSTER_SIZE} ]; then
-                export ETCDCTL_ENDPOINTS=$(eps)
-
+            if [ "${SET_ID}" -ge "${INITIAL_CLUSTER_SIZE}" ]; then
+                ETCDCTL_ENDPOINTS=$(eps)
+                export ETCDCTL_ENDPOINTS
                 # member already added?
                 MEMBER_HASH=$(member_hash)
                 if [ -n "${MEMBER_HASH}" ]; then
                     # the member hash exists but for some reason etcd failed
                     # as the datadir has not be created, we can remove the member
                     # and retrieve new hash
-                    etcdctl $AUTH_OPTIONS member remove ${MEMBER_HASH}
+                    etcdctl $AUTH_OPTIONS member remove "${MEMBER_HASH}"
                 fi
 
                 echo "Adding new member"
-                etcdctl $AUTH_OPTIONS member add ${HOSTNAME} "--peer-urls={{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380" | grep "^ETCD_" > /var/run/etcd/new_member_envs
 
-                if [ $? -ne 0 ]; then
+                if ! etcdctl $AUTH_OPTIONS member add "${HOSTNAME}" "--peer-urls={{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380" | grep "^ETCD_" > /var/run/etcd/new_member_envs ; then
                     echo "Exiting"
                     rm -f /var/run/etcd/new_member_envs
                     exit 1
                 fi
 
                 cat /var/run/etcd/new_member_envs
-                source /var/run/etcd/new_member_envs
+                # shellcheck disable=SC1091
+                . /var/run/etcd/new_member_envs
 
                 collect_member &
 
-                exec etcd --name ${HOSTNAME} \
-                    --listen-peer-urls {{ $etcdPeerProtocol }}://0.0.0.0:2380 \
-                    --listen-client-urls {{ $etcdClientProtocol }}://0.0.0.0:2379 \
-                    --advertise-client-urls {{ $etcdClientProtocol }}://${HOSTNAME}.${SET_NAME}:2379 \
+                exec etcd --name "${HOSTNAME}" \
+                    --listen-peer-urls "{{ $etcdPeerProtocol }}://0.0.0.0:2380" \
+                    --listen-client-urls "{{ $etcdClientProtocol }}://0.0.0.0:2379" \
+                    --advertise-client-urls "{{ $etcdClientProtocol }}://${HOSTNAME}.${SET_NAME}:2379" \
                     --data-dir /var/run/etcd/default.etcd \
-                    --initial-advertise-peer-urls {{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380 \
-                    --initial-cluster ${ETCD_INITIAL_CLUSTER} \
-                    --initial-cluster-state ${ETCD_INITIAL_CLUSTER_STATE}
+                    --initial-advertise-peer-urls "{{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380" \
+                    --initial-cluster "${ETCD_INITIAL_CLUSTER}" \
+                    --initial-cluster-state "${ETCD_INITIAL_CLUSTER_STATE}"
 
             fi
 
             PEERS=""
-            for i in $(seq 0 $((${INITIAL_CLUSTER_SIZE} - 1))); do
+            for i in $(seq 0 $((INITIAL_CLUSTER_SIZE - 1))); do
                 PEERS="${PEERS}${PEERS:+,}${SET_NAME}-${i}={{ $etcdPeerProtocol }}://${SET_NAME}-${i}.${SET_NAME}:2380"
             done
 
             collect_member &
 
             # join member
-            exec etcd --name ${HOSTNAME} \
-                --initial-advertise-peer-urls {{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380 \
-                --listen-peer-urls {{ $etcdPeerProtocol }}://0.0.0.0:2380 \
-                --listen-client-urls {{ $etcdClientProtocol }}://0.0.0.0:2379 \
-                --advertise-client-urls {{ $etcdClientProtocol }}://${HOSTNAME}.${SET_NAME}:2379 \
+            exec etcd --name "${HOSTNAME}" \
+                --initial-advertise-peer-urls "{{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380" \
+                --listen-peer-urls "{{ $etcdPeerProtocol }}://0.0.0.0:2380" \
+                --listen-client-urls "{{ $etcdClientProtocol }}://0.0.0.0:2379" \
+                --advertise-client-urls "{{ $etcdClientProtocol }}://${HOSTNAME}.${SET_NAME}:2379" \
                 --initial-cluster-token etcd-cluster-1 \
-                --initial-cluster ${PEERS} \
+                --initial-cluster "${PEERS}" \
                 --initial-cluster-state new \
                 --data-dir /var/run/etcd/default.etcd
       volumes:


### PR DESCRIPTION
The new etcd image use `dash` as `/bin/sh`. `dash` uses `.` instead of `source` for executing a file in the current shell context (`.` is also POSIX compliant, `source` is not)

In addition, also wait for the current pod to be recognized as reachable before adding the cluster member

shell script was checked with
```
helm template piraeus-op charts/piraeus/charts/etcd  -s templates/statefulset.yaml | yq '.spec.template.spec.containers[0].command[2]' -r | shellcheck - -s sh
```