### PR TITLE
update docs with CRD rename information + UPGRADE doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * `csi.resources` for all CSI related containers. for brevity, there is only one setting for ALL CSI containers. They
     are all stateless go process which use the same amount of resources.
   * `operator.resources` for operator containers
-  * `operator.controllerSet.resources` for LINSTOR controller containers
-  * `operator.nodeSet.resources` for LINSTOR satellite containers
+  * `operator.controller.resources` for LINSTOR controller containers
+  * `operator.satelliteSet.resources` for LINSTOR satellite containers
 * Components deployed by the operator can now run with multiple replicas. Components
   elect a leader, that will take on the actual work as long as it is active. Should one
   pod go down, another replica will take over.
@@ -37,23 +37,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Renamed `LinstorNodeSet` to `LinstorSatelliteSet`. This brings the operator in line with other LINSTOR resources.
-  Existing `LinstorNodeSet` resources will automatically be migrated to `LinstorSatelliteSet`. The old resources will
-  not be deleted. You can verify that migration was successful by running the following command:
-  ```
-  $ kubectl get linstornodesets.piraeus.linbit.com -o=jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.ResourceMigrated}{"\t"}{.status.DependantsMigrated}{"\n"}{end}'
-  piraeus-op-ns true    true
-  ```
-  If both values are `true`, migration was successful. The old resource can be removed after migration.
-
+  Existing `LinstorNodeSet` resources will automatically be migrated to `LinstorSatelliteSet`.
 * Renamed `LinstorControllerSet` to `LinstorController`. The old name implied the existence of multiple (separate)
-  controllers. Existing `LinstorControllerSet` resources will automatically be migrated to `LinstorController`. The old
-  resources will not be deleted. You can verify that migration was successful by running the following command:
-  ```
-  $ kubectl get linstorcontrollersets.piraeus.linbit.com -o=jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.ResourceMigrated}{"\t"}{.status.DependantsMigrated}{"\n"}{end}'
-  piraeus-op-cs true    true
-  ```
-  If both values are `true`, migration was successful. The old resource can be removed after migration.
-
+  controllers. Existing `LinstorControllerSet` resources will automatically be migrated to `LinstorController`.
+* Helm values renamed to align with new CRD names:
+  * `operator.controllerSet` to `operator.controller`
+  * `operator.nodeSet` to `operator.satelliteSet`
 * Node scheduling no longer relies on `linstor.linbit.com/piraeus-node` labels. Instead, all CRDs support
   setting pod [affinity] and [tolerations].
   In detail:
@@ -69,26 +58,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     * `affinity` affinity passed to the linstor controller pod
     * `tolerations` tolerations passed to the linstor controller pod
 
-    Previously, linstor satellite pods required nodes marked with `linstor.linbit.com/piraeus-node=true`. The new
-    default value does not place this restriction on nodes. To restore the old behaviour, set the following affinity:
-    ```yaml
-    affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-          - matchExpressions:
-            - key: linstor.linbit.com/piraeus-node
-              operator: In
-              values:
-              - "true"
-    ```
-
 [affinity]: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 [tolerations]: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-
 * Controller is now a Deployment instead of StatefulSet.
-  This means a controller can be re-scheduled more easily should anything happen to the pod/node.
-  Please make sure any deployed StatefulSet for the controller is removed first.
 
 ## [v0.5.0] - 2020-06-29
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The Helm chart can be configured to use this database instead of deploying an
 etcd cluster by adding the following to the Helm install command:
 
 ```
---set etcd.enabled=false --set "operator.controllerSet.dbConnectionURL=jdbc:postgresql://postgres/postgresdb?user=postgresadmin&password=admin123"
+--set etcd.enabled=false --set "operator.controller.dbConnectionURL=jdbc:postgresql://postgres/postgresdb?user=postgresadmin&password=admin123"
 ```
 
 ### Image mirror for CN users
