### PR TITLE
propagate CR updates to created resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Default value for affinity on LINSTOR controller and CSI controller changed. The new default is to distribute the pods
   across all available nodes.
 * Default value for tolerations for etcd pods changed. They are now able to run on master nodes.
+* Updates to LinstorController, LinstorSatelliteSet and LinstorCSIDriver are now propagated across all created resources
 
 ### Deprecation
 

--- a/pkg/controller/linstorcontroller/linstorcontroller_controller_test.go
+++ b/pkg/controller/linstorcontroller/linstorcontroller_controller_test.go
@@ -205,7 +205,7 @@ keyfile     = /etc/linstor/client/client.key
 
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
-			actualCM, err := NewConfigMapForPCS(test.spec)
+			actualCM, err := NewConfigMapForResource(test.spec)
 			if err != nil {
 				t.Fatalf("config map creation failed: %v", err)
 			}

--- a/pkg/controller/linstorcsidriver/linstorcsidriver_controller.go
+++ b/pkg/controller/linstorcsidriver/linstorcsidriver_controller.go
@@ -329,7 +329,9 @@ func (r *ReconcileLinstorCSIDriver) reconcileNodeDaemonSet(ctx context.Context, 
 	logger.Debugf("creating csi node daemon set")
 	nodeDaemonSet := newCSINodeDaemonSet(csiResource)
 
-	return reconcileutil.CreateOrReplaceWithOwner(ctx, r.client, r.scheme, nodeDaemonSet, csiResource)
+	_, err := reconcileutil.CreateOrUpdateWithOwner(ctx, r.client, r.scheme, nodeDaemonSet, csiResource)
+
+	return err
 }
 
 func (r *ReconcileLinstorCSIDriver) reconcileControllerDeployment(ctx context.Context, csiResource *piraeusv1.LinstorCSIDriver) error {
@@ -341,7 +343,9 @@ func (r *ReconcileLinstorCSIDriver) reconcileControllerDeployment(ctx context.Co
 	logger.Debugf("creating csi controller deployment")
 	controllerDeployment := newCSIControllerDeployment(csiResource)
 
-	return reconcileutil.CreateOrReplaceWithOwner(ctx, r.client, r.scheme, controllerDeployment, csiResource)
+	_, err := reconcileutil.CreateOrUpdateWithOwner(ctx, r.client, r.scheme, controllerDeployment, csiResource)
+
+	return err
 }
 
 func (r *ReconcileLinstorCSIDriver) reconcileCSIDriver(ctx context.Context, csiResource *piraeusv1.LinstorCSIDriver) error {
@@ -353,7 +357,9 @@ func (r *ReconcileLinstorCSIDriver) reconcileCSIDriver(ctx context.Context, csiR
 	logger.Debugf("creating csi driver resource")
 	csiDriver := newCSIDriver(csiResource)
 
-	return reconcileutil.CreateOrReplaceWithOwner(ctx, r.client, r.scheme, csiDriver, csiResource)
+	_, err := reconcileutil.CreateOrUpdate(ctx, r.client, r.scheme, csiDriver)
+
+	return err
 }
 
 var (
@@ -701,8 +707,7 @@ func newCSIDriver(csiResource *piraeusv1.LinstorCSIDriver) *storagev1beta1.CSIDr
 	return &storagev1beta1.CSIDriver{
 		ObjectMeta: metav1.ObjectMeta{
 			// Name must match exactly the one reported by the CSI plugin
-			Name:      "linstor.csi.linbit.com",
-			Namespace: csiResource.Namespace,
+			Name: "linstor.csi.linbit.com",
 		},
 		Spec: storagev1beta1.CSIDriverSpec{
 			AttachRequired: &attachRequired,

--- a/pkg/controller/linstorcsidriver/linstorcsidriver_controller_test.go
+++ b/pkg/controller/linstorcsidriver/linstorcsidriver_controller_test.go
@@ -35,8 +35,7 @@ var (
 	}
 	DefaultCSIDriver = storagev1beta1.CSIDriver{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "linstor.csi.linbit.com",
-			Namespace: "bar",
+			Name: "linstor.csi.linbit.com",
 		},
 		Spec: storagev1beta1.CSIDriverSpec{
 			AttachRequired: &CSIDriverAttachRequired,

--- a/pkg/k8s/reconcileutil/resources.go
+++ b/pkg/k8s/reconcileutil/resources.go
@@ -2,10 +2,16 @@ package reconcileutil
 
 import (
 	"context"
+	"fmt"
 
+	kubeSpec "github.com/piraeusdatastore/piraeus-operator/pkg/k8s/spec"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/mergepatch"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -15,38 +21,142 @@ type GCRuntimeObject interface {
 	runtime.Object
 }
 
-// Create a resource at the cluster scope.
+const (
+	lastAppliedAnnotation = kubeSpec.APIGroup + "/last-applied-configuration"
+	fieldOwner            = kubeSpec.APIGroup + "/pkg/k8s/reconcileutil"
+)
+
+var defaultPreconditions = []mergepatch.PreconditionFunc{
+	mergepatch.RequireMetadataKeyUnchanged("name"),
+	mergepatch.RequireMetadataKeyUnchanged("namespace"),
+	mergepatch.RequireKeyUnchanged("status"),
+}
+
+// Creates or updates a resource to be in line with the given resource spec.
 //
-// cluster scoped resource are not allowed to have owner references, so these objects will not be cleaned up
-// automatically.
-func CreateOrReplace(ctx context.Context, kubeClient client.Client, obj runtime.Object) error {
-	err := kubeClient.Create(ctx, obj)
+// `kubectl apply` for go. First, will try to create the resource. If it already exists, it will try to compute the
+// changes based on the one previously applied and patch the resource.
+func CreateOrUpdate(ctx context.Context, kubeClient client.Client, scheme *runtime.Scheme, obj GCRuntimeObject) (bool, error) {
+	modifiedEncoded, err := ensureAppliedConfigAnnotation(scheme, obj)
+	if err != nil {
+		return false, err
+	}
+
+	err = kubeClient.Create(ctx, obj, client.FieldOwner(fieldOwner))
 	if err == nil {
-		return nil
+		return true, nil
 	}
 
 	if !apierrors.IsAlreadyExists(err) {
-		return err
+		return false, err
 	}
 
-	// TODO: support update operation.
-	// Updates automatically trigger reconciliation, which means we get an endless loop of .Reconcile() calls. To
-	// support this properly we would need to check for spec equality in some way.
-	return nil
+	current, err := getCurrentResource(ctx, kubeClient, scheme, obj)
+	if err != nil {
+		return false, err
+	}
+
+	patchMeta, err := strategicpatch.NewPatchMetaFromStruct(current)
+	if err != nil {
+		return false, fmt.Errorf("failed to patch metadata from empty struct: %w", err)
+	}
+
+	originalEncoded := current.GetAnnotations()[lastAppliedAnnotation]
+
+	// We reset the creation timestamp here.
+	// This is done because the object is not recognized as "empty" in the json encoder. Unless we reset the creation
+	// time of the current resource, it will show up in any patch we want to submit.
+	current.SetCreationTimestamp(metav1.Time{})
+	currentEncoded, err := runtime.Encode(unstructured.UnstructuredJSONScheme, current)
+	if err != nil {
+		return false, fmt.Errorf("failed to re-encoded current resource: %w", err)
+	}
+
+	patch, err := strategicpatch.CreateThreeWayMergePatch([]byte(originalEncoded), modifiedEncoded, currentEncoded, patchMeta, true, defaultPreconditions...)
+	if err != nil {
+		return false, fmt.Errorf("failed to generate patch data: %w", err)
+	}
+
+	if string(patch) == "{}" {
+		return false, nil
+	}
+
+	return true, kubeClient.Patch(ctx, obj, client.ConstantPatch(types.StrategicMergePatchType, patch), client.FieldOwner(fieldOwner))
 }
 
-// Create a resource at current owning resource scope.
+// Creates or updates a resource, ensuring the controller reference is set.
 //
-// Once the owning resource is cleaned up, the created items will be removed as well.
-func CreateOrReplaceWithOwner(ctx context.Context, kubeClient client.Client, scheme *runtime.Scheme, obj GCRuntimeObject, owner metav1.Object) error {
+// Sets the owner reference, ensuring that once the owning resource is cleaned up, the created items will be removed as
+// well. Then calls CreateOrUpdate.
+func CreateOrUpdateWithOwner(ctx context.Context, kubeClient client.Client, scheme *runtime.Scheme, obj GCRuntimeObject, owner metav1.Object) (bool, error) {
 	err := controllerutil.SetControllerReference(owner, obj, scheme)
 	// If it is already owned, we don't treat the SetControllerReference() call as a failure condition
 	if err != nil {
 		_, isAlreadyOwned := err.(*controllerutil.AlreadyOwnedError)
 		if !isAlreadyOwned {
-			return err
+			return false, err
 		}
 	}
 
-	return CreateOrReplace(ctx, kubeClient, obj)
+	return CreateOrUpdate(ctx, kubeClient, scheme, obj)
+}
+
+// Returns the current state of the given object, as stored in Kubernetes.
+func getCurrentResource(ctx context.Context, kubeClient client.Client, scheme *runtime.Scheme, obj GCRuntimeObject) (GCRuntimeObject, error) {
+	gvks, unversioned, err := scheme.ObjectKinds(obj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine object kinds: %w", err)
+	}
+
+	if unversioned {
+		return nil, fmt.Errorf("cannot update unversioned type")
+	}
+
+	emptyObj, err := scheme.New(gvks[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new instance based on GVK: %w", err)
+	}
+
+	err = kubeClient.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, emptyObj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to feetch current resource state: %w", err)
+	}
+
+	current, ok := emptyObj.(GCRuntimeObject)
+	if !ok {
+		return nil, fmt.Errorf("failed to cast cloned object to original type")
+	}
+
+	return current, nil
+}
+
+// Ensure the resource has the current config stored in an annotation.
+func ensureAppliedConfigAnnotation(scheme *runtime.Scheme, obj GCRuntimeObject) ([]byte, error) {
+	// Instead of encoding the json directly, we first convert it to "Unstructured", i.e. a map[string]interface{}
+	// We do this to remove a "status" item if there is any. Not all status fields are marked as `json:",omitempty`,
+	// so their default value will be serialized too. The status field itself is marked as `json:",omitempty`, which
+	// is useless, as struct values are never empty in golang.
+	objUnstructured := unstructured.Unstructured{}
+
+	err := scheme.Convert(obj, &objUnstructured, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert to unstructured item: %w", err)
+	}
+
+	delete(objUnstructured.Object, "status")
+
+	objEncoded, err := runtime.Encode(unstructured.UnstructuredJSONScheme, &objUnstructured)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare applied configuration metadata: %w", err)
+	}
+
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	annotations[lastAppliedAnnotation] = string(objEncoded)
+	obj.SetAnnotations(annotations)
+
+	return objEncoded, nil
 }


### PR DESCRIPTION
Changes to Linstor* CRs will now trigger updates on all created resources.
Any changes made to the resources that are _not_ explicitly set by the
operator will not be touched. Also force a rerun every minute to update the
status field.

The implementation is heavily inspired by how "kubectl apply" works.
The idea is:
* Store the "applied configuration" in an annotation
* Compare wanted with current and applied configuration in a 3-way-merge
* Patch if the 3-way-merge patch is not empty

There are some manual fixes necessary to ensure that the serialized spec
only contains actually set fields:
* metadata.creationTimestamp is serialized as "null", it should be skipped
* status values should be skipped too