### PR TITLE
Allow controller SA to update restricted endpoints

### DIFF
--- a/charts/piraeus/templates/controller-rbac.yml
+++ b/charts/piraeus/templates/controller-rbac.yml
@@ -13,12 +13,26 @@ metadata:
   name: linstor-leader-elector
   namespace: {{ .Release.Namespace }}
 rules:
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "watch", "list", "delete", "update", "create"]
-  - apiGroups: [""]
-    resources: ["endpoints"]
-    verbs: ["create", "patch", "update"]
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - watch
+      - list
+      - delete
+      - update
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - endpoints/restricted
+    verbs:
+      - create
+      - patch
+      - update
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/piraeus/templates/controller-rbac.yml
+++ b/deploy/piraeus/templates/controller-rbac.yml
@@ -13,12 +13,26 @@ metadata:
   name: linstor-leader-elector
   namespace: default
 rules:
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "watch", "list", "delete", "update", "create"]
-  - apiGroups: [""]
-    resources: ["endpoints"]
-    verbs: ["create", "patch", "update"]
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - watch
+      - list
+      - delete
+      - update
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - endpoints/restricted
+    verbs:
+      - create
+      - patch
+      - update
 ---
 # Source: piraeus/templates/controller-rbac.yml
 kind: RoleBinding


### PR DESCRIPTION
Openshift verifies that manually created endpoints do not overlap with
the Pod IP range by default. However, this is exactly what we want to do
in our k8s-await-election helper: manually controller the service endpoint.

Openshift does allow updating the endpoint if the user/SA can access the
endpoints/restricted endpoint.