@@ -206,9 +206,9 @@ kubectl create secret docker-registry drbdiocred --docker-server=<SERVER> --dock
 First you need to create the resource definitions
 
 ```
-kubectl create -f charts/piraeus/crds/operator-controllerset-crd.yaml
-kubectl create -f charts/piraeus/crds/operator-nodeset-crd.yaml
-kubectl create -f charts/piraeus/crds/csinodeinfos.csi.storage.k8s.io.yaml
+kubectl create -f charts/piraeus/crds/piraeus.linbit.com_linstorcsidrivers_crd.yaml
+kubectl create -f charts/piraeus/crds/piraeus.linbit.com_linstorsatellitesets_crd.yaml
+kubectl create -f charts/piraeus/crds/piraeus.linbit.com_linstorcontrollers_crd.yaml
 ```
 
 Inspect the basic deployment example (examples/piraeus-operator-part-1.yaml), it may be deployed by:
@@ -227,24 +227,7 @@ kubectl create -f examples/piraeus-operator-part-2.yaml
 
 ## Upgrading
 
-While the API version remains at `v1alpha1`, this project does not maintain
-stability of or provide conversion of the Custom Resource Definitions.
-
-If you are using the Helm deployment, you may find that upgrades fail with
-errors similar to the following:
-
-```
-UPGRADE FAILED: cannot patch "piraeus-op-cs" with kind LinstorControllerSet: LinstorControllerSet.piraeus.linbit.com "piraeus-op-cs" is invalid: spec.etcdURL: Required value
-```
-
-The simplest solution in this case is to manually replace the CRD:
-
-```
-kubectl replace -f charts/piraeus/crds/operator-controllerset-crd.yaml
-```
-
-Then continue with the Helm upgrade. Values that are lost during the
-replacement will be set again by Helm.
+Please see the dedicated [UPGRADE document](./UPGRADE.md)
 
 ## License
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,85 @@
+The following document describes how to convert
+
+# Upgrade to v1.0
+
+Upgrades from v0.* versions to v1.0 are best-effort only. The following guide assumes
+an upgrade from v0.5.0.
+
+* Renamed `LinstorNodeSet` to `LinstorSatelliteSet`. This brings the operator in line with other LINSTOR resources.
+  Existing `LinstorNodeSet` resources will automatically be migrated to `LinstorSatelliteSet`. The old resources will
+  not be deleted. You can verify that migration was successful by running the following command:
+  ```
+  $ kubectl get linstornodesets.piraeus.linbit.com -o=jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.ResourceMigrated}{"\t"}{.status.DependantsMigrated}{"\n"}{end}'
+  piraeus-op-ns true    true
+  ```
+  If both values are `true`, migration was successful. The old resource can be removed after migration.
+
+* Renamed `LinstorControllerSet` to `LinstorController`. The old name implied the existence of multiple (separate)
+  controllers. Existing `LinstorControllerSet` resources will automatically be migrated to `LinstorController`. The old
+  resources will not be deleted. You can verify that migration was successful by running the following command:
+  ```
+  $ kubectl get linstorcontrollersets.piraeus.linbit.com -o=jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.ResourceMigrated}{"\t"}{.status.DependantsMigrated}{"\n"}{end}'
+  piraeus-op-cs true    true
+  ```
+  If both values are `true`, migration was successful. The old resource can be removed after migration.
+
+* Along with the CRDs, Helm settings changed too:
+  * `operator.controllerSet` to `operator.controller`
+  * `operator.nodeSet` to `operator.satelliteSet`
+  If old settings are used, Helm will return an error.
+
+* Node scheduling no longer relies on `linstor.linbit.com/piraeus-node` labels. Instead, all CRDs support
+  setting pod [affinity] and [tolerations].
+  In detail:
+  * `linstorcsidrivers` gained 4 new resource keys, with no change in default behaviour:
+    * `nodeAffinity` affinity passed to the csi nodes
+    * `nodeTolerations` tolerations passed to the csi nodes
+    * `controllerAffinity` affinity passed to the csi controller
+    * `controllerTolerations` tolerations passed to the csi controller
+  * `linstorcontrollerset` gained 2 new resource keys, with no change in default behaviour:
+    * `affinity` affinity passed to the linstor controller pod
+    * `tolerations` tolerations passed to the linstor controller pod
+  * `linstornodeset` gained 2 new resource keys, **with change in default behaviour**:
+    * `affinity` affinity passed to the linstor controller pod
+    * `tolerations` tolerations passed to the linstor controller pod
+
+    Previously, linstor satellite pods required nodes marked with `linstor.linbit.com/piraeus-node=true`. The new
+    default value does not place this restriction on nodes. To restore the old behaviour, set the following affinity:
+    ```yaml
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: linstor.linbit.com/piraeus-node
+              operator: In
+              values:
+              - "true"
+    ```
+
+[affinity]: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+[tolerations]: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+
+
+# Upgrade between v0.* versions
+
+While the API version remains at `v1alpha1`, this project does not maintain
+stability of or provide conversion of the Custom Resource Definitions.
+
+If you are using the Helm deployment, you may find that upgrades fail with
+errors similar to the following:
+
+```
+UPGRADE FAILED: cannot patch "piraeus-op-cs" with kind LinstorController: LinstorController.piraeus.linbit.com "piraeus-op-cs" is invalid: spec.etcdURL: Required value
+```
+
+The simplest solution in this case is to manually replace the CRD:
+
+```
+kubectl replace -f charts/piraeus/crds/piraeus.linbit.com_linstorcsidrivers_crd.yaml
+kubectl replace -f charts/piraeus/crds/piraeus.linbit.com_linstorsatellitesets_crd.yaml
+kubectl replace -f charts/piraeus/crds/piraeus.linbit.com_linstorcontrollers_crd.yaml
+```
+
+Then continue with the Helm upgrade. Values that are lost during the
+replacement will be set again by Helm.

