### PR TITLE
add log directory group to controller pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `csi-snapshotter.podsecuritycontext` sets the securityContext of the CSI-Snapshotter pods
   - `operator.podsecuritycontext` sets the securityContext of the operator pods
 * Example settings for openshift
+* LINSTOR controller runs with additional GID 1000, to ensure write access to log directory
 
 ### Changed
 

--- a/pkg/controller/linstorcontroller/linstorcontroller_controller.go
+++ b/pkg/controller/linstorcontroller/linstorcontroller_controller.go
@@ -788,10 +788,15 @@ func newDeploymentForResource(controllerResource *piraeusv1.LinstorController) *
 					ImagePullSecrets: pullSecrets,
 					Affinity:         getDeploymentAffinity(controllerResource),
 					Tolerations:      controllerResource.Spec.Tolerations,
+					SecurityContext:  getSecurityContext(),
 				},
 			},
 		},
 	}
+}
+
+func getSecurityContext() *corev1.PodSecurityContext {
+	return &corev1.PodSecurityContext{SupplementalGroups: []int64{kubeSpec.LinstorControllerGID}}
 }
 
 func getDeploymentAffinity(controllerResource *piraeusv1.LinstorController) *corev1.Affinity {

--- a/pkg/k8s/spec/const.go
+++ b/pkg/k8s/spec/const.go
@@ -43,6 +43,7 @@ const (
 	LinstorControllerConfigFile = "linstor.toml"
 	LinstorSatelliteConfigFile  = "linstor_satellite.toml"
 	LinstorClientConfigFile     = "linstor-client.conf"
+	LinstorControllerGID        = 1000
 )
 
 // Special strings for communicating with the module injector


### PR DESCRIPTION
LINSTOR controller image are build with the assumption that the LINSTOR
process will run as UID 1000 or at least GID 1000. This is not the case
when running on some platforms (notably Openshift). We add the required
group to the container user by explicitly setting the supplementalGroups
for the pod.