### PR TITLE
add basic test for "offline" installation

### DIFF
--- a/.github/workflows/offline.yml
+++ b/.github/workflows/offline.yml
@@ -1,0 +1,25 @@
+name: test helm deployment in offline environment
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+  pull_request:
+jobs:
+  test:
+    # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
+    # includes helm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: verify that helm runs offline
+        run: docker run --rm --volume $PWD:/work:ro --volume $(which helm):/usr/local/bin/helm --net=none alpine:latest helm template /work/charts/piraeus
+      - name: verify all pull policies can be set
+        run: |
+          ALL_PULL_POLICIES="$(helm template charts/piraeus | grep -c imagePullPolicy)"
+          CHANGED_PULL_POLICIES="$(helm template charts/piraeus --set global.imagePullPolicy=MyChangedValue | grep -c MyChangedValue)"
+          if [ "${ALL_PULL_POLICIES}" -ne "${CHANGED_PULL_POLICIES}" ] ; then
+            echo "not all pull policies updated!" >&2
+            exit 1
+          fi

--- a/charts/piraeus/charts/csi-snapshotter/values.schema.json
+++ b/charts/piraeus/charts/csi-snapshotter/values.schema.json
@@ -10,8 +10,8 @@
       "type": "integer"
     },
     "resources": {
-      "description": "resource requirements for the snapshotter container",
-      "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.18/api/openapi-spec/swagger.json#/definitions/io.k8s.api.core.v1.ResourceRequirements"
+      "description": "resource requirements for the snapshotter container. See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+      "type": "object"
     }
   },
   "required": [


### PR DESCRIPTION
Add a test-workflow that verifies that the chart is suitable for "offline"
environments, i.e. environments which do not have internet access. The workflow
checks that
* helm can render the templates offline (see issue #63 on why this could fail)
* helm can modify all instances of imagePullPolicy