### PR TITLE
allow overriding images via env variables

### DIFF
--- a/pkg/controller/linstorcontroller/linstorcontroller_controller.go
+++ b/pkg/controller/linstorcontroller/linstorcontroller_controller.go
@@ -128,6 +128,17 @@ func (r *ReconcileLinstorController) Reconcile(request reconcile.Request) (recon
 		controllerResource.Status.SatelliteStatuses = make([]*shared.SatelliteStatus, 0)
 	}
 
+	log.Info("reconcile spec with env")
+
+	specs := []reconcileutil.EnvSpec{
+		{Env: kubeSpec.ImageLinstorControllerEnv, Target: &controllerResource.Spec.ControllerImage},
+	}
+
+	err = reconcileutil.UpdateFromEnv(ctx, r.client, controllerResource, specs...)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	log.Info("reconciling LinstorController")
 
 	getSecret := func(secretName string) (map[string][]byte, error) {

--- a/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
+++ b/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
@@ -128,6 +128,18 @@ func (r *ReconcileLinstorSatelliteSet) Reconcile(request reconcile.Request) (rec
 		return reconcile.Result{}, err
 	}
 
+	log.Debug("reconcile spec with env")
+
+	specs := []reconcileutil.EnvSpec{
+		{Env: kubeSpec.ImageLinstorSatelliteEnv, Target: &pns.Spec.SatelliteImage},
+		{Env: kubeSpec.ImageKernelModuleInjectionEnv, Target: &pns.Spec.KernelModuleInjectionImage},
+	}
+
+	err = reconcileutil.UpdateFromEnv(ctx, r.client, pns, specs...)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	log.Debug("check if all required fields are filled")
 
 	err = r.reconcileResource(ctx, pns)

--- a/pkg/k8s/reconcileutil/update_from_env.go
+++ b/pkg/k8s/reconcileutil/update_from_env.go
@@ -1,0 +1,33 @@
+package reconcileutil
+
+import (
+	"context"
+	"os"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type EnvSpec struct {
+	Env    string
+	Target *string
+}
+
+func UpdateFromEnv(ctx context.Context, client client.Client, obj runtime.Object, specs ...EnvSpec) error {
+	changed := false
+
+	for i := range specs {
+		val, ok := os.LookupEnv(specs[i].Env)
+		if ok {
+			changed = true
+			*specs[i].Target = val
+		}
+	}
+
+	if !changed {
+		return nil
+	}
+
+	return client.Update(ctx, obj)
+}

--- a/pkg/k8s/spec/const.go
+++ b/pkg/k8s/spec/const.go
@@ -68,6 +68,19 @@ const (
 	LinstorSatelliteServiceAccount  = "linstor-satellite"
 )
 
+// ocp: special environment variables for certified operators
+const (
+	ImageLinstorControllerEnv     = "RELATED_IMAGE_LINSTOR_CONTROLLER"
+	ImageLinstorSatelliteEnv      = "RELATED_IMAGE_LINSTOR_SATELLITE"
+	ImageKernelModuleInjectionEnv = "RELATED_IMAGE_KERNEL_MODULE_INJECTION"
+	ImageCSIPluginEnv             = "RELATED_IMAGE_CSI_PLUGIN"
+	ImageCSIAttacherEnv           = "RELATED_IMAGE_CSI_ATTACHER"
+	ImageCSINodeRegistrarEnv      = "RELATED_IMAGE_CSI_NODE_REGISTRAR"
+	ImageCSIProvisionerEnv        = "RELATED_IMAGE_CSI_PROVISIONER"
+	ImageCSISnapshotterEnv        = "RELATED_IMAGE_CSI_SNAPSHOTTER"
+	ImageCSIResizerEnv            = "RELATED_IMAGE_CSI_RESIZER"
+)
+
 // Shared consts common to container volumes. These need to be vars, so they
 // are addressible.
 var (


### PR DESCRIPTION
For certified operators we need to allow overriding the images from environment variables.

See https://redhat-connect.gitbook.io/certified-operator-guide/appendix/offline-enabled-operators#all-operators-helm-ansible-or-golang