### PR TITLE
use strategy type: Recreate for linstor-controller

### DIFF
--- a/pkg/controller/linstorcontroller/linstorcontroller_controller.go
+++ b/pkg/controller/linstorcontroller/linstorcontroller_controller.go
@@ -745,6 +745,7 @@ func newDeploymentForResource(controllerResource *piraeusv1.LinstorController) *
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: labels},
 			Replicas: controllerResource.Spec.Replicas,
+			Strategy: appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      controllerResource.Name + "-controller",


### PR DESCRIPTION
Hi, `strategy: {"type": "Recreate"}` instructs Kubernetes to delete all existing pods before applying new ones.
I believe that this setting will provide more seamless upgrades for linstor-controller pods.