### PR TITLE
fix helm warnings when merging tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed Helm warnings when setting "csi.controllerAffinity", "operator.controller.affinity" and
+  "operator.satelliteSet.storagePools".
+
 ## [v1.2.0] - 2020-11-18
 
 ### Added

--- a/charts/piraeus/templates/operator-controller.yaml
+++ b/charts/piraeus/templates/operator-controller.yaml
@@ -15,7 +15,9 @@ spec:
   imagePullPolicy: {{ .Values.global.imagePullPolicy | quote }}
   linstorHttpsControllerSecret: {{ .Values.linstorHttpsControllerSecret | quote }}
   linstorHttpsClientSecret: {{ .Values.linstorHttpsClientSecret | quote }}
+{{- if .Values.operator.controller.affinity }}
   affinity: {{ .Values.operator.controller.affinity | toJson }}
+{{- end }}
   tolerations: {{ .Values.operator.controller.tolerations | toJson}}
   resources: {{ .Values.operator.controller.resources | toJson }}
   replicas: {{ .Values.operator.controller.replicas }}

--- a/charts/piraeus/templates/operator-csi-driver.yaml
+++ b/charts/piraeus/templates/operator-csi-driver.yaml
@@ -22,7 +22,9 @@ spec:
   controllerEndpoint: {{ template "controller.endpoint" . }}
   nodeAffinity: {{ .Values.csi.nodeAffinity | toJson }}
   nodeTolerations: {{ .Values.csi.nodeTolerations | toJson}}
+{{- if .Values.csi.controllerAffinity }}
   controllerAffinity: {{ .Values.csi.controllerAffinity | toJson }}
+{{- end }}
   controllerTolerations: {{ .Values.csi.controllerTolerations | toJson}}
   enableTopology: {{ .Values.csi.enableTopology }}
   resources: {{ .Values.csi.resources | toJson }}

--- a/charts/piraeus/values.cn.yaml
+++ b/charts/piraeus/values.cn.yaml
@@ -37,7 +37,7 @@ csi:
   controllerReplicas: 1
   nodeAffinity: {}
   nodeTolerations: []
-  controllerAffinity: null
+  controllerAffinity: {}
   controllerTolerations: []
   enableTopology: false
   resources: {}
@@ -63,7 +63,7 @@ operator:
     dbCertSecret: ""
     dbUseClientCert: false
     sslSecret: ""
-    affinity: null
+    affinity: {}
     tolerations:
       - key: node-role.kubernetes.io/master
         operator: "Exists"
@@ -73,7 +73,7 @@ operator:
   satelliteSet:
     enabled: true
     satelliteImage: daocloud.io/piraeus/piraeus-server:v1.10.0
-    storagePools: null
+    storagePools: {}
     sslSecret: ""
     automaticStorageType: None
     affinity: {}

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -37,7 +37,7 @@ csi:
   controllerReplicas: 1
   nodeAffinity: {}
   nodeTolerations: []
-  controllerAffinity: null
+  controllerAffinity: {}
   controllerTolerations: []
   enableTopology: false
   resources: {}
@@ -63,7 +63,7 @@ operator:
     dbCertSecret: ""
     dbUseClientCert: false
     sslSecret: ""
-    affinity: null
+    affinity: {}
     tolerations:
       - key: node-role.kubernetes.io/master
         operator: "Exists"
@@ -73,7 +73,7 @@ operator:
   satelliteSet:
     enabled: true
     satelliteImage: quay.io/piraeusdatastore/piraeus-server:v1.10.0
-    storagePools: null
+    storagePools: {}
     sslSecret: ""
     automaticStorageType: None
     affinity: {}

--- a/deploy/piraeus/templates/operator-controller.yaml
+++ b/deploy/piraeus/templates/operator-controller.yaml
@@ -16,7 +16,6 @@ spec:
   imagePullPolicy: "IfNotPresent"
   linstorHttpsControllerSecret: ""
   linstorHttpsClientSecret: ""
-  affinity: null
   tolerations: [{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"}]
   resources: {}
   replicas: 1

--- a/deploy/piraeus/templates/operator-csi-driver.yaml
+++ b/deploy/piraeus/templates/operator-csi-driver.yaml
@@ -23,7 +23,6 @@ spec:
   controllerEndpoint: http://piraeus-op-cs.default.svc:3370
   nodeAffinity: {}
   nodeTolerations: []
-  controllerAffinity: null
   controllerTolerations: []
   enableTopology: false
   resources: {}

--- a/doc/helm-values.adoc
+++ b/doc/helm-values.adoc
@@ -132,7 +132,7 @@ Description:: Tolerations to pass to the CSI snapshot controller.
 == CSI Driver
 
 === `csi.controllerAffinity`
-Default:: `null`
+Default:: `{}`
 Valid values:: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity[affinity]
 Description:: Affinity settings for controller pods. Can be used to pin controller pods to specific nodes. The default will expand to:
 +
@@ -147,7 +147,8 @@ affinity:
           role: csi-controller
       topologyKey: kubernetes.io/hostname
 ----
-
++
+To not use any affinity settings, set the value to `nodeAffinity: {}`
 
 === `csi.controllerReplicas`
 Default:: `1`
@@ -292,7 +293,7 @@ Valid values::
 Description:: If set to false, no LinstorController resource will be created by Helm. This means no LINSTOR controller will be deployed.
 
 === `operator.controller.affinity`
-Default:: `null`
+Default:: `{}`
 Valid values:: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity[affinity]
 Description:: Affinity settings for controller pods. Can be used to restrict the pods to specific nodes. The default will expand to:
 +
@@ -307,6 +308,8 @@ affinity:
           role: piraeus-controller
       topologyKey: kubernetes.io/hostname
 ----
++
+To not use any affinity settings, set the value to `nodeAffinity: {}`
 
 === `operator.controller.controllerImage`
 Default:: `quay.io/piraeusdatastore/piraeus-server:v1.10.0`
@@ -425,7 +428,7 @@ Valid values:: secret name
 Description:: Name of the secret to use for secure communication between controller and satellites. Check link:./security.md#configuring-secure-communication-between-linstor-components[the security guide].
 
 === `operator.satelliteSet.storagePools`
-Default:: `None`
+Default:: `{}`
 Valid values:: map
 Description:: See the link:./storage.md#configuring-storage-pool-creation[guide on storage pool creation]
 


### PR DESCRIPTION
For Helm a "null" merged with a "table" is a warning. Instead of "null"
we should use empty tables.

However, we still want to differentiate between the default value and an
intentional empty value. This is important for the "affinity" settings,
as we use a default value if go encounters as "nil" value. To support this, we
leave out the whole key if the default value is encountered in the Helm
template.

The effect of this in the operator code is:
* A value of "{}" will be seen as "nil". This will trigger setting the default
  affinity.
* A value that only contains a table key but no table value will be passed
  through. The effect is that no affinity will be configured, and we won't
  override it with the default affinity.