### PR TITLE
Helm: make creation of controller and satellite set optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `storagePools` can now also set up devices similar to `automaticStorageType`, but with more fine grained control.
   See the [updated storage guide](./doc/storage.md#preparing-physical-devices)
+* New Helm options to disable creation of LinstorController and LinstorSatelliteSet resource
+  `operator.controller.enabled` and `operator.satelliteSet.enabled`.
+* New Helm option to override the generated controller endpoint: `controllerEndpoint`
 
 ### Changed
 

--- a/charts/piraeus/templates/_helpers.tpl
+++ b/charts/piraeus/templates/_helpers.tpl
@@ -48,10 +48,14 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Endpoint URL of LINSTOR controller
 */}}
 {{- define "controller.endpoint" -}}
-  {{- if empty .Values.linstorHttpsClientSecret -}}
-    http://{{ template "operator.fullname" . }}-cs.{{ .Release.Namespace }}.svc:3370
+  {{- if .Values.controllerEndpoint -}}
+    {{ .Values.controllerEndpoint }}
   {{- else -}}
-    https://{{ template "operator.fullname" . }}-cs.{{ .Release.Namespace }}.svc:3371
+    {{- if empty .Values.linstorHttpsClientSecret -}}
+      http://{{ template "operator.fullname" . }}-cs.{{ .Release.Namespace }}.svc:3370
+    {{- else -}}
+      https://{{ template "operator.fullname" . }}-cs.{{ .Release.Namespace }}.svc:3371
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/piraeus/templates/operator-controller.yaml
+++ b/charts/piraeus/templates/operator-controller.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.operator.controller.enabled }}
 apiVersion: piraeus.linbit.com/v1
 kind: LinstorController
 metadata:
@@ -18,3 +19,4 @@ spec:
   tolerations: {{ .Values.operator.controller.tolerations | toJson}}
   resources: {{ .Values.operator.controller.resources | toJson }}
   replicas: {{ .Values.operator.controller.replicas }}
+{{- end }}

--- a/charts/piraeus/templates/operator-csi-driver.yaml
+++ b/charts/piraeus/templates/operator-csi-driver.yaml
@@ -25,4 +25,4 @@ spec:
   controllerTolerations: {{ .Values.csi.controllerTolerations | toJson}}
   enableTopology: {{ .Values.csi.enableTopology }}
   resources: {{ .Values.csi.resources | toJson }}
-  {{- end }}
+{{- end }}

--- a/charts/piraeus/templates/operator-satelliteset.yaml
+++ b/charts/piraeus/templates/operator-satelliteset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.operator.satelliteSet.enabled }}
 apiVersion: piraeus.linbit.com/v1
 kind: LinstorSatelliteSet
 metadata:
@@ -21,3 +22,4 @@ spec:
   storagePools:
 {{ toYaml .Values.operator.satelliteSet.storagePools | indent 4 }}
   {{- end }}
+{{- end }}

--- a/charts/piraeus/values.cn.yaml
+++ b/charts/piraeus/values.cn.yaml
@@ -43,6 +43,7 @@ priorityClassName: ""
 drbdRepoCred: "" # <- Specify the kubernetes secret name here
 linstorHttpsControllerSecret: "" # <- name of secret containing linstor server certificates+key. See docs/security.md
 linstorHttpsClientSecret: "" # <- name of secret containing linstor client certificates+key. See docs/security.md
+controllerEndpoint: "" # <- override to the generated controller endpoint. use if controller is not deployed via operator
 psp:
   privilegedRole: ""
   unprivilegedRole: ""
@@ -51,6 +52,7 @@ operator:
   image: daocloud.io/piraeus/piraeus-operator:latest
   resources: {}
   controller:
+    enabled: true
     controllerImage: daocloud.io/piraeus/piraeus-server:v1.9.0
     luksSecret: ""
     dbCertSecret: ""
@@ -61,6 +63,7 @@ operator:
     resources: {}
     replicas: 1
   satelliteSet:
+    enabled: true
     satelliteImage: daocloud.io/piraeus/piraeus-server:v1.9.0
     storagePools: null
     sslSecret: ""

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -43,6 +43,7 @@ priorityClassName: ""
 drbdRepoCred: "" # <- Specify the kubernetes secret name here
 linstorHttpsControllerSecret: "" # <- name of secret containing linstor server certificates+key. See docs/security.md
 linstorHttpsClientSecret: "" # <- name of secret containing linstor client certificates+key. See docs/security.md
+controllerEndpoint: "" # <- override to the generated controller endpoint. use if controller is not deployed via operator
 psp:
   privilegedRole: ""
   unprivilegedRole: ""
@@ -51,6 +52,7 @@ operator:
   image: quay.io/piraeusdatastore/piraeus-operator:latest
   resources: {}
   controller:
+    enabled: true
     controllerImage: quay.io/piraeusdatastore/piraeus-server:v1.9.0
     luksSecret: ""
     dbCertSecret: ""
@@ -61,6 +63,7 @@ operator:
     resources: {}
     replicas: 1
   satelliteSet:
+    enabled: true
     satelliteImage: quay.io/piraeusdatastore/piraeus-server:v1.9.0
     storagePools: null
     sslSecret: ""

--- a/doc/helm-values.adoc
+++ b/doc/helm-values.adoc
@@ -39,6 +39,10 @@ Default:: `""`
 Valid values:: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass[priority class] name
 Description:: Name of the priority class with which the LINSTOR components should be scheduled.
 
+=== `controllerEndpoint`
+Default:: `""`
+Valid values:: HTTP/S URL
+Description:: Override the generated URL for the LINSTOR controller deployment. Useful if the controller is not deployed via the operator.
 
 == Operator
 
@@ -202,6 +206,13 @@ Description:: Resource requests and limits to apply to the etcd containers. See 
 
 == Piraeus Controller
 
+=== `operator.controller.enabled`
+Default:: `True`
+Valid values::
+* `True`
+* `False`
+Description:: If set to false, no LinstorController resource will be created by Helm. This means no LINSTOR controller will be deployed.
+
 === `operator.controller.affinity`
 Default:: `{}`
 Valid values:: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity[affinity]
@@ -253,6 +264,13 @@ Description:: Tolerations to pass to the controller pods.
 
 
 == Piraeus Satellites
+
+=== `operator.satelliteSet.enabled`
+Default:: `True`
+Valid values::
+* `True`
+* `False`
+Description:: If set to false, no LinstorSatelliteSet resource will be created by Helm. This means no LINSTOR satellites will be deployed.
 
 === `operator.satelliteSet.affinity`
 Default:: `{}`


### PR DESCRIPTION
In some cases you want to manually deploy the controller and/or satellites, or
manually add the resources at a later time. This commit adds the option to skip
creation of LinstorController and LinstorSatelliteSet resources (was already
possible for LinstorCSIDriver).

Also adds the option to set the LINSTOR controller URL to any desired value.