### PR TITLE
only start legacy controllers if legacy CRDs present

### DIFF
--- a/pkg/apis/piraeus/v1alpha1/linstorcontrollerset_types.go
+++ b/pkg/apis/piraeus/v1alpha1/linstorcontrollerset_types.go
@@ -56,6 +56,7 @@ type LinstorControllerSet struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // LinstorControllerSetList contains a list of LinstorControllerSet
+// DEPRECATED: use LinstorControllerList.
 type LinstorControllerSetList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/apis/piraeus/v1alpha1/linstornodeset_types.go
+++ b/pkg/apis/piraeus/v1alpha1/linstornodeset_types.go
@@ -71,6 +71,7 @@ type LinstorNodeSet struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // LinstorNodeSetList contains a list of LinstorNodeSet
+// DEPRECATED: use LinstorSatelliteSetList.
 type LinstorNodeSetList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Previously, if legacy CRDs are not present the legacy contoller cannot start.
This aborts the whole operator runtime. Instead we want to continue running
without the legacy controllers.

This commit adds a manual check for legacy CRDs to each legacy controller.
The extra check is needed because the controller ".Watch()" function does
no sanity check in this regard. The error is generated by the controller
runtime at a later point.

Fixes #71 