### PR TITLE
centralize security context configuration + SCC support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Disable securityContext enforcement by setting `global.setSecurityContext=false`.
+* Add cluster roles to work with OpenShift's SCC system.
 * Control volume placement and accessibility by using CSIs Topology feature. Controlled by setting
   [`csi.enableTopology`](./doc/helm-values.adoc#csienabletopology).
 * All pods use a dedicated service account to allow for fine-grained permission control.

--- a/charts/piraeus/charts/csi-snapshotter/templates/deployment.yaml
+++ b/charts/piraeus/charts/csi-snapshotter/templates/deployment.yaml
@@ -25,9 +25,7 @@ spec:
       containers:
         - name: snapshot-controller
           securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
-            privileged: false
+{{ include "operator.securitycontext" . | indent 12 }}
           image: {{ .Values.image }}
           args:
             - "--v=5"

--- a/charts/piraeus/charts/etcd/templates/statefulset.yaml
+++ b/charts/piraeus/charts/etcd/templates/statefulset.yaml
@@ -46,9 +46,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.global.imagePullPolicy | quote }}
         securityContext:
-          runAsUser: 1000
-          runAsGroup: 1000
-          privileged: false
+{{ include "operator.securitycontext" . | indent 10 }}
         ports:
         - containerPort: {{ .Values.peerPort }}
           name: peer

--- a/charts/piraeus/templates/_helpers.tpl
+++ b/charts/piraeus/templates/_helpers.tpl
@@ -79,3 +79,13 @@ Environment to pass to stork
       key: ca.pem
 {{- end -}}
 {{- end -}}
+{{/*
+Sets the default security context for all pods
+*/}}
+{{- define "operator.securitycontext" -}}
+{{- if .Values.global.setSecurityContext -}}
+runAsUser: 1000
+runAsGroup: 1000
+privileged: false
+{{- end -}}
+{{- end -}}

--- a/charts/piraeus/templates/csi-node-rbac.yml
+++ b/charts/piraeus/templates/csi-node-rbac.yml
@@ -9,3 +9,33 @@ kind: ServiceAccount
 metadata:
   name: csi-node
   namespace: {{ .Release.Namespace }}
+---
+# Cluster permissions for openshift installations
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csi-node
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  resourceNames:
+  - privileged
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-node
+subjects:
+  - kind: ServiceAccount
+    name: csi-node
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: csi-node

--- a/charts/piraeus/templates/operator-deployment.yaml
+++ b/charts/piraeus/templates/operator-deployment.yaml
@@ -20,9 +20,7 @@ spec:
           image: {{ .Values.operator.image }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy | quote }}
           securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
-            privileged: false
+{{ include "operator.securitycontext" . | indent 12 }}
           env:
             - name: WATCH_NAMESPACE
               valueFrom:

--- a/charts/piraeus/templates/satellite-rbac.yml
+++ b/charts/piraeus/templates/satellite-rbac.yml
@@ -6,3 +6,33 @@ kind: ServiceAccount
 metadata:
   name: linstor-satellite
   namespace: {{ .Release.Namespace }}
+---
+  # Cluster permissions for openshift installations
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: linstor-satellite
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - privileged
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linstor-satellite
+subjects:
+  - kind: ServiceAccount
+    name: linstor-satellite
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: linstor-satellite

--- a/charts/piraeus/templates/stork-deployment.yaml
+++ b/charts/piraeus/templates/stork-deployment.yaml
@@ -123,9 +123,7 @@ spec:
           resources:
 {{ .Values.stork.storkResources | toYaml | indent 12}}
           securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
-            privileged: false
+{{ include "operator.securitycontext" . | indent 12 }}
           name: stork
           env:
 {{ include "stork.config" . | indent 12 }}
@@ -259,9 +257,7 @@ spec:
             initialDelaySeconds: 15
           name: {{ .Release.Name }}-stork-scheduler
           securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
-            privileged: false
+{{ include "operator.securitycontext" . | indent 12 }}
           readinessProbe:
             httpGet:
               path: /healthz

--- a/charts/piraeus/values.cn.yaml
+++ b/charts/piraeus/values.cn.yaml
@@ -1,5 +1,6 @@
 global:
   imagePullPolicy: IfNotPresent # empty pull policy means k8s default is used ("always" if tag == ":latest", "ifnotpresent" else)
+  setSecurityContext: true # Force non-privileged containers to run as non-root users
 # Dependency charts
 etcd:
   persistentVolume:

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -1,5 +1,6 @@
 global:
   imagePullPolicy: IfNotPresent # empty pull policy means k8s default is used ("always" if tag == ":latest", "ifnotpresent" else)
+  setSecurityContext: true # Force non-privileged containers to run as non-root users
 # Dependency charts
 etcd:
   persistentVolume:

--- a/deploy/piraeus/templates/csi-node-rbac.yml
+++ b/deploy/piraeus/templates/csi-node-rbac.yml
@@ -7,8 +7,41 @@ metadata:
   namespace: default
 ---
 # Source: piraeus/templates/csi-node-rbac.yml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csi-node
+  namespace: default
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  resourceNames:
+  - privileged
+  verbs:
+  - use
+---
+# Source: piraeus/templates/csi-node-rbac.yml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-node
+subjects:
+  - kind: ServiceAccount
+    name: csi-node
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: csi-node
+---
+# Source: piraeus/templates/csi-node-rbac.yml
 # This YAML file contains all RBAC objects that are necessary to run a
 # CSI controller pod
 #
 # This file was created by looking at the documentation for:
 # node-driver-registrar v1.3.0: https://github.com/kubernetes-csi/node-driver-registrar/tree/v1.3.0#required-permissions
+---
+# Source: piraeus/templates/csi-node-rbac.yml
+# Cluster permissions for openshift installations

--- a/deploy/piraeus/templates/satellite-rbac.yml
+++ b/deploy/piraeus/templates/satellite-rbac.yml
@@ -7,5 +7,38 @@ metadata:
   namespace: default
 ---
 # Source: piraeus/templates/satellite-rbac.yml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: linstor-satellite
+  namespace: default
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - privileged
+    verbs:
+      - use
+---
+# Source: piraeus/templates/satellite-rbac.yml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linstor-satellite
+subjects:
+  - kind: ServiceAccount
+    name: linstor-satellite
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: linstor-satellite
+---
+# Source: piraeus/templates/satellite-rbac.yml
 # This YAML file contains all RBAC objects that are necessary to run a
 # LINSTOR satellite pod
+---
+# Source: piraeus/templates/satellite-rbac.yml
+# Cluster permissions for openshift installations

--- a/doc/helm-values.adoc
+++ b/doc/helm-values.adoc
@@ -17,6 +17,13 @@ Valid values::
 * `Never`
 Description:: Global pull policy to apply to all images. Can be set to `""` to use kubernetes default behaviour. See https://kubernetes.io/docs/concepts/containers/images/#updating-images[pull policy].
 
+=== `global.setSecurityContext`
+Default:: `True`
+Valid values::
+* `True`
+* `False`
+Description:: If true, all non-privileged containers start with a fixed UID of 1000 and GID of 1000.
+
 === `linstorHttpsClientSecret`
 Default:: `""`
 Valid values:: secret name


### PR DESCRIPTION
Some clusters (for example openshift installations) do not allow
a fixed UID for a particular pod by default. Instead, the UID is automatically
assigned by kubernetes. In these cases it is required to leave the
securityContext on the pod empty.

This commit adds a new helm value "global.setSecurityContext" which
can control the creation of the securityContext blocks. Also adds new
ClusterRoles to all service-accounts running privileged containers.
This allows them start privileged containers on openshift instances.