### PR TITLE
Docs: s/controllerset/controller/  s/nodeset/satelliteset/

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,12 +140,12 @@ to perform some manual steps before deleting a Helm deployment.
 
 2. Delete the LINSTOR controller and satellite resources.
 
-   Deployment of LINSTOR satellite and controller is controlled by the `linstornodeset` and `linstorcontrollerset`
+   Deployment of LINSTOR satellite and controller is controlled by the `linstorsatelliteset` and `linstorcontroller`
    resources. You can delete the resources associated with your deployment using `kubectl`
 
    ```
-   kubectl delete linstorcontrollerset <helm-deploy-name>-cs
-   kubectl delete linstornodeset <helm-deploy-name>-ns
+   kubectl delete linstorsatelliteset <helm-deploy-name>-ns
+   kubectl delete linstorcontroller <helm-deploy-name>-cs
    ```
 
    After a short wait, the controller and satellite pods should terminate. If they continue to run, you can
@@ -160,7 +160,7 @@ to perform some manual steps before deleting a Helm deployment.
    ```
 
    However due to the Helm's current policy, the Custom Resource Definitions named
-   `linstorcontrollerset` and `linstornodeset` will __not__ be deleted by the
+   `linstorcontroller` and `linstorsatelliteset` will __not__ be deleted by the
    command.
 
    More information regarding Helm's current position on CRD's can be found

--- a/charts/piraeus/crds/piraeus.linbit.com_linstornodesets_crd.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstornodesets_crd.yaml
@@ -714,15 +714,15 @@ spec:
               nullable: true
               type: string
             storagePools:
-              description: StoragePools is a list of StoragePools for LinstorNodeSet
+              description: StoragePools is a list of StoragePools for LinstorSatelliteSet
                 to manage.
               nullable: true
               properties:
                 lvmPools:
-                  description: LVMPools for LinstorNodeSet to manage.
+                  description: LVMPools for LinstorSatelliteSet to manage.
                   items:
                     description: StoragePoolLVM represents LVM storage pool to be
-                      managed by a LinstorNodeSet
+                      managed by a LinstorSatelliteSet
                     properties:
                       name:
                         description: Name of the storage pool.
@@ -737,10 +737,10 @@ spec:
                   nullable: true
                   type: array
                 lvmThinPools:
-                  description: LVMThinPools for LinstorNodeSet to manage.
+                  description: LVMThinPools for LinstorSatelliteSet to manage.
                   items:
                     description: StoragePoolLVMThin represents LVM Thin storage pool
-                      to be managed by a LinstorNodeSet
+                      to be managed by a LinstorSatelliteSet
                     properties:
                       name:
                         description: Name of the storage pool.

--- a/charts/piraeus/crds/piraeus.linbit.com_linstorsatellitesets_crd.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstorsatellitesets_crd.yaml
@@ -723,15 +723,15 @@ spec:
                 nullable: true
                 type: string
               storagePools:
-                description: StoragePools is a list of StoragePools for LinstorNodeSet
+                description: StoragePools is a list of StoragePools for LinstorSatelliteSet
                   to manage.
                 nullable: true
                 properties:
                   lvmPools:
-                    description: LVMPools for LinstorNodeSet to manage.
+                    description: LVMPools for LinstorSatelliteSet to manage.
                     items:
                       description: StoragePoolLVM represents LVM storage pool to be
-                        managed by a LinstorNodeSet
+                        managed by a LinstorSatelliteSet
                       properties:
                         name:
                           description: Name of the storage pool.
@@ -746,10 +746,10 @@ spec:
                     nullable: true
                     type: array
                   lvmThinPools:
-                    description: LVMThinPools for LinstorNodeSet to manage.
+                    description: LVMThinPools for LinstorSatelliteSet to manage.
                     items:
                       description: StoragePoolLVMThin represents LVM Thin storage
-                        pool to be managed by a LinstorNodeSet
+                        pool to be managed by a LinstorSatelliteSet
                       properties:
                         name:
                           description: Name of the storage pool.
@@ -1593,15 +1593,15 @@ spec:
                 nullable: true
                 type: string
               storagePools:
-                description: StoragePools is a list of StoragePools for LinstorNodeSet
+                description: StoragePools is a list of StoragePools for LinstorSatelliteSet
                   to manage.
                 nullable: true
                 properties:
                   lvmPools:
-                    description: LVMPools for LinstorNodeSet to manage.
+                    description: LVMPools for LinstorSatelliteSet to manage.
                     items:
                       description: StoragePoolLVM represents LVM storage pool to be
-                        managed by a LinstorNodeSet
+                        managed by a LinstorSatelliteSet
                       properties:
                         name:
                           description: Name of the storage pool.
@@ -1616,10 +1616,10 @@ spec:
                     nullable: true
                     type: array
                   lvmThinPools:
-                    description: LVMThinPools for LinstorNodeSet to manage.
+                    description: LVMThinPools for LinstorSatelliteSet to manage.
                     items:
                       description: StoragePoolLVMThin represents LVM Thin storage
-                        pool to be managed by a LinstorNodeSet
+                        pool to be managed by a LinstorSatelliteSet
                       properties:
                         name:
                           description: Name of the storage pool.

--- a/doc/storage.md
+++ b/doc/storage.md
@@ -27,11 +27,11 @@ The possible values for `operator.satelliteSet.automaticStorageType`:
 ## Configuring storage pool creation
 
 The piraeus operator installed by helm can be used to create storage pools. Creation is under control of the
-LinstorNodeSet resource:
+LinstorSatelliteSet resource:
 
 ```
