### PR TITLE
Let injector image fail if usermode_helper not disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Enable strict checking of DRBD parameter to disable usermode helper in container environments.
+
 ### Changed
 
 * Updated `operator-sdk` to v0.19.4

--- a/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
+++ b/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
@@ -1008,6 +1008,10 @@ func daemonSetWithDRBDKernelModuleInjection(ds *apps.DaemonSet, satelliteSet *pi
 					Name:  kubeSpec.LinstorKernelModHow,
 					Value: kernelModHow,
 				},
+				{
+					Name:  kubeSpec.LinstorKernelModHelperCheck,
+					Value: kubeSpec.LinstorKernelModHelperCheckEnabled,
+				},
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				{

--- a/pkg/k8s/spec/const.go
+++ b/pkg/k8s/spec/const.go
@@ -48,10 +48,12 @@ const (
 
 // Special strings for communicating with the module injector
 const (
-	LinstorKernelModHow            = "LB_HOW"
-	LinstorKernelModCompile        = "compile"
-	LinstorKernelModShippedModules = "shipped_modules"
-	LinstorKernelModDepsOnly       = "deps_only"
+	LinstorKernelModHow                = "LB_HOW"
+	LinstorKernelModCompile            = "compile"
+	LinstorKernelModShippedModules     = "shipped_modules"
+	LinstorKernelModDepsOnly           = "deps_only"
+	LinstorKernelModHelperCheck        = "LB_FAIL_IF_USERMODE_HELPER_NOT_DISABLED"
+	LinstorKernelModHelperCheckEnabled = "yes"
 )
 
 // Special strings when configuring Linstor


### PR DESCRIPTION
Using LINSTOR in containers without disabling DRBD usermode_helper will
lead to "StandAlone" resources. A new setting was added in the
kernel module injector images that checks that the parameter is configured
for container environments.