### PR TITLE
add new kmod injection mode `DepsOnly`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Support volume resizing with newer CSI versions.
 * A new Helm chart `csi-snapshotter` that deploys extra components needed for volume snapshots.
+* Add new kmod injection mode `DepsOnly`. Will try load kmods for LINSTOR layers from the host. Deprecates `None`.
 
 * Automatic deployment of [Stork](https://github.com/libopenstorage/stork) scheduler configured for LINSTOR.
 

--- a/charts/piraeus/crds/piraeus.linbit.com_linstornodesets_crd.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstornodesets_crd.yaml
@@ -53,6 +53,7 @@ spec:
               - None
               - Compile
               - ShippedModules
+              - DepsOnly
               type: string
             drbdRepoCred:
               description: drbdRepoCred is the name of the kubernetes secret that

--- a/pkg/apis/piraeus/v1alpha1/linstornodeset_types.go
+++ b/pkg/apis/piraeus/v1alpha1/linstornodeset_types.go
@@ -46,7 +46,7 @@ type LinstorNodeSetSpec struct {
 	AutomaticStorageType string `json:"automaticStorageType"`
 
 	// drbdKernelModuleInjectionMode selects the source for the DRBD kernel module
-	// +kubebuilder:validation:Enum=None;Compile;ShippedModules
+	// +kubebuilder:validation:Enum=None;Compile;ShippedModules;DepsOnly
 	DRBDKernelModuleInjectionMode KernelModuleInjectionMode `json:"drbdKernelModuleInjectionMode"`
 
 	// Name of k8s secret that holds the SSL key for a node (called `keystore.jks`) and
@@ -82,6 +82,8 @@ const (
 	ModuleInjectionCompile = "Compile"
 	// ModuleInjectionShippedModules means that a module included in the injector image will be used
 	ModuleInjectionShippedModules = "ShippedModules"
+	// ModuleInjectionDepsOnly means we only inject already present modules on the host for LINSTOR layers
+	ModuleInjectionDepsOnly = "DepsOnly"
 )
 
 // LinstorNodeSetStatus defines the observed state of LinstorNodeSet

--- a/pkg/controller/linstornodeset/linstornodeset_controller.go
+++ b/pkg/controller/linstornodeset/linstornodeset_controller.go
@@ -902,11 +902,14 @@ func daemonSetWithDRBDKernelModuleInjection(ds *apps.DaemonSet, pns *piraeusv1al
 	mode := pns.Spec.DRBDKernelModuleInjectionMode
 	switch mode {
 	case piraeusv1alpha1.ModuleInjectionNone:
+		logrus.WithField("drbdKernelModuleInjectionMode", mode).Warnf("using deprecated injection mode: beginning with injector image version 9.0.23, it is recommended to use '%s' instead", piraeusv1alpha1.ModuleInjectionDepsOnly)
 		return ds
 	case piraeusv1alpha1.ModuleInjectionCompile:
 		kernelModHow = kubeSpec.LinstorKernelModCompile
 	case piraeusv1alpha1.ModuleInjectionShippedModules:
 		kernelModHow = kubeSpec.LinstorKernelModShippedModules
+	case piraeusv1alpha1.ModuleInjectionDepsOnly:
+		kernelModHow = kubeSpec.LinstorKernelModDepsOnly
 	default:
 		logrus.WithFields(logrus.Fields{
 			"mode": mode,

--- a/pkg/k8s/spec/const.go
+++ b/pkg/k8s/spec/const.go
@@ -50,6 +50,7 @@ const (
 	LinstorKernelModHow            = "LB_HOW"
 	LinstorKernelModCompile        = "compile"
 	LinstorKernelModShippedModules = "shipped_modules"
+	LinstorKernelModDepsOnly       = "deps_only"
 )
 
 // Special strings when configuring Linstor


### PR DESCRIPTION
`DepsOnly` means that the nodeset init container will only load already
present kernel modules which may be of use by LINSTOR. Missing kmods are
ignored, and no DRBD will be compiled.

This mode acts as a replacement for `None`, which is now deprecated.