-$ kubectl get LinstorNodeSet.piraeus.linbit.com piraeus-op-ns -o yaml
-kind: LinstorNodeSet
+$ kubectl get LinstorSatelliteSet.piraeus.linbit.com piraeus-op-ns -o yaml
+kind: LinstorSatelliteSet
 metadata:
 ..
 spec:
@@ -74,10 +74,10 @@ helm install -f <file> charts/piraeus-op
 ### After install
 
 On a cluster with the operator already configured (i.e. after `helm install`),
-you can edit the nodeset configuration like this:
+you can edit the satelliteset configuration like this:
 
 ```
-$ kubectl edit LinstorNodeSet.piraeus.linbit.com <nodesetname>
+$ kubectl edit LinstorSatelliteSet.piraeus.linbit.com <satellitesetname>
 ```
 
 The storage pool configuration can be updated like in the example above.

--- a/examples/resource-requirements.yaml
+++ b/examples/resource-requirements.yaml
@@ -23,7 +23,7 @@ csi:
   resources: *minimal-resources
 operator:
   resources: *minimal-resources
-  controllerSet:
+  controller:
     resources:
       limits:
         cpu: "1.0"
@@ -31,7 +31,7 @@ operator:
       requests:
         cpu: "0.3"
         memory: "500Mi"
-  nodeSet:
+  satelliteSet:
     resources:
       limits:
         cpu: "1.0"

--- a/pkg/apis/piraeus/shared/linstor_types.go
+++ b/pkg/apis/piraeus/shared/linstor_types.go
@@ -68,11 +68,11 @@ func NewStoragePoolStatus(pool *lapi.StoragePool) *StoragePoolStatus {
 
 // StoragePools hold lists of linstor storage pools supported by this operator.
 type StoragePools struct {
-	// LVMPools for LinstorNodeSet to manage.
+	// LVMPools for LinstorSatelliteSet to manage.
 	// +optional
 	// +nullable
 	LVMPools []*StoragePoolLVM `json:"lvmPools"`
-	// LVMThinPools for LinstorNodeSet to manage.
+	// LVMThinPools for LinstorSatelliteSet to manage.
 	// +optional
 	// +nullable
 	LVMThinPools []*StoragePoolLVMThin `json:"lvmThinPools"`
@@ -84,7 +84,7 @@ type StoragePool interface {
 }
 
 // StoragePoolLVM represents LVM storage pool to be managed by a
-// LinstorNodeSet
+// LinstorSatelliteSet
 type StoragePoolLVM struct {
 	// Name of the storage pool.
 	Name string `json:"name"`
@@ -104,7 +104,7 @@ func (s *StoragePoolLVM) ToLinstorStoragePool() lapi.StoragePool {
 }
 
 // StoragePoolLVMThin represents LVM Thin storage pool to be
-// managed by a LinstorNodeSet
+// managed by a LinstorSatelliteSet
 type StoragePoolLVMThin struct {
 	StoragePoolLVM `json:",inline"`
 	// Name of underlying lvm thin volume

--- a/pkg/apis/piraeus/v1/linstorsatelliteset_types.go
+++ b/pkg/apis/piraeus/v1/linstorsatelliteset_types.go
@@ -28,7 +28,7 @@ type LinstorSatelliteSetSpec struct {
 	// priorityClassName is the name of the PriorityClass for the node pods
 	PriorityClassName shared.PriorityClassName `json:"priorityClassName"`
 
-	// StoragePools is a list of StoragePools for LinstorNodeSet to manage.
+	// StoragePools is a list of StoragePools for LinstorSatelliteSet to manage.
 	// +optional
 	// +nullable
 	StoragePools *shared.StoragePools `json:"storagePools"`

--- a/pkg/apis/piraeus/v1alpha1/linstorsatelliteset_types.go
+++ b/pkg/apis/piraeus/v1alpha1/linstorsatelliteset_types.go
@@ -28,7 +28,7 @@ type LinstorSatelliteSetSpec struct {
 	// priorityClassName is the name of the PriorityClass for the node pods
 	PriorityClassName shared.PriorityClassName `json:"priorityClassName"`
 
-	// StoragePools is a list of StoragePools for LinstorNodeSet to manage.
+	// StoragePools is a list of StoragePools for LinstorSatelliteSet to manage.
 	// +optional
 	// +nullable
 	StoragePools *shared.StoragePools `json:"storagePools"`


### PR DESCRIPTION
Some docs and code comments still referenced the old CRD names. This commit
replaces the remaining uses, apart from:
* variable names in code (no user impact)
* old changelog entries
* in the legacy CRDs (obviously)