### PR TITLE
Update default chowner image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Default image updated:
+  * `pv-hostpath`: `chownerImage`: `quay.io/centos/centos:8`
+
 ## [v1.3.0] - 2020-12-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ can be done automatically by passing `--set selinux=true` to the above `helm ins
 
 The `pv-hostpath` chart will create a job for each created PV. The jobs are meant to ensure the host volumes are set up
 with the correct permission, so that etcd can run as a non-privileged container. To override the default choice of
-`centos:8`, use `--set chownerImage=<my-image>`.
+`quay.io/centos/centos:8`, use `--set chownerImage=<my-image>`.
 
 ### Using an existing database
 

--- a/charts/pv-hostpath/Chart.yaml
+++ b/charts/pv-hostpath/Chart.yaml
@@ -1,4 +1,4 @@
 name: pv-hostpath
 description: Hostpath volumes for etcd persistence
-version: 0.2.4
-appVersion: 0.2.4
+version: 0.2.5
+appVersion: 0.2.5

--- a/charts/pv-hostpath/values.yaml
+++ b/charts/pv-hostpath/values.yaml
@@ -3,7 +3,7 @@ path: /var/lib/linstor-etcd
 uid: 1000
 gid: 1000
 # Container image used to set up permissions for host volumes. Should contain `chown`, `chmod` and `chcon` (if `selinux=true`)
-chownerImage: library/centos:8
+chownerImage: quay.io/centos/centos:8
 tolerations:
   - key: node-role.kubernetes.io/master
     operator: "Exists"


### PR DESCRIPTION
Since docker.io introduced a usage limit, the pv-hostpath chart may fail
run into a time-out when pulling the image. To prevent this we switch the
default image to one provided by quay.io.