### PR TITLE
configurable linux kernel headers location

### DIFF
--- a/charts/piraeus/crds/piraeus.linbit.com_linstorsatellitesets_crd.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstorsatellitesets_crd.yaml
@@ -648,6 +648,13 @@ spec:
               imagePullPolicy:
                 description: Pull policy applied to all pods started from this controller
                 type: string
+              kernelModuleInjectionHeadersLocation:
+                description: KernelModuleInjectionHeadersLocation defines linux kernel
+                  headers location
+                enum:
+                - Container
+                - Host
+                type: string
               kernelModuleInjectionImage:
                 description: kernelModuleInjectionImage is the image (location + tag)
                   for the LINSTOR/DRBD kernel module injector

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -82,3 +82,4 @@ operator:
     kernelModuleInjectionImage: quay.io/piraeusdatastore/drbd9-bionic:v9.0.25
     kernelModuleInjectionMode: Compile
     kernelModuleInjectionResources: {}
+    kernelModuleInjectionHeadersLocation: "Host"

--- a/pkg/apis/piraeus/shared/linstor_types.go
+++ b/pkg/apis/piraeus/shared/linstor_types.go
@@ -354,3 +354,12 @@ const (
 	// ModuleInjectionDepsOnly means we only inject already present modules on the host for LINSTOR layers
 	ModuleInjectionDepsOnly = "DepsOnly"
 )
+
+type KernelModuleInjectionHeadersLocation string
+
+const (
+	// ModuleInjectionHeadersLocationHost means that kernel headers are available on the host
+	ModuleInjectionHeadersLocationHost = "Host"
+	// ModuleInjectionHeadersLocationContainer means that kernel headers are avaiable in container
+	ModuleInjectionHeadersLocationContainer = "Container"
+)

--- a/pkg/apis/piraeus/v1/linstorsatelliteset_types.go
+++ b/pkg/apis/piraeus/v1/linstorsatelliteset_types.go
@@ -77,6 +77,11 @@ type LinstorSatelliteSetSpec struct {
 	// +optional
 	KernelModuleInjectionMode shared.KernelModuleInjectionMode `json:"kernelModuleInjectionMode"`
 
+	// KernelModuleInjectionHeadersLocation defines linux kernel headers location
+	// +kubebuilder:validation:Enum=Container;Host
+	// +optional
+	KernelModuleInjectionHeadersLocation shared.KernelModuleInjectionHeadersLocation `json:"kernelModuleInjectionHeadersLocation"`
+
 	// Resource requirements for the kernel module builder/injector container
 	// +optional
 	// +nullable

--- a/pkg/k8s/spec/const.go
+++ b/pkg/k8s/spec/const.go
@@ -48,12 +48,15 @@ const (
 
 // Special strings for communicating with the module injector
 const (
-	LinstorKernelModHow                = "LB_HOW"
-	LinstorKernelModCompile            = "compile"
-	LinstorKernelModShippedModules     = "shipped_modules"
-	LinstorKernelModDepsOnly           = "deps_only"
-	LinstorKernelModHelperCheck        = "LB_FAIL_IF_USERMODE_HELPER_NOT_DISABLED"
-	LinstorKernelModHelperCheckEnabled = "yes"
+	LinstorKernelModHow                   = "LB_HOW"
+	LinstorKernelModCompile               = "compile"
+	LinstorKernelModShippedModules        = "shipped_modules"
+	LinstorKernelModDepsOnly              = "deps_only"
+	LinstorKernelModHelperCheck           = "LB_FAIL_IF_USERMODE_HELPER_NOT_DISABLED"
+	LinstorKernelModHelperCheckEnabled    = "yes"
+	LinstorKernelHeadersLocation          = "KERNEL_HEADERS_LOCATION"
+	LinstorKernelHeadersLocationHost      = "host"
+	LinstorKernelHeadersLocationContainer = "container"
 )
 
 // Special strings when configuring Linstor


### PR DESCRIPTION
In OpenShift environment(FCOS) kernel headers are not accessible in /usr/src directory
Additionaly /usr/src directory is ReadOnly in FCOS.
We have to download kernel headers inside kernel injector container, during entrypoint, or when building
 docker image(in offline configuration), like
https://gitlab.com/nvidia/container-images/driver/-/blob/master/ubuntu16.04/nvidia-driver


