### PR TITLE
use deployment to configure linstor-controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [affinity]: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 [tolerations]: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
 
+* Controller is now a Deployment instead of StatefulSet.
+  This means a controller can be re-scheduled more easily should anything happen to the pod/node.
+  Please make sure any deployed StatefulSet for the controller is removed first.
+
 ## [v0.5.0] - 2020-06-29
 
 ### Added

--- a/charts/piraeus/templates/operator-serviceaccount.yaml
+++ b/charts/piraeus/templates/operator-serviceaccount.yaml
@@ -34,8 +34,6 @@ rules:
     resources:
       - deployments
       - daemonsets
-      - replicasets
-      - statefulsets
     verbs:
       - create
       - patch
@@ -44,13 +42,6 @@ rules:
       - delete
       - watch
       - update
-  - apiGroups:
-      - monitoring.coreos.com
-    resources:
-      - servicemonitors
-    verbs:
-      - get
-      - create
   - apiGroups:
       - apps
     resourceNames:
@@ -63,12 +54,6 @@ rules:
       - ""
     resources:
       - pods
-    verbs:
-      - get
-  - apiGroups:
-      - apps
-    resources:
-      - replicasets
     verbs:
       - get
   - apiGroups:

--- a/examples/piraeus-operator-part-1.yaml
+++ b/examples/piraeus-operator-part-1.yaml
@@ -22,8 +22,6 @@ rules:
   resources:
   - deployments
   - daemonsets
-  - replicasets
-  - statefulsets
   verbs:
   - '*'
 - apiGroups:

--- a/pkg/k8s/spec/const.go
+++ b/pkg/k8s/spec/const.go
@@ -57,6 +57,7 @@ const (
 const (
 	LinstorLUKSPassphraseEnvName = "MASTER_PASSPHRASE"
 	JavaOptsName                 = "JAVA_OPTS"
+	LinstorRegistrationProperty  = "Aux/registered-by"
 )
 
 // k8s constants: Special names for k8s APIs.

--- a/pkg/k8s/spec/piraeus.go
+++ b/pkg/k8s/spec/piraeus.go
@@ -29,6 +29,9 @@ const (
 	// NodeRole is the role for the node set
 	NodeRole = "piraeus-node"
 
+	// Name is the name of the operator
+	Name = "piraeus-operator"
+
 	// LockName is the name of the lock for leader election
 	LockName = "piraeus-operator-lock"
 )


### PR DESCRIPTION
By using a deployment, a controller can be re-scheduled in case of a node
failure without human intervention. Since multiple LINSTOR controllers
cannot manage the same set of nodes at the same time, we cap the replica
count at 1 and use the "Recreate" deployment strategy.

In case of a node going suddenly offline, a new pod is scheduled after the
default timeout (300s). The old pod will still be marked as running, but it
won't receive any traffic (the node is offline, and the service endpoint would
not route traffic in any case).

The possibility of multiple pods associated with a controller deployment being
available in the Kubernetes API at the same time needed some rework in the
ControllerSet registration and status update code.