### PR TITLE
improve etcd deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * New Helm options to disable creation of LinstorController and LinstorSatelliteSet resource
   `operator.controller.enabled` and `operator.satelliteSet.enabled`.
 * New Helm option to override the generated controller endpoint: `controllerEndpoint`
+* Allow overriding the default `securityContext` on a component basis:
+  - `etcd.podsecuritycontext` sets the securityContext of etcd pods
+  - `stork.podsecuritycontext` sets the securityContext of stork plugin and scheduler pods
+  - `csi-snapshotter.podsecuritycontext` sets the securityContext of the CSI-Snapshotter pods
+  - `operator.podsecuritycontext` sets the securityContext of the operator pods
+* Example settings for openshift
 
 ### Changed
 
 * Fixed a bug in `pv-hostpath` where permissions on the created directory are not applied on all nodes.
+* Volumes created by `pv-hostpath` are now group writable. This makes them easier to integrate with `fsGroup` settings.
 * Default value for affinity on LINSTOR controller and CSI controller changed. The new default is to distribute the pods
   across all available nodes.
+* Default value for tolerations for etcd pods changed. They are now able to run on master nodes.
 
 ### Deprecation
 

--- a/Makefile
+++ b/Makefile
@@ -94,4 +94,4 @@ release:
 deploy/piraeus:
 	rm -rf "$@"
 	mkdir -p "$@"