--- a/charts/piraeus/templates/legacy-check.yaml
+++ b/charts/piraeus/templates/legacy-check.yaml
@@ -1,0 +1,10 @@
+{{/*
+Update check to make sure no legacy settings are used
+*/}}
+{{- if .Values.operator.controllerSet -}}
+  {{ fail "Detected use of legacy key 'operator.controllerSet'. Use 'operator.controller' instead" }}
+{{- end -}}
+
+{{- if .Values.operator.nodeSet -}}
+  {{ fail "Detected use of legacy key 'operator.nodeSet'. Use 'operator.satelliteSet' instead" }}
+{{- end -}}

--- a/charts/piraeus/templates/operator-controller.yaml
+++ b/charts/piraeus/templates/operator-controller.yaml
@@ -4,16 +4,16 @@ metadata:
   name: {{ template "operator.fullname" . }}-cs
 spec:
   priorityClassName: {{ .Values.priorityClassName | default "" | quote }}
-  dbConnectionURL:  {{ .Values.operator.controllerSet.dbConnectionURL | default (print "etcd://" .Release.Name "-etcd:2379") }}
-  luksSecret: {{ .Values.operator.controllerSet.luksSecret }}
-  sslSecret: {{ .Values.operator.controllerSet.sslSecret }}
-  dbCertSecret: {{ .Values.operator.controllerSet.dbCertSecret | default "" }}
-  dbUseClientCert: {{ .Values.operator.controllerSet.dbUseClientCert }}
+  dbConnectionURL:  {{ .Values.operator.controller.dbConnectionURL | default (print "etcd://" .Release.Name "-etcd:2379") }}
+  luksSecret: {{ .Values.operator.controller.luksSecret }}
+  sslSecret: {{ .Values.operator.controller.sslSecret }}
+  dbCertSecret: {{ .Values.operator.controller.dbCertSecret | default "" }}
+  dbUseClientCert: {{ .Values.operator.controller.dbUseClientCert }}
   drbdRepoCred: {{ .Values.drbdRepoCred }}
