### PR TITLE
pv-hostpath: ensure permissions are applied on all nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+* Fixed a bug in `pv-hostpath` where permissions on the created directory are not applied on all nodes.
+
 ## [v1.1.0] - 2020-10-13
 
 ### Breaking

--- a/charts/pv-hostpath/Chart.yaml
+++ b/charts/pv-hostpath/Chart.yaml
@@ -1,4 +1,4 @@
 name: pv-hostpath
 description: Hostpath volumes for etcd persistence
-version: 0.2.1
-appVersion: 0.2.1
+version: 0.2.2
+appVersion: 0.2.2

--- a/charts/pv-hostpath/templates/pv.yaml
+++ b/charts/pv-hostpath/templates/pv.yaml
@@ -58,5 +58,14 @@ spec:
           hostPath:
             type: DirectoryOrCreate
             path: {{ required "A valid .Values.path entry required!" $.Values.path }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: In
+                values:
+                - {{ . }}
 ---
 {{ end }}


### PR DESCRIPTION
This commit adds an affinity spec to jobs used to set the permissions
on created hostpath volumes. Without this, some nodes may not get their
permissions set for the created volume.