### PR TITLE
customizable image registry and pull policy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,9 @@ repos:
         files: '^pkg/apis/.*\.go$'
         pass_filenames: false
         entry: make crds
+      - id: generate-cn-values
+        name: generate helm values for CN users
+        language: system
+        files: '^charts/piraeus/values.*\.yaml'
+        pass_filenames: false
+        entry: make helm-values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+* Central value for controller image pull policy of all pods. Use `--set global.imagePullPolicy=<value>` on
+  helm deployment.
+* `charts/piraeus/values.cn.yaml` a set of helm values for faster image download for CN users.
+
 ### Changed
 
 * Node scheduling no longer relies on `linstor.linbit.com/piraeus-node` labels. Instead, all CRDs support

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,14 @@ crds:
 	operator-sdk generate crds
 	mv ./deploy/crds/* ./charts/piraeus/crds
 
+helm-values:
+	cp ./charts/piraeus/values.yaml ./charts/piraeus/values.cn.yaml
+	sed 's|gcr.io/etcd-development/etcd|daocloud.io/piraeus/etcd|' -i ./charts/piraeus/values.cn.yaml
+	sed 's|docker.io/linbit/stork:latest|daocloud.io/piraeus/stork:latest|' -i ./charts/piraeus/values.cn.yaml
+	sed 's|gcr.io/google_containers/kube-scheduler-amd64|daocloud.io/piraeus/kube-scheduler-amd64|' -i ./charts/piraeus/values.cn.yaml
+	sed 's|quay.io/piraeusdatastore|daocloud.io/piraeus|' -i ./charts/piraeus/values.cn.yaml
+	sed 's|quay.io/k8scsi|daocloud.io/piraeus|' -i ./charts/piraeus/values.cn.yaml
+
 release:
 	# check that VERSION is set
 	@if [ -z "$(VERSION)" ]; then \
@@ -63,6 +71,8 @@ release:
 	yq w -i charts/piraeus/Chart.yaml appVersion $(VERSION)
 	# set operator image to tagged version
 	yq w -i charts/piraeus/values.yaml operator.image "quay.io/piraeusdatastore/piraeus-operator:$(VERSION)"
+	yq w -i charts/piraeus/values.cn.yaml operator.image "daocloud.io/piraeus/piraeus-operator:$(VERSION)"
+	git add --update
 	# commit as current release + tag
 	git commit -aevm "Release v$(VERSION)"
 	git tag v$(VERSION)
@@ -71,5 +81,6 @@ release:
 	echo "[Unreleased]: https://github.com/piraeusdatastore/piraeus-operator/compare/v$(VERSION)...HEAD" >> CHANGELOG.md
 	# set operator image back to :latest during development
 	yq w -i charts/piraeus/values.yaml operator.image "quay.io/piraeusdatastore/piraeus-operator:latest"
+	yq w -i charts/piraeus/values.cn.yaml operator.image "daocloud.io/piraeus/piraeus-operator:latest"
 	# commit begin of new dev cycle
 	git commit -aevm "Prepare next dev cycle"

--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ etcd cluster by adding the following to the Helm install command:
 --set etcd.enabled=false --set "operator.controllerSet.dbConnectionURL=jdbc:postgresql://postgres/postgresdb?user=postgresadmin&password=admin123"
 ```
 
+### Image mirror for CN users
+
+The chart contains a values file prepared for chinese users [`values.cn.yaml`](./charts/piraeus/values.cn.yaml).
+It replaces the default image locations with images hosted on daocloud.io.
+
 ### Terminating Helm deployment
 
 To protect the storage infrastructure of the cluster from accidentally deleting vital components, it is necessary

--- a/charts/piraeus/charts/csi-snapshotter/templates/statefulset.yaml
+++ b/charts/piraeus/charts/csi-snapshotter/templates/statefulset.yaml
@@ -29,4 +29,4 @@ spec:
           args:
             - "--v=5"
             - "--leader-election=false"
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.global.imagePullPolicy | quote }}

--- a/charts/piraeus/charts/etcd/templates/statefulset.yaml
+++ b/charts/piraeus/charts/etcd/templates/statefulset.yaml
@@ -43,7 +43,7 @@ spec:
       containers:
       - name: {{ template "etcd.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+        imagePullPolicy: {{ .Values.global.imagePullPolicy | quote }}
         ports:
         - containerPort: {{ .Values.peerPort }}
           name: peer

--- a/charts/piraeus/charts/etcd/values.yaml
+++ b/charts/piraeus/charts/etcd/values.yaml
@@ -10,7 +10,6 @@ replicas: 3
 image:
   repository: "gcr.io/etcd-development/etcd"
   tag: "v3.4.9"
-  pullPolicy: "IfNotPresent"
 resources: {}
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little

--- a/charts/piraeus/crds/piraeus.linbit.com_linstorcontrollersets_crd.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstorcontrollersets_crd.yaml
@@ -630,6 +630,9 @@ spec:
               description: DrbdRepoCred is the name of the kubernetes secret that
                 holds the credential for the DRBD repositories
               type: string
+            imagePullPolicy:
+              description: Pull policy applied to all pods started from this controller
+              type: string
             linstorHttpsClientSecret:
               description: 'Name of the secret containing: (a) `ca.pem`: root certificate
                 used to validate HTTPS connections with Linstor (PEM format, without

--- a/charts/piraeus/crds/piraeus.linbit.com_linstorcsidrivers_crd.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstorcsidrivers_crd.yaml
@@ -678,6 +678,9 @@ spec:
             csiSnapshotterImage:
               description: Name of the CSI external snapshotter image. See https://kubernetes-csi.github.io/docs/external-snapshotter.html
               type: string
+            imagePullPolicy:
+              description: Pull policy applied to all pods started from this controller
+              type: string
             imagePullSecret:
               description: Name of a secret with authentication details for the `LinstorPluginImage`
                 registry

--- a/charts/piraeus/crds/piraeus.linbit.com_linstornodesets_crd.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstornodesets_crd.yaml
@@ -632,6 +632,9 @@ spec:
               description: drbdRepoCred is the name of the kubernetes secret that
                 holds the credential for the DRBD repositories
               type: string
+            imagePullPolicy:
+              description: Pull policy applied to all pods started from this controller
+              type: string
             kernelModImage:
               description: kernelModImage is the image (location + tag) for the LINSTOR/DRBD
                 kernel module injector container

--- a/charts/piraeus/templates/operator-controllerset.yaml
+++ b/charts/piraeus/templates/operator-controllerset.yaml
@@ -11,6 +11,7 @@ spec:
   dbUseClientCert: {{ .Values.operator.controllerSet.dbUseClientCert }}
   drbdRepoCred: {{ .Values.drbdRepoCred }}
   controllerImage: {{ .Values.operator.controllerSet.controllerImage }}
+  imagePullPolicy: {{ .Values.global.imagePullPolicy | quote }}
   linstorHttpsControllerSecret: {{ .Values.linstorHttpsControllerSecret | quote }}
   linstorHttpsClientSecret: {{ .Values.linstorHttpsClientSecret | quote }}
   affinity: {{ .Values.operator.controllerSet.affinity | toJson }}

--- a/charts/piraeus/templates/operator-csi-driver.yaml
+++ b/charts/piraeus/templates/operator-csi-driver.yaml
@@ -7,11 +7,13 @@ spec:
   enabled: {{ .Values.csi.enabled }}
   imagePullSecret: {{ .Values.drbdRepoCred | quote }}
   linstorPluginImage: {{ .Values.csi.pluginImage | quote }}
+  imagePullPolicy: {{ .Values.global.imagePullPolicy | quote }}
   csiControllerServiceAccountName: csi-controller
   csiNodeServiceAccountName: csi-node
   csiAttacherImage: {{ .Values.csi.csiAttacherImage | quote }}
   csiNodeDriverRegistrarImage: {{ .Values.csi.csiNodeDriverRegistrarImage | quote }}
   csiProvisionerImage: {{ .Values.csi.csiProvisionerImage | quote }}
+  csiResizerImage: {{ .Values.csi.csiResizerImage | quote }}
   csiSnapshotterImage: {{ .Values.csi.csiSnapshotterImage | quote }}
   linstorHttpsClientSecret: {{ .Values.linstorHttpsClientSecret | quote }}
   priorityClassName: {{ .Values.priorityClassName | default "" | quote }}

--- a/charts/piraeus/templates/operator-deployment.yaml
+++ b/charts/piraeus/templates/operator-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
         - name: piraeus-operator
           image: {{ .Values.operator.image }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.global.imagePullPolicy | quote }}
           env:
             - name: WATCH_NAMESPACE
               valueFrom:

--- a/charts/piraeus/templates/operator-nodeset.yaml
+++ b/charts/piraeus/templates/operator-nodeset.yaml
@@ -7,6 +7,7 @@ spec:
   sslSecret: {{ .Values.operator.nodeSet.sslSecret }}
   drbdKernelModuleInjectionMode: {{ .Values.operator.nodeSet.drbdKernelModuleInjectionMode }}
   drbdRepoCred: {{ .Values.drbdRepoCred }}
+  imagePullPolicy: {{ .Values.global.imagePullPolicy | quote }}
   satelliteImage: {{ .Values.operator.nodeSet.satelliteImage }}
   kernelModImage: {{ .Values.operator.nodeSet.kernelModImage }}
   linstorHttpsClientSecret: {{ .Values.linstorHttpsClientSecret | quote }}

--- a/charts/piraeus/templates/stork-deployment.yaml
+++ b/charts/piraeus/templates/stork-deployment.yaml
@@ -111,8 +111,8 @@ spec:
             - --leader-elect=true
             - --snapshotter=false
             - --cluster-domain-controllers=false
-          imagePullPolicy: Always
-          image: {{ .Values.stork.image }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy | quote }}
+          image: {{ .Values.stork.storkImage }}
           ports:
             - containerPort: 8099
               name: extender
@@ -250,7 +250,8 @@ spec:
             - --policy-configmap-namespace={{ .Release.Namespace }}
             - --leader-elect-resource-name={{ .Release.Name }}-stork-scheduler
             - --leader-elect-resource-namespace={{ .Release.Namespace }}
-          image: "gcr.io/google_containers/kube-scheduler-amd64:{{ .Capabilities.KubeVersion }}"
+          image: "{{ .Values.stork.schedulerImage }}:{{ .Capabilities.KubeVersion }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy | quote }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/piraeus/values.cn.yaml
+++ b/charts/piraeus/values.cn.yaml
@@ -7,24 +7,24 @@ etcd:
     storage: 1Gi
   replicas: 1 # How many instances of etcd will be added to the initial cluster.
   image:
-    repository: gcr.io/etcd-development/etcd
+    repository: daocloud.io/piraeus/etcd
     tag: v3.4.9
 csi-snapshotter:
   enabled: true # <- enable to add k8s snapshotting CRDs and controller. Needed for CSI snapshotting
-  image: quay.io/k8scsi/snapshot-controller:v2.1.0
+  image: daocloud.io/piraeus/snapshot-controller:v2.1.0
 stork:
   enabled: true
-  storkImage: docker.io/linbit/stork:latest
-  schedulerImage: gcr.io/google_containers/kube-scheduler-amd64
+  storkImage: daocloud.io/piraeus/stork:latest
+  schedulerImage: daocloud.io/piraeus/kube-scheduler-amd64
   replicas: 1
 csi:
   enabled: true
-  pluginImage: quay.io/piraeusdatastore/piraeus-csi:v0.9.0
-  csiAttacherImage: quay.io/k8scsi/csi-attacher:v2.2.0
-  csiNodeDriverRegistrarImage: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
-  csiProvisionerImage: quay.io/k8scsi/csi-provisioner:v1.6.0
-  csiSnapshotterImage: quay.io/k8scsi/csi-snapshotter:v2.1.0
-  csiResizerImage: quay.io/k8scsi/csi-resizer:v0.5.0
+  pluginImage: daocloud.io/piraeus/piraeus-csi:v0.9.0
+  csiAttacherImage: daocloud.io/piraeus/csi-attacher:v2.2.0
+  csiNodeDriverRegistrarImage: daocloud.io/piraeus/csi-node-driver-registrar:v1.3.0
+  csiProvisionerImage: daocloud.io/piraeus/csi-provisioner:v1.6.0
+  csiSnapshotterImage: daocloud.io/piraeus/csi-snapshotter:v2.1.0
+  csiResizerImage: daocloud.io/piraeus/csi-resizer:v0.5.0
   nodeAffinity: {}
   nodeTolerations: []
   controllerAffinity: {}
@@ -34,9 +34,9 @@ drbdRepoCred: drbdiocred # <- Specify the kubernetes secret name here
 linstorHttpsControllerSecret: "" # <- name of secret containing linstor server certificates+key. See docs/security.md
 linstorHttpsClientSecret: "" # <- name of secret containing linstor client certificates+key. See docs/security.md
 operator:
-  image: quay.io/piraeusdatastore/piraeus-operator:latest
+  image: daocloud.io/piraeus/piraeus-operator:latest
   controllerSet:
-    controllerImage: quay.io/piraeusdatastore/piraeus-server:v1.7.1
+    controllerImage: daocloud.io/piraeus/piraeus-server:v1.7.1
     luksSecret: ""
     dbCertSecret: ""
     dbUseClientCert: false
@@ -45,8 +45,8 @@ operator:
     tolerations: []
   nodeSet:
     drbdKernelModuleInjectionMode: Compile
-    satelliteImage: quay.io/piraeusdatastore/piraeus-server:v1.7.1
-    kernelModImage: quay.io/piraeusdatastore/drbd9-bionic:v9.0.24
+    satelliteImage: daocloud.io/piraeus/piraeus-server:v1.7.1
+    kernelModImage: daocloud.io/piraeus/drbd9-bionic:v9.0.24
     storagePools: null
     sslSecret: ""
     automaticStorageType: None

--- a/examples/piraeus-operator-part-1.yaml
+++ b/examples/piraeus-operator-part-1.yaml
@@ -114,7 +114,7 @@ spec:
           image: "quay.io/piraeusdatastore/piraeus-operator:latest"
           command:
           - piraeus-operator
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE
               valueFrom:

--- a/pkg/apis/piraeus/v1alpha1/linstorcontrollerset_types.go
+++ b/pkg/apis/piraeus/v1alpha1/linstorcontrollerset_types.go
@@ -18,7 +18,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -62,6 +62,10 @@ type LinstorControllerSetSpec struct {
 	// controllerImage is the image (location + tag) for the LINSTOR controller/server container
 	ControllerImage string `json:"controllerImage"`
 
+	// Pull policy applied to all pods started from this controller
+	// +optional
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy"`
+
 	// Name of the secret containing the java keystore (`keystore.jks`) used to enable HTTPS on the
 	// controller. The controller will create a secured https endpoint on port 3371 with the key
 	// stored in `keystore.jks`. The keystore must be secured using the passphrase "linstor". Also
@@ -72,12 +76,12 @@ type LinstorControllerSetSpec struct {
 	// Affinity for scheduling the controller pod
 	// +optional
 	// +nullable
-	Affinity *v1.Affinity `json:"affinity"`
+	Affinity *corev1.Affinity `json:"affinity"`
 
 	// Tolerations for scheduling the controller pod
 	// +optional
 	// +nullable
-	Tolerations []v1.Toleration `json:"tolerations"`
+	Tolerations []corev1.Toleration `json:"tolerations"`
 
 	LinstorClientConfig `json:",inline"`
 }

--- a/pkg/apis/piraeus/v1alpha1/linstorcsidriver_types.go
+++ b/pkg/apis/piraeus/v1alpha1/linstorcsidriver_types.go
@@ -18,7 +18,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -48,6 +48,11 @@ type LinstorCSIDriverSpec struct {
 
 	// Name of a secret with authentication details for the `LinstorPluginImage` registry
 	ImagePullSecret string `json:"imagePullSecret"`
+
+	// Pull policy applied to all pods started from this controller
+	// +optional
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy"`
+
 	// Image that contains the linstor-csi driver plugin
 	LinstorPluginImage string `json:"linstorPluginImage"`
 
@@ -71,22 +76,22 @@ type LinstorCSIDriverSpec struct {
 	// Affinity for scheduling the CSI node pods
 	// +optional
 	// +nullable
-	NodeAffinity *v1.Affinity `json:"nodeAffinity"`
+	NodeAffinity *corev1.Affinity `json:"nodeAffinity"`
 
 	// Tolerations for scheduling CSI node pods
 	// +optional
 	// +nullable
-	NodeTolerations []v1.Toleration `json:"nodeTolerations"`
+	NodeTolerations []corev1.Toleration `json:"nodeTolerations"`
 
 	// Affinity for scheduling the CSI controller pod
 	// +optional
 	// +nullable
-	ControllerAffinity *v1.Affinity `json:"controllerAffinity"`
+	ControllerAffinity *corev1.Affinity `json:"controllerAffinity"`
 
 	// Tolerations for schedluing CSI controller pods
 	// +optional
 	// +nullable
-	ControllerTolerations []v1.Toleration `json:"controllerTolerations"`
+	ControllerTolerations []corev1.Toleration `json:"controllerTolerations"`
 
 	LinstorClientConfig `json:",inline"`
 }

--- a/pkg/apis/piraeus/v1alpha1/linstornodeset_types.go
+++ b/pkg/apis/piraeus/v1alpha1/linstornodeset_types.go
@@ -18,7 +18,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -59,6 +59,10 @@ type LinstorNodeSetSpec struct {
 	// drbdRepoCred is the name of the kubernetes secret that holds the credential for the DRBD repositories
 	DrbdRepoCred string `json:"drbdRepoCred"`
 
+	// Pull policy applied to all pods started from this controller
+	// +optional
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy"`
+
 	// satelliteImage is the image (location + tag) for the LINSTOR satellite container
 	SatelliteImage string `json:"satelliteImage"`
 
@@ -73,12 +77,12 @@ type LinstorNodeSetSpec struct {
 	// Affinity for scheduling the satellite pods
 	// +optional
 	// +nullable
-	Affinity *v1.Affinity `json:"affinity"`
+	Affinity *corev1.Affinity `json:"affinity"`
 
 	// Tolerations for scheduling the satellite pods
 	// +optional
 	// +nullable
-	Tolerations []v1.Toleration `json:"tolerations"`
+	Tolerations []corev1.Toleration `json:"tolerations"`
 
 	LinstorClientConfig `json:",inline"`
 }

--- a/pkg/controller/linstorcontrollerset/linstorcontrollerset_controller.go
+++ b/pkg/controller/linstorcontrollerset/linstorcontrollerset_controller.go
@@ -380,7 +380,7 @@ func (r *ReconcileLinstorControllerSet) reconcileControllers(ctx context.Context
 		log.WithField("#controllerPods", len(ourPods.Items)).Debug("requeue because multiple controller pods are present")
 		return &reconcileutil.TemporaryError{
 			RequeueAfter: time.Minute,
-			Source: fmt.Errorf("multiple controller pods present"),
+			Source:       fmt.Errorf("multiple controller pods present"),
 		}
 	}
 
@@ -406,7 +406,7 @@ func (r *ReconcileLinstorControllerSet) reconcileStatus(ctx context.Context, pcs
 	}
 
 	pcs.Status.ControllerStatus = &piraeusv1alpha1.NodeStatus{
-		NodeName: controllerName,
+		NodeName:               controllerName,
 		RegisteredOnController: false,
 	}
 
@@ -486,7 +486,6 @@ func (r *ReconcileLinstorControllerSet) findActiveControllerPod(ctx context.Cont
 	default:
 		return nil, fmt.Errorf("expected one controller pod, got multiple: %v", candidatePods)
 	}
-
 }
 
 // finalizeControllerSet returns whether it is finished as well as potentially an error
@@ -711,7 +710,7 @@ func newDeploymentForResource(pcs *piraeusv1alpha1.LinstorControllerSet) *appsv1
 							Name:            "linstor-controller",
 							Image:           pcs.Spec.ControllerImage,
 							Args:            []string{"startController"}, // Run linstor-controller.
-							ImagePullPolicy: corev1.PullIfNotPresent,
+							ImagePullPolicy: pcs.Spec.ImagePullPolicy,
 							SecurityContext: &corev1.SecurityContext{Privileged: &kubeSpec.Privileged},
 							Ports: []corev1.ContainerPort{
 								{

--- a/pkg/controller/linstorcsidriver/linstorcsidriver_controller.go
+++ b/pkg/controller/linstorcsidriver/linstorcsidriver_controller.go
@@ -399,9 +399,10 @@ func newCSINodeDaemonSet(csiResource *piraeusv1alpha1.LinstorCSIDriver) *appsv1.
 	env = append(env, linstorClient.APIResourceAsEnvVars(csiResource.Spec.ControllerEndpoint, &csiResource.Spec.LinstorClientConfig)...)
 
 	driverRegistrar := corev1.Container{
-		Name:  "csi-node-driver-registrar",
-		Image: csiResource.Spec.CSINodeDriverRegistrarImage,
-		Args:  []string{"--v=5", "--csi-address=$(CSI_ENDPOINT)", "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"},
+		Name:            "csi-node-driver-registrar",
+		Image:           csiResource.Spec.CSINodeDriverRegistrarImage,
+		ImagePullPolicy: csiResource.Spec.ImagePullPolicy,
+		Args:            []string{"--v=5", "--csi-address=$(CSI_ENDPOINT)", "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"},
 		Lifecycle: &corev1.Lifecycle{
 			PreStop: &corev1.Handler{
 				Exec: &corev1.ExecAction{Command: []string{"/bin/sh", "-c", "rm -rf /registration/linstor.csi.linbit.com /registration/linstor.csi.linbit.com-reg.sock"}},
@@ -428,7 +429,7 @@ func newCSINodeDaemonSet(csiResource *piraeusv1alpha1.LinstorCSIDriver) *appsv1.
 	linstorPluginContainer := corev1.Container{
 		Name:            "csi-node-driver-linstor-plugin",
 		Image:           csiResource.Spec.LinstorPluginImage,
-		ImagePullPolicy: "Always",
+		ImagePullPolicy: csiResource.Spec.ImagePullPolicy,
 		Args:            []string{"--csi-endpoint=unix://$(CSI_ENDPOINT)", "--node=$(KUBE_NODE_NAME)", "--linstor-endpoint=$(LS_CONTROLLERS)", "--log-level=debug"},
 		Env:             env,
 		SecurityContext: &corev1.SecurityContext{
@@ -510,8 +511,9 @@ func newCSIControllerDeployment(csiResource *piraeusv1alpha1.LinstorCSIDriver) *
 	linstorEnvVars := linstorClient.APIResourceAsEnvVars(csiResource.Spec.ControllerEndpoint, &csiResource.Spec.LinstorClientConfig)
 
 	csiProvisioner := corev1.Container{
-		Name:  "csi-provisioner",
-		Image: csiResource.Spec.CSIProvisionerImage,
+		Name:            "csi-provisioner",
+		Image:           csiResource.Spec.CSIProvisionerImage,
+		ImagePullPolicy: csiResource.Spec.ImagePullPolicy,
 		Args: []string{
 			"--provisioner=linstor.csi.linbit.com",
 			"--csi-address=$(ADDRESS)",
@@ -526,8 +528,9 @@ func newCSIControllerDeployment(csiResource *piraeusv1alpha1.LinstorCSIDriver) *
 		}},
 	}
 	csiAttacher := corev1.Container{
-		Name:  "csi-attacher",
-		Image: csiResource.Spec.CSIAttacherImage,
+		Name:            "csi-attacher",
+		Image:           csiResource.Spec.CSIAttacherImage,
+		ImagePullPolicy: csiResource.Spec.ImagePullPolicy,
 		Args: []string{
 			"--v=5",
 			"--csi-address=$(ADDRESS)",
@@ -540,8 +543,9 @@ func newCSIControllerDeployment(csiResource *piraeusv1alpha1.LinstorCSIDriver) *
 		}},
 	}
 	csiSnapshotter := corev1.Container{
-		Name:  "csi-snapshotter",
-		Image: csiResource.Spec.CSISnapshotterImage,
+		Name:            "csi-snapshotter",
+		Image:           csiResource.Spec.CSISnapshotterImage,
+		ImagePullPolicy: csiResource.Spec.ImagePullPolicy,
 		Args: []string{
 			"-timeout=4m",
 			"-csi-address=$(ADDRESS)",
@@ -553,8 +557,9 @@ func newCSIControllerDeployment(csiResource *piraeusv1alpha1.LinstorCSIDriver) *
 		}},
 	}
 	csiResizer := corev1.Container{
-		Name:  "csi-resizer",
-		Image: csiResource.Spec.CSIResizerImage,
+		Name:            "csi-resizer",
+		Image:           csiResource.Spec.CSIResizerImage,
+		ImagePullPolicy: csiResource.Spec.ImagePullPolicy,
 		Args: []string{
 			"--v=5",
 			"--csi-address=$(ADDRESS)",
@@ -567,8 +572,9 @@ func newCSIControllerDeployment(csiResource *piraeusv1alpha1.LinstorCSIDriver) *
 		}},
 	}
 	linstorPlugin := corev1.Container{
-		Name:  "linstor-csi-plugin",
-		Image: csiResource.Spec.LinstorPluginImage,
+		Name:            "linstor-csi-plugin",
+		Image:           csiResource.Spec.LinstorPluginImage,
+		ImagePullPolicy: csiResource.Spec.ImagePullPolicy,
 		Args: []string{
 			"--csi-endpoint=unix://$(ADDRESS)",
 			"--node=$(KUBE_NODE_NAME)",
@@ -582,7 +588,6 @@ func newCSIControllerDeployment(csiResource *piraeusv1alpha1.LinstorCSIDriver) *
 			},
 			linstorEnvVars...,
 		),
-		ImagePullPolicy: "Always",
 		VolumeMounts: []corev1.VolumeMount{{
 			Name:      socketVolume.Name,
 			MountPath: "/var/lib/csi/sockets/pluginproxy/",

--- a/pkg/controller/linstornodeset/linstornodeset_controller.go
+++ b/pkg/controller/linstornodeset/linstornodeset_controller.go
@@ -697,7 +697,7 @@ func newDaemonSetforPNS(pns *piraeusv1alpha1.LinstorNodeSet, config *corev1.Conf
 							Args: []string{
 								"startSatellite",
 							}, // Run linstor-satellite.
-							ImagePullPolicy: corev1.PullIfNotPresent,
+							ImagePullPolicy: pns.Spec.ImagePullPolicy,
 							SecurityContext: &corev1.SecurityContext{Privileged: &kubeSpec.Privileged},
 							Ports: []corev1.ContainerPort{
 								{
@@ -906,7 +906,7 @@ func daemonSetWithDRBDKernelModuleInjection(ds *apps.DaemonSet, pns *piraeusv1al
 		{
 			Name:            "drbd-kernel-module-injector",
 			Image:           pns.Spec.KernelModImage,
-			ImagePullPolicy: corev1.PullIfNotPresent,
+			ImagePullPolicy: pns.Spec.ImagePullPolicy,
 			SecurityContext: &corev1.SecurityContext{Privileged: &kubeSpec.Privileged},
 			Env: []corev1.EnvVar{
 				{


### PR DESCRIPTION
Proposed changes:
```
1. make images customizable: csi-snapshotter-controller, kube-scheduler-amd64
2. make linstor-controller pod TerminationGracePeriodSeconds=0, so that it can be automatically rescheduled after node goes down
3. make imagePullPolicy customizable
4. created a value.cn.yaml for chinese users who cannot stably access quay.io, gcr.io and docker hub.
```

TO-DOs:
```
1. add resource limit for each Pod, as some k8s platform enforce quota so that pods without specified resource limit cannot come up
2. the csi-controller pod should be deployed by statefulset with leader election, instead of a single-pod deployment
3. there should a quick start in the readme which gives less options. 
4. Regarding the failover of linstor-controller pod, even with TerminationGracePeriodSeconds=0, it will take about 5 minutes before kubernetes reschedules the pod, which is too slow for a storage system. I think we should explore use Kubernetes built-in leader-election for its HA.ref: https://tunein.engineering/implementing-leader-election-for-kubernetes-pods-2477deef8f13
```