### PR TITLE
Enable CSIs topology feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Control volume placement and accessibility by using CSIs Topology feature. Controlled by setting
+  [`csi.enableTopology`](./doc/helm-values.adoc#csienabletopology).
 * All pods use a dedicated service account to allow for fine-grained permission control.
 * The new [helm section `psp.*`](./doc/helm-values.adoc#psp) can automatically configure the ServiceAccount
   of all components to use the appropriate [PSP](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) roles.

--- a/charts/piraeus/crds/piraeus.linbit.com_linstorcsidrivers_crd.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstorcsidrivers_crd.yaml
@@ -683,6 +683,10 @@ spec:
             csiSnapshotterImage:
               description: Name of the CSI external snapshotter image. See https://kubernetes-csi.github.io/docs/external-snapshotter.html
               type: string
+            enableTopology:
+              description: Enable CSI topology feature to control volume accessibility
+                on cluster nodes
+              type: boolean
             imagePullPolicy:
               description: Pull policy applied to all pods started from this controller
               type: string

--- a/charts/piraeus/templates/operator-csi-driver.yaml
+++ b/charts/piraeus/templates/operator-csi-driver.yaml
@@ -23,5 +23,6 @@ spec:
   nodeTolerations: {{ .Values.csi.nodeTolerations | toJson}}
   controllerAffinity: {{ .Values.csi.controllerAffinity | toJson }}
   controllerTolerations: {{ .Values.csi.controllerTolerations | toJson}}
+  enableTopology: {{ .Values.csi.enableTopology }}
   resources: {{ .Values.csi.resources | toJson }}
   {{- end }}

--- a/charts/piraeus/values.cn.yaml
+++ b/charts/piraeus/values.cn.yaml
@@ -36,6 +36,7 @@ csi:
   nodeTolerations: []
   controllerAffinity: {}
   controllerTolerations: []
+  enableTopology: false
   resources: {}
 priorityClassName: ""
 drbdRepoCred: "" # <- Specify the kubernetes secret name here

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -36,6 +36,7 @@ csi:
   nodeTolerations: []
   controllerAffinity: {}
   controllerTolerations: []
+  enableTopology: false
   resources: {}
 priorityClassName: ""
 drbdRepoCred: "" # <- Specify the kubernetes secret name here

--- a/deploy/piraeus/templates/operator-csi-driver.yaml
+++ b/deploy/piraeus/templates/operator-csi-driver.yaml
@@ -24,4 +24,5 @@ spec:
   nodeTolerations: []
   controllerAffinity: {}
   controllerTolerations: []
+  enableTopology: false
   resources: {}

--- a/doc/helm-values.adoc
+++ b/doc/helm-values.adoc
@@ -127,6 +127,14 @@ Valid values::
 * `False`
 Description:: Enable deployment of the LINSTOR CSI driver.
 
+=== `csi.enableTopology`
+Default:: `False`
+Value values::
+* `True`
+* `False`
+Description:: Enable the CSI Topology feature. This feature ensures that pods are always assigned to nodes that can
+access persistent volumes. This is especially important for volumes without a networking layer (DRBD).
+
 === `csi.nodeAffinity`
 Default:: `{}`
 Valid values:: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity[affinity]

--- a/pkg/apis/piraeus/v1/linstorcsidriver_types.go
+++ b/pkg/apis/piraeus/v1/linstorcsidriver_types.go
@@ -105,6 +105,10 @@ type LinstorCSIDriverSpec struct {
 	// +nullable
 	ControllerTolerations []corev1.Toleration `json:"controllerTolerations"`
 
+	// Enable CSI topology feature to control volume accessibility on cluster nodes
+	// +optional
+	EnableTopology bool `json:"enableTopology"`
+
 	shared.LinstorClientConfig `json:",inline"`
 }
 

--- a/pkg/controller/linstorcsidriver/linstorcsidriver_controller.go
+++ b/pkg/controller/linstorcsidriver/linstorcsidriver_controller.go
@@ -19,6 +19,7 @@ package linstorcsidriver
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
@@ -553,7 +554,7 @@ func newCSIControllerDeployment(csiResource *piraeusv1.LinstorCSIDriver) *appsv1
 			"--provisioner=linstor.csi.linbit.com",
 			"--csi-address=$(ADDRESS)",
 			"--v=5",
-			"--feature-gates=Topology=false",
+			fmt.Sprintf("--feature-gates=Topology=%t", csiResource.Spec.EnableTopology),
 			"--connection-timeout=4m",
 			"--enable-leader-election=true",
 			"--leader-election-type=leases",


### PR DESCRIPTION
Using volumes that are not configured with a networking layer requires
the kubescheduler to place pods on nodes that have access to a specific
persistent volume. This can be handled by STORK or using the optional
Topology feature of CSI. As a less invasive alternative to STORK
this feature works without changes to Pod and PVC specs for users.

There are some caveats to this approach:
* Its an extra burden on the API server in clusters with lots of volumes
* Nodes that joined the cluster after a given volume is created are not
  considered for that volume.

The latest linstor-csi master contains a mitigation for both of these issues.

See https://github.com/piraeusdatastore/linstor-csi/pull/83
Fixes #68 