### PR TITLE
fixup for help output from legacy-check.yaml

### DIFF
--- a/charts/piraeus/templates/legacy-check.yaml
+++ b/charts/piraeus/templates/legacy-check.yaml
@@ -14,5 +14,5 @@ Update check to make sure no legacy settings are used
 {{- end -}}
 
 {{- if .Values.operator.satelliteSet.kernelModImage -}}
-  {{ fail "Detected use of legacy key 'operator.satelliteSet.kernelModImage'. Use 'operator.satelliteSet.kernelModImage' instead" }}
+  {{ fail "Detected use of legacy key 'operator.satelliteSet.kernelModImage'. Use 'operator.satelliteSet.kernelModuleInjectionImage' instead" }}
 {{- end -}}


### PR DESCRIPTION
The new name for `operator.satelliteSet.kernelModImage` is
`operator.satelliteSet.kernelModuleInjectionImage`, but the help output
suggests using the old name.