### PR TITLE
update to use new github-actions PATH update

### DIFF
--- a/.github/workflows/scripts/install-operator-sdk.sh
+++ b/.github/workflows/scripts/install-operator-sdk.sh
@@ -11,4 +11,4 @@ if [ ! -x "${HOME}/operator-sdk/bin/operator-sdk" ] ; then
   chmod +x "${HOME}/operator-sdk/bin/operator-sdk"
 fi
 
-echo "::add-path::${HOME}/operator-sdk/bin/"
+echo "${HOME}/operator-sdk/bin/" >> "${GITHUB_PATH}"


### PR DESCRIPTION
using the "::add-path::" command is deprecated and will be removed
on 2020-11-16. use the replacement method of writing to $GITHUB_PATH
instead.

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/