### PR TITLE
add special resource specification for injector image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * `operator.resources` for operator containers
   * `operator.controller.resources` for LINSTOR controller containers
   * `operator.satelliteSet.resources` for LINSTOR satellite containers
+  * `operator.satelliteSet.kernelModuleInjectionResources` for kernel module injector/builder containers
 * Components deployed by the operator can now run with multiple replicas. Components
   elect a leader, that will take on the actual work as long as it is active. Should one
   pod go down, another replica will take over.

--- a/charts/piraeus/crds/piraeus.linbit.com_linstornodesets_crd.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstornodesets_crd.yaml
@@ -640,6 +640,26 @@ spec:
               description: kernelModImage is the image (location + tag) for the LINSTOR/DRBD
                 kernel module injector container
               type: string
+            kernelModuleInjectionResources:
+              description: Resource requirements for the kernel module builder/injector
+                container
+              nullable: true
+              properties:
+                limits:
+                  additionalProperties:
+                    type: string
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  additionalProperties:
+                    type: string
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+              type: object
             linstorHttpsClientSecret:
               description: 'Name of the secret containing: (a) `ca.pem`: root certificate
                 used to validate HTTPS connections with Linstor (PEM format, without
@@ -653,7 +673,7 @@ spec:
                 the node pods
               type: string
             resources:
-              description: Resource requirements for the LINSTOR satellite pod
+              description: Resource requirements for the LINSTOR satellite container
               nullable: true
               properties:
                 limits:

--- a/charts/piraeus/crds/piraeus.linbit.com_linstorsatellitesets_crd.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstorsatellitesets_crd.yaml
@@ -640,6 +640,26 @@ spec:
               description: kernelModImage is the image (location + tag) for the LINSTOR/DRBD
                 kernel module injector container
               type: string
+            kernelModuleInjectionResources:
+              description: Resource requirements for the kernel module builder/injector
+                container
+              nullable: true
+              properties:
+                limits:
+                  additionalProperties:
+                    type: string
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  additionalProperties:
+                    type: string
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+              type: object
             linstorHttpsClientSecret:
               description: 'Name of the secret containing: (a) `ca.pem`: root certificate
                 used to validate HTTPS connections with Linstor (PEM format, without
@@ -653,7 +673,7 @@ spec:
                 the node pods
               type: string
             resources:
-              description: Resource requirements for the LINSTOR satellite pod
+              description: Resource requirements for the LINSTOR satellite container
               nullable: true
               properties:
                 limits:

--- a/charts/piraeus/templates/operator-satelliteset.yaml
+++ b/charts/piraeus/templates/operator-satelliteset.yaml
@@ -16,6 +16,7 @@ spec:
   affinity: {{ .Values.operator.satelliteSet.affinity | toJson }}
   tolerations: {{ .Values.operator.satelliteSet.tolerations | toJson}}
   resources: {{ .Values.operator.satelliteSet.resources | toJson }}
+  kernelModuleInjectionResources: {{ .Values.operator.satelliteSet.kernelModuleInjectionResources | toJson }}
   {{- if .Values.operator.satelliteSet.storagePools }}
   storagePools:
 {{ toYaml .Values.operator.satelliteSet.storagePools | indent 4 }}

--- a/charts/piraeus/values.cn.yaml
+++ b/charts/piraeus/values.cn.yaml
@@ -63,3 +63,4 @@ operator:
     affinity: {}
     tolerations: []
     resources: {}
+    kernelModuleInjectionResources: {}

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -63,3 +63,4 @@ operator:
     affinity: {}
     tolerations: []
     resources: {}
+    kernelModuleInjectionResources: {}

--- a/examples/resource-requirements.yaml
+++ b/examples/resource-requirements.yaml
@@ -39,3 +39,10 @@ operator:
       requests:
         cpu: "0.1"
         memory: "300Mi"
+    kernelModuleInjectionResources:
+      limits:
+        cpu: "1.0"
+        memory: "1Gi"
+      requests:
+        cpu: "0.5"
+        memory: "750Mi"

--- a/pkg/apis/piraeus/v1alpha1/linstorsatelliteset_types.go
+++ b/pkg/apis/piraeus/v1alpha1/linstorsatelliteset_types.go
@@ -67,10 +67,15 @@ type LinstorSatelliteSetSpec struct {
 	// +optional
 	ControllerEndpoint string `json:"controllerEndpoint"`
 
-	// Resource requirements for the LINSTOR satellite pod
+	// Resource requirements for the LINSTOR satellite container
 	// +optional
 	// +nullable
 	Resources corev1.ResourceRequirements `json:"resources"`
+
+	// Resource requirements for the kernel module builder/injector container
+	// +optional
+	// +nullable
+	KernelModuleInjectionResources corev1.ResourceRequirements `json:"kernelModuleInjectionResources"`
 
 	// Affinity for scheduling the satellite pods
 	// +optional

--- a/pkg/apis/piraeus/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/piraeus/v1alpha1/zz_generated.deepcopy.go
@@ -569,6 +569,7 @@ func (in *LinstorSatelliteSetSpec) DeepCopyInto(out *LinstorSatelliteSetSpec) {
 		**out = **in
 	}
 	in.Resources.DeepCopyInto(&out.Resources)
+	in.KernelModuleInjectionResources.DeepCopyInto(&out.KernelModuleInjectionResources)
 	if in.Affinity != nil {
 		in, out := &in.Affinity, &out.Affinity
 		*out = new(v1.Affinity)

--- a/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
+++ b/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
@@ -896,6 +896,7 @@ func daemonSetWithDRBDKernelModuleInjection(ds *apps.DaemonSet, pns *piraeusv1al
 					MountPath: kubeSpec.ModulesDir,
 				},
 			},
+			Resources: pns.Spec.KernelModuleInjectionResources,
 		},
 	}
 


### PR DESCRIPTION
While working on #53, it became clear that there is no way to set
the resources for the injector init container. This init container
is special however, as the range of required resources varies between
different injection modes.

The best solution is: let the user decide. This commit adds a new
value to the satelliteSet resource "kernelModuleInjectionResources".
This is directly passed to the init container.

The example resource settings are updated to reflect a known-good
resource request for compiling the kernel module from source.

Closes #53 