-  controllerImage: {{ .Values.operator.controllerSet.controllerImage }}
+  controllerImage: {{ .Values.operator.controller.controllerImage }}
   imagePullPolicy: {{ .Values.global.imagePullPolicy | quote }}
   linstorHttpsControllerSecret: {{ .Values.linstorHttpsControllerSecret | quote }}
   linstorHttpsClientSecret: {{ .Values.linstorHttpsClientSecret | quote }}
-  affinity: {{ .Values.operator.controllerSet.affinity | toJson }}
-  tolerations: {{ .Values.operator.controllerSet.tolerations | toJson}}
-  resources: {{ .Values.operator.controllerSet.resources | toJson }}
+  affinity: {{ .Values.operator.controller.affinity | toJson }}
+  tolerations: {{ .Values.operator.controller.tolerations | toJson}}
+  resources: {{ .Values.operator.controller.resources | toJson }}

--- a/charts/piraeus/templates/operator-satelliteset.yaml
+++ b/charts/piraeus/templates/operator-satelliteset.yaml
@@ -4,19 +4,19 @@ metadata:
   name: {{ template "operator.fullname" . }}-ns
 spec:
   priorityClassName: {{ .Values.priorityClassName | default "" | quote }}
-  sslSecret: {{ .Values.operator.nodeSet.sslSecret }}
-  drbdKernelModuleInjectionMode: {{ .Values.operator.nodeSet.drbdKernelModuleInjectionMode }}
+  sslSecret: {{ .Values.operator.satelliteSet.sslSecret }}
+  drbdKernelModuleInjectionMode: {{ .Values.operator.satelliteSet.drbdKernelModuleInjectionMode }}
   drbdRepoCred: {{ .Values.drbdRepoCred }}
   imagePullPolicy: {{ .Values.global.imagePullPolicy | quote }}
-  satelliteImage: {{ .Values.operator.nodeSet.satelliteImage }}
-  kernelModImage: {{ .Values.operator.nodeSet.kernelModImage }}
+  satelliteImage: {{ .Values.operator.satelliteSet.satelliteImage }}
+  kernelModImage: {{ .Values.operator.satelliteSet.kernelModImage }}
   linstorHttpsClientSecret: {{ .Values.linstorHttpsClientSecret | quote }}
   controllerEndpoint: {{ template "controller.endpoint" . }}
-  automaticStorageType: {{ .Values.operator.nodeSet.automaticStorageType | default "None" | quote }}
-  affinity: {{ .Values.operator.nodeSet.affinity | toJson }}
-  tolerations: {{ .Values.operator.nodeSet.tolerations | toJson}}
-  resources: {{ .Values.operator.nodeSet.resources | toJson }}
-  {{- if .Values.operator.nodeSet.storagePools }}
+  automaticStorageType: {{ .Values.operator.satelliteSet.automaticStorageType | default "None" | quote }}
+  affinity: {{ .Values.operator.satelliteSet.affinity | toJson }}
+  tolerations: {{ .Values.operator.satelliteSet.tolerations | toJson}}
+  resources: {{ .Values.operator.satelliteSet.resources | toJson }}
+  {{- if .Values.operator.satelliteSet.storagePools }}
   storagePools:
-{{ toYaml .Values.operator.nodeSet.storagePools | indent 4 }}
+{{ toYaml .Values.operator.satelliteSet.storagePools | indent 4 }}
   {{- end }}

--- a/charts/piraeus/values.cn.yaml
+++ b/charts/piraeus/values.cn.yaml
@@ -44,7 +44,7 @@ operator:
   replicas: 1 # <- number of replicas for the operator deployment
   image: daocloud.io/piraeus/piraeus-operator:latest
   resources: {}
-  controllerSet:
+  controller:
     controllerImage: daocloud.io/piraeus/piraeus-server:v1.7.1
     luksSecret: ""
     dbCertSecret: ""
@@ -53,7 +53,7 @@ operator:
     affinity: {}
     tolerations: []
     resources: {}
