### PR TITLE
Use a timeout of 1m for all CSI components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Updated `operator-sdk` to v0.19.4
+* Set CSI component timeout to 1 minute to reduce the number of retries in the CSI driver
 
 ### Fixed
 


### PR DESCRIPTION
* Provisioner timeout increased from 15s to 1m
* Other timeouts reduced from 4m to 1m

The provisioner probably also had a timeout of 4 minutes in an older version, but that was changed at some point. 1 Minute seemed to completely remove the "Context cancelled" messages in a test run, while not seeming as excessive as the 4m for the other components