### PR TITLE
Allow user-chosen scheduler image tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * Reference docs for all helm settings. [Link](./doc/helm-values.adoc)
+* `stork.schedulerTag` can override the automatically chosen tag for the `kube-scheduler` image.
+  Previously, the tag always matched the kubernetes release.
 
 ## [v1.0.0-rc1] - 2020-07-28
 

--- a/charts/piraeus/templates/stork-deployment.yaml
+++ b/charts/piraeus/templates/stork-deployment.yaml
@@ -249,7 +249,7 @@ spec:
             - --policy-configmap-namespace={{ .Release.Namespace }}
             - --leader-elect-resource-name={{ .Release.Name }}-stork-scheduler
             - --leader-elect-resource-namespace={{ .Release.Namespace }}
-          image: "{{ .Values.stork.schedulerImage }}:{{ .Capabilities.KubeVersion }}"
+          image: "{{ .Values.stork.schedulerImage }}:{{ .Values.stork.schedulerTag | default .Capabilities.KubeVersion.Version }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy | quote }}
           livenessProbe:
             httpGet:

--- a/charts/piraeus/values.cn.yaml
+++ b/charts/piraeus/values.cn.yaml
@@ -19,6 +19,7 @@ stork:
   enabled: true
   storkImage: daocloud.io/piraeus/stork:latest
   schedulerImage: daocloud.io/piraeus/kube-scheduler-amd64
+  schedulerTag: ""
   replicas: 1
   storkResources: {} # resources requirements for the stork plugin containers
   schedulerResources: {} # resource requirements for the kube-scheduler containers

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -19,6 +19,7 @@ stork:
   enabled: true
   storkImage: docker.io/linbit/stork:latest
   schedulerImage: gcr.io/google_containers/kube-scheduler-amd64
+  schedulerTag: ""
   replicas: 1
   storkResources: {} # resources requirements for the stork plugin containers
   schedulerResources: {} # resource requirements for the kube-scheduler containers


### PR DESCRIPTION
`stork.schedulerTag` can override the automatically chosen tag for
the `kube-scheduler` image. Previously, the tag always matched the
kubernetes release.

The corresponding entry in doc/helm-values.adoc was already added
in previous commit in error.