-  nodeSet:
+  satelliteSet:
     drbdKernelModuleInjectionMode: Compile
     satelliteImage: daocloud.io/piraeus/piraeus-server:v1.7.1
     kernelModImage: daocloud.io/piraeus/drbd9-bionic:v9.0.24

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -44,7 +44,7 @@ operator:
   replicas: 1 # <- number of replicas for the operator deployment
   image: quay.io/piraeusdatastore/piraeus-operator:latest
   resources: {}
-  controllerSet:
+  controller:
     controllerImage: quay.io/piraeusdatastore/piraeus-server:v1.7.1
     luksSecret: ""
     dbCertSecret: ""
@@ -53,7 +53,7 @@ operator:
     affinity: {}
     tolerations: []
     resources: {}
-  nodeSet:
+  satelliteSet:
     drbdKernelModuleInjectionMode: Compile
     satelliteImage: quay.io/piraeusdatastore/piraeus-server:v1.7.1
     kernelModImage: quay.io/piraeusdatastore/drbd9-bionic:v9.0.24

--- a/doc/security.md
+++ b/doc/security.md
@@ -10,7 +10,7 @@ kubernetes secret. The secret has to contain the key `ca.pem` with the PEM encod
 
 The secret can then be passed to the controller by passing the following argument to `helm install`
 ```
---set operator.controllerSet.dbCertSecret=<secret name>
+--set operator.controller.dbCertSecret=<secret name>
 ```
 
 ### Authentication with `etcd` using certificates
@@ -18,7 +18,7 @@ The secret can then be passed to the controller by passing the following argumen
 If you want to use TLS certificates to authenticate with an `etcd` database, you need to set the following option on
 helm install:
 ```
---set operator.controllerSet.dbUseClientCert=true
+--set operator.controller.dbUseClientCert=true
 ```
 
 If this option is active, the secret specified in the above section must contain two additional keys:
@@ -53,7 +53,7 @@ follow these steps:
   ```
 * Pass the names of the created secrets to `helm install`
   ```
-  --set operator.nodeSet.sslSecret=node-secret --set operator.controllerSet.sslSecret=control-secret
+  --set operator.satelliteSet.sslSecret=node-secret --set operator.controller.sslSecret=control-secret
   ```
 
 :warning: It is currently **NOT** possible to change the keystore password. LINSTOR expects the passwords to be
@@ -132,5 +132,5 @@ kubectl create secret generic linstor-pass --from-literal=MASTER_PASSPHRASE=<pas
 On install, add the following arguments to the helm command:
 
 ```
---set operator.controllerSet.luksSecret=linstor-pass
+--set operator.controller.luksSecret=linstor-pass
 ```

--- a/doc/storage.md
+++ b/doc/storage.md
@@ -13,11 +13,11 @@ are block devices that:
 * do not contain partition information
 * have more than 1 GiB
 
-Any such device will be prepared according to the value of `operator.nodeSet.automaticStorageType`. Devices are
+Any such device will be prepared according to the value of `operator.satelliteSet.automaticStorageType`. Devices are
 added to a storage pool based on the device name (i.e. all `/dev/nvme1` devices will be part of the pool
 `nvme1`)
 
-The possible values for `operator.nodeSet.automaticStorageType`:
+The possible values for `operator.satelliteSet.automaticStorageType`:
 
 * `None` no automatic set up (default)
 * `LVM` create a LVM (thick) storage pool
@@ -51,13 +51,13 @@ There are two ways to configure storage pools
 
 ### At install time
 
-At install time, by setting the value of `operator.nodeSet.storagePools` when running helm install.
+At install time, by setting the value of `operator.satelliteSet.storagePools` when running helm install.
 
 First create a file with the storage configuration like:
 
 ```yaml
 operator:
-  nodeSet:
+  satelliteSet:
     storagePools:
       lvmPools:
       - name: lvm-thick


### PR DESCRIPTION
Update documentation to use the new CRD names. Also
move some detailed instructions into a dedicated UPGRADE.md
document. This should keep the changelog focused on what changed,
while users still have a place to read up on how they are affected.