-	helm template piraeus-op charts/piraeus --set stork.schedulerTag=v1.16.0 --output-dir deploy >/dev/null
+	helm template -n default piraeus-op charts/piraeus --set stork.schedulerTag=v1.16.0 --output-dir deploy >/dev/null

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ The operator can be deployed with Helm v3 chart in /charts as follows:
     helm install piraeus-op ./charts/piraeus
     ```
 
+  You can pick from a number of example settings:
+
+  * default values [`values.yaml`](./charts/piraeus/values.yaml)
+  * images optimized for CN [`values.cn.yaml`](./charts/piraeus/values.cn.yaml).
+  * override for Openshift [`values-openshift.yaml`](./charts/piraeus/values-openshift.yaml)
+
   A full list of all available options to pass to helm can be found [here](./doc/helm-values.adoc).
 
 ### LINSTOR etcd `hostPath` persistence
@@ -85,6 +91,11 @@ helm install linstor-etcd ./charts/pv-hostpath --set "nodes={<NODE0>,<NODE1>,<NO
 
 Persistence for etcd is enabled by default.
 
+#### `hostPath` volumes and SELinux
+
+Clusters with SELinux enabled hosts (for example: OpenShift clusters) need to relabel the created directory. This
+can be done automatically by passing `--set selinux=true` to the above `helm install` command.
+
 ### Using an existing database
 
 LINSTOR can connect to an existing PostgreSQL, MariaDB or etcd database. For
@@ -102,11 +113,6 @@ etcd cluster by adding the following to the Helm install command:
 ```
 --set etcd.enabled=false --set "operator.controller.dbConnectionURL=jdbc:postgresql://postgres/postgresdb?user=postgresadmin&password=admin123"
 ```
-
-### Image mirror for CN users
-
-The chart contains a values file prepared for chinese users [`values.cn.yaml`](./charts/piraeus/values.cn.yaml).
-It replaces the default image locations with images hosted on daocloud.io.
 
 ### Pod resources
 
@@ -133,6 +139,10 @@ The following components can be started with multiple replicas:
 [`csi-snapshotter.replicas`]: ./doc/helm-values.adoc#csi-snapshotterreplicas
 [`etcd.replicas`]: ./doc/helm-values.adoc#etcdreplicas
 [`stork.replicas`]: ./doc/helm-values.adoc#storkreplicas
+
+### Influence pod scheduling
+
+You can influence the assignement of various components to specific nodes. See the [scheduling guide.](./doc/scheduling.md)
 
 ### Terminating Helm deployment
 

--- a/charts/piraeus/charts/csi-snapshotter/templates/deployment.yaml
+++ b/charts/piraeus/charts/csi-snapshotter/templates/deployment.yaml
@@ -23,7 +23,11 @@ spec:
     spec:
       serviceAccountName: snapshot-controller
       securityContext:
-{{ include "operator.podsecuritycontext" . | indent 8 }}
+{{- if .Values.podsecuritycontext }}
+{{ .Values.podsecuritycontext | toYaml | indent 8 }}
+{{- else }}
+{{ include "operator.defaultpodsecuritycontext" $ | indent 8 }}
+{{- end }}
       containers:
         - name: snapshot-controller
           image: {{ .Values.image }}
@@ -33,3 +37,6 @@ spec:
           imagePullPolicy: {{ .Values.global.imagePullPolicy | quote }}
           resources:
 {{ .Values.resources | toYaml | indent 12 }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      tolerations: {{ toJson .Values.tolerations }}

--- a/charts/piraeus/charts/csi-snapshotter/values.yaml
+++ b/charts/piraeus/charts/csi-snapshotter/values.yaml
@@ -1,3 +1,12 @@
 image: quay.io/k8scsi/snapshot-controller:v2.0.1
 replicas: 1
 resources: {}
+podsecuritycontext: {}
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app: snapshot-controller
+        topologyKey: "kubernetes.io/hostname"
+tolerations: []

--- a/charts/piraeus/charts/etcd/templates/statefulset.yaml
+++ b/charts/piraeus/charts/etcd/templates/statefulset.yaml
@@ -32,6 +32,15 @@ spec:
 {{- if .Values.affinity }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
+{{ else }}
+      affinity:
+        # Ensures only one pod is scheduled per node
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: {{ template "etcd.name" . }}
+              topologyKey: "kubernetes.io/hostname"
 {{- end }}
 {{- if .Values.nodeSelector }}
       nodeSelector:
@@ -42,7 +51,11 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- end }}
       securityContext:
-{{ include "operator.podsecuritycontext" . | indent 8 }}
+{{- if .Values.podsecuritycontext }}
+{{ toYaml .Values.podsecuritycontext | indent 8 }}
+{{- else }}
+{{ include "operator.defaultpodsecuritycontext" $ | indent 8 }}
+{{- end }}
       containers:
       - name: {{ template "etcd.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/piraeus/charts/etcd/values.yaml
+++ b/charts/piraeus/charts/etcd/values.yaml
@@ -62,16 +62,10 @@ memoryMode: false
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
 nodeSelector: {}
-tolerations: []
-affinity:
-  # Ensures only one pod is scheduled per node
-  podAntiAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchExpressions:
-            - key: app
-              operator: In
-              values:
-                - etcd
-        topologyKey: "kubernetes.io/hostname"
+tolerations:
+  - key: node-role.kubernetes.io/master
+    operator: "Exists"
+    effect: "NoSchedule"
+affinity: {}
+podsecuritycontext: {}
 extraEnv: []

--- a/charts/piraeus/templates/_helpers.tpl
+++ b/charts/piraeus/templates/_helpers.tpl
@@ -86,7 +86,7 @@ Environment to pass to stork
 {{/*
 Sets the default security context for all pods
 */}}
-{{- define "operator.podsecuritycontext" -}}
+{{- define "operator.defaultpodsecuritycontext" -}}
 {{- if .Values.global.setSecurityContext -}}
 runAsUser: 1000
 runAsGroup: 1000

--- a/charts/piraeus/templates/operator-deployment.yaml
+++ b/charts/piraeus/templates/operator-deployment.yaml
@@ -16,7 +16,11 @@ spec:
     spec:
       serviceAccountName: {{ template "operator.fullname" . }}
       securityContext:
-{{ include "operator.podsecuritycontext" . | indent 8 }}
+{{- if .Values.operator.podsecuritycontext }}
+{{ toYaml .Values.operator.podsecuritycontext | indent 8 }}
+{{- else }}
+{{ include "operator.defaultpodsecuritycontext" $ | indent 8 }}
+{{- end }}
       containers:
         - name: piraeus-operator
           image: {{ .Values.operator.image }}
@@ -37,4 +41,17 @@ spec:
 {{- if .Values.drbdRepoCred }}
       imagePullSecrets:
         - name: {{ .Values.drbdRepoCred | quote }}
+{{- end }}
+      tolerations: {{ toJson .Values.operator.tolerations }}
+{{- if .Values.operator.affinity }}
+      affinity:
+{{ toYaml .Values.operator.affinity | indent 8 }}
+{{- else}}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  name: {{ template "operator.fullname" . }}-operator
 {{- end }}

--- a/charts/piraeus/templates/stork-deployment.yaml
+++ b/charts/piraeus/templates/stork-deployment.yaml
@@ -137,7 +137,11 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       serviceAccountName: stork-account
       securityContext:
-{{ include "operator.podsecuritycontext" . | indent 8 }}
+{{- if .Values.stork.podsecuritycontext }}
+{{ .Values.stork.podsecuritycontext | toYaml | indent 8 }}
+{{- else }}
+{{ include "operator.defaultpodsecuritycontext" $ | indent 8 }}
+{{- end }}
 # Source: https://raw.githubusercontent.com/libopenstorage/stork/v2.4.1/specs/stork-scheduler.yaml
 ---
 apiVersion: v1
@@ -274,6 +278,10 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       hostPID: false
       securityContext:
-{{ include "operator.podsecuritycontext" . | indent 8 }}
+{{- if .Values.stork.podsecuritycontext }}
+{{ .Values.stork.podsecuritycontext | toYaml | indent 8 }}
+{{- else }}
+{{ include "operator.defaultpodsecuritycontext" $ | indent 8 }}
+{{- end }}
       serviceAccountName: stork-scheduler-account
 {{- end }}

--- a/charts/piraeus/values-openshift.yaml
+++ b/charts/piraeus/values-openshift.yaml
@@ -1,0 +1,8 @@
+global:
+  setSecurityContext: false
+csi-snapshotter:
+  # already configured by OCP
+  enabled: false
+etcd:
+  podsecuritycontext:
+    supplementalGroups: [1000]

--- a/charts/piraeus/values.cn.yaml
+++ b/charts/piraeus/values.cn.yaml
@@ -24,6 +24,7 @@ stork:
   replicas: 1
   storkResources: {} # resources requirements for the stork plugin containers
   schedulerResources: {} # resource requirements for the kube-scheduler containers
+  podsecuritycontext: {}
 csi:
   enabled: true
   pluginImage: daocloud.io/piraeus/piraeus-csi:v0.9.0
@@ -50,7 +51,10 @@ psp:
 operator:
   replicas: 1 # <- number of replicas for the operator deployment
   image: daocloud.io/piraeus/piraeus-operator:latest
+  affinity: {}
+  tolerations: []
   resources: {}
+  podsecuritycontext: {}
   controller:
     enabled: true
     controllerImage: daocloud.io/piraeus/piraeus-server:v1.9.0
@@ -59,7 +63,10 @@ operator:
     dbUseClientCert: false
     sslSecret: ""
     affinity: null
-    tolerations: []
+    tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: "Exists"
+        effect: "NoSchedule"
     resources: {}
     replicas: 1
   satelliteSet:

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -24,6 +24,7 @@ stork:
   replicas: 1
   storkResources: {} # resources requirements for the stork plugin containers
   schedulerResources: {} # resource requirements for the kube-scheduler containers
+  podsecuritycontext: {}
 csi:
   enabled: true
   pluginImage: quay.io/piraeusdatastore/piraeus-csi:v0.9.0
@@ -50,7 +51,10 @@ psp:
 operator:
   replicas: 1 # <- number of replicas for the operator deployment
   image: quay.io/piraeusdatastore/piraeus-operator:latest
+  affinity: {}
+  tolerations: []
   resources: {}
+  podsecuritycontext: {}
   controller:
     enabled: true
     controllerImage: quay.io/piraeusdatastore/piraeus-server:v1.9.0
@@ -59,7 +63,10 @@ operator:
     dbUseClientCert: false
     sslSecret: ""
     affinity: null
-    tolerations: []
+    tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: "Exists"
+        effect: "NoSchedule"
     resources: {}
     replicas: 1
   satelliteSet:

--- a/charts/pv-hostpath/Chart.yaml
+++ b/charts/pv-hostpath/Chart.yaml
@@ -1,4 +1,4 @@
 name: pv-hostpath
 description: Hostpath volumes for etcd persistence
-version: 0.2.2
-appVersion: 0.2.2
+version: 0.2.3
+appVersion: 0.2.3

--- a/charts/pv-hostpath/templates/_helpers.tpl
+++ b/charts/pv-hostpath/templates/_helpers.tpl
@@ -1,0 +1,10 @@
+{{- define "post-install-labels" -}}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+{{- end -}}
+{{- define "post-install-annotations" -}}
+"helm.sh/hook": post-install,post-upgrade
+"helm.sh/hook-delete-policy": hook-succeeded
+{{- end -}}

--- a/charts/pv-hostpath/templates/pv.yaml
+++ b/charts/pv-hostpath/templates/pv.yaml
@@ -1,3 +1,72 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-chowner
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "post-install-labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook-weight": "-5"
+{{ include "post-install-annotations" . | indent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-chowner
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "post-install-labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook-weight": "-5"
+{{ include "post-install-annotations" . | indent 4 }}
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - privileged
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-chowner
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "post-install-labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook-weight": "-5"
+{{ include "post-install-annotations" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-chowner
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-chowner
+---
+{{- if .Values.pspRole }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-psp
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "post-install-labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook-weight": "-5"
+{{ include "post-install-annotations" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Values.pspRole }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-chowner
+{{- end }}
+---
 {{ range (required "A valid .Values.nodes entry required!" .Values.nodes) }}
 apiVersion: v1
 kind: PersistentVolume
@@ -25,31 +94,34 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  labels:
-    app.kubernetes.io/managed-by: {{ $.Release.Service | quote }}
-    app.kubernetes.io/instance: {{ $.Release.Name | quote }}
-    app.kubernetes.io/version: {{ $.Chart.AppVersion }}
-    helm.sh/chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
   name: {{ $.Release.Name }}-{{ . }}-chown
   namespace: {{ $.Release.Namespace | default "default" }}
+  labels:
+{{ include "post-install-labels" $ | indent 4 }}
+  annotations:
+{{ include "post-install-annotations" $ | indent 4 }}
 spec:
   template:
     metadata:
       name: {{ $.Release.Name }}-{{ . }}-chown
       namespace: {{ $.Release.Namespace | default "default" }}
     spec:
+      serviceAccountName: {{ $.Release.Name }}-chowner
       restartPolicy: Never
       containers:
         - name: chown
-          image: busybox
+          securityContext:
+            privileged: true
+          image: library/centos:8
           command:
-            - chown
-            - -R
-            - {{ $.Values.uid | default 1000 }}:{{ $.Values.uid | default 1000 }}
-            - /volume
+            - sh
+            - -ce
+            - |
+              chown -R {{ $.Values.uid | default 1000 }}:{{ $.Values.uid | default 1000 }} /volume
+              chmod -R 0775 /volume
+              {{- if $.Values.selinux }}
+              chcon -R -t container_file_t /volume
+              {{- end }}
           volumeMounts:
             - mountPath: /volume
               name: pv
@@ -58,6 +130,8 @@ spec:
           hostPath:
             type: DirectoryOrCreate
             path: {{ required "A valid .Values.path entry required!" $.Values.path }}
+      tolerations:
+{{ $.Values.tolerations | toYaml | indent 8 }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/charts/pv-hostpath/values.yaml
+++ b/charts/pv-hostpath/values.yaml
@@ -2,3 +2,9 @@ size: 1Gi
 path: /var/lib/linstor-etcd
 uid: 1000
 gid: 1000
+tolerations:
+  - key: node-role.kubernetes.io/master
+    operator: "Exists"
+    effect: "NoSchedule"
+pspRole: ""
+selinux: false

--- a/deploy/piraeus/charts/csi-snapshotter/templates/deployment.yaml
+++ b/deploy/piraeus/charts/csi-snapshotter/templates/deployment.yaml
@@ -29,6 +29,14 @@ spec:
           imagePullPolicy: "IfNotPresent"
           resources:
             {}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: snapshot-controller
+            topologyKey: kubernetes.io/hostname
+      tolerations: []
 ---
 # Source: piraeus/charts/csi-snapshotter/templates/deployment.yaml
 # This YAML file shows how to deploy the snapshot controller

--- a/deploy/piraeus/charts/etcd/templates/statefulset.yaml
+++ b/deploy/piraeus/charts/etcd/templates/statefulset.yaml
@@ -29,15 +29,17 @@ spec:
     spec:
       serviceAccountName: "etcd"
       affinity:
+        # Ensures only one pod is scheduled per node
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - etcd
-            topologyKey: kubernetes.io/hostname
+            - labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: "kubernetes.io/hostname"
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000

--- a/deploy/piraeus/templates/operator-controller.yaml
+++ b/deploy/piraeus/templates/operator-controller.yaml
@@ -17,6 +17,6 @@ spec:
   linstorHttpsControllerSecret: ""
   linstorHttpsClientSecret: ""
   affinity: null
-  tolerations: []
+  tolerations: [{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"}]
   resources: {}
   replicas: 1

--- a/deploy/piraeus/templates/operator-deployment.yaml
+++ b/deploy/piraeus/templates/operator-deployment.yaml
@@ -38,3 +38,11 @@ spec:
               value: "piraeus-operator"
           resources:
             {}
+      tolerations: []
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  name: piraeus-op-operator

--- a/doc/helm-values.adoc
+++ b/doc/helm-values.adoc
@@ -63,6 +63,22 @@ Default:: `{}`
 Valid values:: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource requests]
 Description:: Resource requests and limits to apply to the operator containers.
 
+=== `operator.podsecuritycontext`
+Default:: `{}`
+Valid values:: A valid pod-level https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[security-context]
+Description:: Override for the default security context passed to the operator pods. See <<_global_setsecuritycontext>>
+
+=== `operator.affinity`
+Default:: `{}`
+Valid values:: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity[affinity]
+Description:: Set the operator pod affinity. The default expands to allow only one operator pod per node.
+
+=== `operator.tolerations`
+Default:: `[]`
+Valid values:: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[tolerations]
+Description:: Tolerations to pass to the operator pod.
+
+
 
 == Cluster Snapshot Controller
 
@@ -87,6 +103,30 @@ Description:: Number of replicas of the CSI snapshot controller.
 Default:: `{}`
 Valid values:: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource requests]
 Description:: Resource requests and limits to apply to the CSI snapshot controller containers.
+
+=== `csi-snapshotter.podsecuritycontext`
+Default:: `{}`
+Valid values:: A valid pod-level https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[security-context]
+Description:: Override for the default security context passed to the csi-snapshotter pods. See <<_global_setsecuritycontext>>
+
+=== `csi-snapshotter.affinity`
+Default::
+[source,yaml]
+----
+podAntiAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+  - labelSelector:
+      matchLabels:
+        app: snapshot-controller
+    topologyKey: "kubernetes.io/hostname"
+----
+Valid values:: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity[affinity]
+Description:: Set the pod affinity. The default forces pod to be assigned to different nodes.
+
+=== `csi-snapshotter.tolerations`
+Default:: `[]`
+Valid values:: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[tolerations]
+Description:: Tolerations to pass to the CSI snapshot controller.
 
 
 == CSI Driver
@@ -210,11 +250,31 @@ Default:: `1`
 Valid values:: number
 Description:: number of replicas to use for ETCD. An odd number is preferred.
 
+=== `etcd.affinity`
+Default:: `{}`
+Valid values:: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity[affinity]
+Description:: Affinity settings for etcd pods. The default allows scheduling on master nodes.
+
 === `etcd.resources`
 Default:: `{}`
 Valid values:: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource requests]
 Description:: Resource requests and limits to apply to the etcd containers. See https://etcd.io/docs/v3.4.0/faq/#system-requirements[etcd docs]
 
+=== `etcd.tolerations`
+Default::
+[source]
+----
+- key: node-role.kubernetes.io/master
+  operator: "Exists"
+  effect: "NoSchedule"
+----
+Valid values:: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[tolerations]
+Description:: Set the tolerations for etcd. Defaults to allow scheduling on master nodes.
+
+=== `etcd.podsecuritycontext`
+Default:: `{}`
+Valid values:: A valid pod-level https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[security-context]
+Description:: Override for the default security context passed to the etcd pods. See <<_global_setsecuritycontext>>
 
 
 == Piraeus Controller
@@ -429,3 +489,8 @@ Description:: Name of the image to use for the stork plugin
 Default:: `{}`
 Valid values:: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource requests]
 Description:: Resource requests and limits to apply to the stork containers.
+
+=== `stork.podsecuritycontext`
+Default:: `{}`
+Valid values:: A valid pod-level https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[security-context]
+Description:: Override for the default security context passed to the stork and scheduler pods. See <<_global_setsecuritycontext>>

--- a/doc/scheduling.md
+++ b/doc/scheduling.md
@@ -1,0 +1,58 @@
+# Influencing Kubernetes scheduling
+
+This is meant as a short introduction to the various options that influence scheduling when using the Piraeus chart.
+To influence pod placement, we use the Kubernetes concepts of [tolerations] and [affinity].
+
+[tolerations]: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+[affinity]: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+
+## High Availability by distributing pods
+
+If you are running multiple replicas to achieve High Availability, you want pods to be distributed across as many
+nodes as possible. This ensures that failure of a single node does not interrupt a critical set of pods.
+
+The way to achieve scheduling on different nodes is by using `podAntiAffinity`:
+
+```yaml
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app: etcd
+        topologyKey: "kubernetes.io/hostname"
+```
+
+This affinity setting ensures that only one pod with label `app: etcd` will be scheduled per node.
+
+Piraeus will use such `affinity` settings by default for:
+* `etcd` change by setting `operator.etcd`
+* `operator` change by setting `operator.affinity`
+* `csi-snapshotter` change by setting `csi-snapshotter.affinity`
+* `Piraeus controller` change by setting `operator.controller.affinity`
+* `CSI controller` change by setting `csi.controllerAffinity`
+
+## Place pods on master nodes
+
+To allow pods to be placed on master nodes, you need add [tolerations]:
+
+```yaml
+tolerations:
+- key: node-role.kubernetes.io/master
+  operator: "Exists"
+  effect: "NoSchedule"
+```
+
+This toleration allows pods to be scheduled on master nodes.
+
+Note that using tolerations this way only _allows_ scheduling on master nodes, but does not force it. The pod can still
+end up on a worker node. To force scheduling on master nodes, use affinity settings to set the `nodeAffinity`.
+
+By default, piraeus will set this toleration for the `etcd` pods. Tolerations can be set on:
+* `etcd` by setting `etcd.tolerations`
+* `csi-snapshotter` by setting `csi-snapshotter.tolerations`
+* `operator` by setting `operator.tolerations`
+* `Piraeus controller` by setting `operator.controller.tolerations`
+* `Piraeus satellites` by setting `operator.satelliteSet.tolerations`
+* `CSI controller` by setting `csi.controllerTolerations`
+* `CSI nodes` by setting `csi.nodeTolerations`


### PR DESCRIPTION
* allow manual override of securityContext per component
  - etcd
  - csi-controller
  - stork
  - operator

* pv-hostpath integrated with PSP and SCC restrictions
* pv-hostpath prepares volumes for eventual fsGroup use + SELinux labels
* pv-hostpath jobs are able to run on master nodes by default
* etcd pods are able to run on master nodes by default