### PR TITLE
set default pod affinity for HA deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Fixed a bug in `pv-hostpath` where permissions on the created directory are not applied on all nodes.
+* Default value for affinity on LINSTOR controller and CSI controller changed. The new default is to distribute the pods
+  across all available nodes.
 
 ### Deprecation
 

--- a/charts/piraeus/values.cn.yaml
+++ b/charts/piraeus/values.cn.yaml
@@ -35,7 +35,7 @@ csi:
   controllerReplicas: 1
   nodeAffinity: {}
   nodeTolerations: []
-  controllerAffinity: {}
+  controllerAffinity: null
   controllerTolerations: []
   enableTopology: false
   resources: {}
@@ -58,7 +58,7 @@ operator:
     dbCertSecret: ""
     dbUseClientCert: false
     sslSecret: ""
-    affinity: {}
+    affinity: null
     tolerations: []
     resources: {}
     replicas: 1

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -35,7 +35,7 @@ csi:
   controllerReplicas: 1
   nodeAffinity: {}
   nodeTolerations: []
-  controllerAffinity: {}
+  controllerAffinity: null
   controllerTolerations: []
   enableTopology: false
   resources: {}
@@ -58,7 +58,7 @@ operator:
     dbCertSecret: ""
     dbUseClientCert: false
     sslSecret: ""
-    affinity: {}
+    affinity: null
     tolerations: []
     resources: {}
     replicas: 1

--- a/deploy/piraeus/templates/operator-controller.yaml
+++ b/deploy/piraeus/templates/operator-controller.yaml
@@ -16,7 +16,7 @@ spec:
   imagePullPolicy: "IfNotPresent"
   linstorHttpsControllerSecret: ""
   linstorHttpsClientSecret: ""
-  affinity: {}
+  affinity: null
   tolerations: []
   resources: {}
   replicas: 1

--- a/deploy/piraeus/templates/operator-csi-driver.yaml
+++ b/deploy/piraeus/templates/operator-csi-driver.yaml
@@ -22,7 +22,7 @@ spec:
   controllerEndpoint: http://piraeus-op-cs.default.svc:3370
   nodeAffinity: {}
   nodeTolerations: []
-  controllerAffinity: {}
+  controllerAffinity: null
   controllerTolerations: []
   enableTopology: false
   resources: {}

--- a/doc/helm-values.adoc
+++ b/doc/helm-values.adoc
@@ -92,9 +92,22 @@ Description:: Resource requests and limits to apply to the CSI snapshot controll
 == CSI Driver
 
 === `csi.controllerAffinity`
-Default:: `{}`
+Default:: `null`
 Valid values:: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity[affinity]
-Description:: Affinity settings for controller pods. Can be used to pin controller pods to specific nodes.
+Description:: Affinity settings for controller pods. Can be used to pin controller pods to specific nodes. The default will expand to:
++
+[source,yaml]
+----
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchLabels:
+          app: piraeus
+          role: csi-controller
+      topologyKey: kubernetes.io/hostname
+----
+
 
 === `csi.controllerReplicas`
 Default:: `1`
@@ -214,9 +227,21 @@ Valid values::
 Description:: If set to false, no LinstorController resource will be created by Helm. This means no LINSTOR controller will be deployed.
 
 === `operator.controller.affinity`
-Default:: `{}`
+Default:: `null`
 Valid values:: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity[affinity]
-Description:: Affinity settings for controller pods. Can be used to restrict the pods to specific nodes.
+Description:: Affinity settings for controller pods. Can be used to restrict the pods to specific nodes. The default will expand to:
++
+[source,yaml]
+----
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchLabels:
+          app: piraeus-op
+          role: piraeus-controller
+      topologyKey: kubernetes.io/hostname
+----
 
 === `operator.controller.controllerImage`
 Default:: `quay.io/piraeusdatastore/piraeus-server:v1.9.0`

--- a/pkg/k8s/spec/const.go
+++ b/pkg/k8s/spec/const.go
@@ -64,6 +64,7 @@ const (
 const (
 	SystemNamespace                 = "kube-system"
 	SystemCriticalPriorityClassName = "system-node-critical"
+	DefaultTopologyKey              = "kubernetes.io/hostname"
 	LinstorControllerServiceAccount = "linstor-controller"
 	LinstorSatelliteServiceAccount  = "linstor-satellite"
 )

--- a/pkg/k8s/spec/piraeus.go
+++ b/pkg/k8s/spec/piraeus.go
@@ -29,6 +29,12 @@ const (
 	// NodeRole is the role for the node set
 	NodeRole = "piraeus-node"
 
+	// CSIControllerRole is the role for the CSI Controller Workloads
+	CSIControllerRole = "csi-controller"
+
+	// CSINodeRole is the role for the CSI Node Workloads
+	CSINodeRole = "csi-node"
+
 	// Name is the name of the operator
 	Name = "piraeus-operator"
 


### PR DESCRIPTION
Set a default anti-affinity for LINSTOR Controller and CSI Controller pods.
Since the main reason to scale these components is to provide HA functionality,
the default value should ensure the spread of pods across as many nodes as
possible.

This closes #108 