### PR TITLE
Make chown job image configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * New component: `haController` will deploy the [Piraeus High Availability Controller].
   More information is available in the [optional components page](./doc/optional-components.md#high-availability-controller)
 * Enable strict checking of DRBD parameter to disable usermode helper in container environments.
+* Override the image used in "chown" jobs in the `pv-hostpath` chart by using `--set chownerImage=<my-image>`.
 
 [Piraeus High Availability Controller]: https://github.com/piraeusdatastore/piraeus-ha-controller
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ Persistence for etcd is enabled by default.
 Clusters with SELinux enabled hosts (for example: OpenShift clusters) need to relabel the created directory. This
 can be done automatically by passing `--set selinux=true` to the above `helm install` command.
 
+#### Override the default choice of chown job image
+
+The `pv-hostpath` chart will create a job for each created PV. The jobs are meant to ensure the host volumes are set up
+with the correct permission, so that etcd can run as a non-privileged container. To override the default choice of
+`centos:8`, use `--set chownerImage=<my-image>`.
+
 ### Using an existing database
 
 LINSTOR can connect to an existing PostgreSQL, MariaDB or etcd database. For

--- a/charts/pv-hostpath/templates/pv.yaml
+++ b/charts/pv-hostpath/templates/pv.yaml
@@ -112,7 +112,7 @@ spec:
         - name: chown
           securityContext:
             privileged: true
-          image: library/centos:8
+          image: {{ $.Values.chownerImage | quote }}
           command:
             - sh
             - -ce

--- a/charts/pv-hostpath/values.yaml
+++ b/charts/pv-hostpath/values.yaml
@@ -2,6 +2,8 @@ size: 1Gi
 path: /var/lib/linstor-etcd
 uid: 1000
 gid: 1000
+# Container image used to set up permissions for host volumes. Should contain `chown`, `chmod` and `chcon` (if `selinux=true`)
+chownerImage: library/centos:8
 tolerations:
   - key: node-role.kubernetes.io/master
     operator: "Exists"


### PR DESCRIPTION
Make the chown job image configurable (default centos:8). This is useful
for all offline installs and other set ups where the default registry is
not good enough.