### PR TITLE
Update host preparation section for DRBD

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,8 @@ associated Helm chart:
 
 The operator can be deployed with Helm v3 chart in /charts as follows:
 
-* Prepare the hosts for DRBD deployment. There are several options:
-  * Install DRBD directly on the hosts as
-    [documented](https://www.linbit.com/drbd-user-guide/users-guide-9-0/#p-build-install-configure).
-  * Install the appropriate kernel headers package for your distribution and
-    choose the appropriate
-    [kernel module injector](doc/helm-values.adoc#operatorsatellitesetkernelmoduleinjectionimage).
-    Then the operator will compile and load the required modules.
+- Prepare the hosts for DRBD deployment. This depends on your host OS. You can find more information on the available
+  options in the [host setup guide](./doc/host-setup.md).
 
 - If you are deploying with images from private repositories, create
   a kubernetes secret to allow obtaining the images. This example will create
@@ -38,7 +33,7 @@ The operator can be deployed with Helm v3 chart in /charts as follows:
     The name of this secret must match the one specified in the Helm values, by
     passing `--set drbdRepoCred=drbdiocred` to helm.
 
-* Configure storage for the LINSTOR etcd instance.
+- Configure storage for the LINSTOR etcd instance.
   There are various options for configuring the etcd instance for LINSTOR:
   * Use an existing storage provisioner with a default `StorageClass`.
   * [Use `hostPath` volumes](#linstor-etcd-hostpath-persistence).

--- a/doc/host-setup.md
+++ b/doc/host-setup.md
@@ -1,0 +1,65 @@
+# Preparing the host for DRBD
+
+Piraeus depends on DRBD for data replication across multiple nodes. [DRBD] is a kernel module that must be loaded on
+every node that should access the storage. Depending on your exact host OS and set up, you can choose **one** from the
+following options to load DRBD:
+
+[DRBD]: https://github.com/LINBIT/drbd/
+
+## Build and load DRBD using the Kernel Module Injection Image (Preferred)
+
+Every satellite container created by the operator will use an [InitContainer] to ensure DRBD is available. This init
+step can also compile and load DRBD directly. To build DRBD, the container needs access to the kernel sources. It will
+look for the sources on the host under `/usr/src` and `/lib/modules/$(uname -r)`. Most distributions provide a convenient package
+for the kernel source:
+
+* Ubuntu: `apt-get install linux-headers-$(uname -r)`
+* CentOS: `yum install kernel-devel-$(uname -r)`
+
+Install these packages and use the injector image matching your distribution:
+
+* CentOS 7: `quay.io/piraeusdatastore/drbd9-centos7`
+* CentOS 8: `quay.io/piraeusdatastore/drbd9-centos8` (See [#137] for CentOS 8 Stream)
+* Ubuntu 20.04: `quay.io/piraeusdatastore/drbd9-focal`
+* Ubuntu 18.04: `quay.io/piraeusdatastore/drbd9-bionic`
+
+You can set the image by passing `--set operator.satelliteSet.kernelModuleInjectionImage=<image>` to Helm.
+
+[InitContainer]: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+[#137]: https://github.com/piraeusdatastore/piraeus-operator/issues/137
+
+## Install DRBD on the host
+
+Some users may prefer to install the DRBD directly on the host. While a DRBD package is available on some distributions,
+they are often out of date and can't be used for Piraeus. Instead, you should follow the [link to DRBDs user guide] to
+ensure you install a recent enough version. After that, please read the instructions below to make DRBD ready for
+containerized workloads.
+
+[link to DRBDs user guide]: https://www.linbit.com/drbd-user-guide/users-guide-9-0/#p-build-install-configure
+
+You have to disable DRBD's user mode helper. This feature of the DRBD module enables running user configured commands on
+changes in DRBDs state. When using it with containers, it could confuse programs that expect to know of all configured
+DRBD resources, such as the default `drbdadm`. This command then reports an error, which is interpreted by DRBD to abort
+the current transition. In the end, you are left with a lot of `StandAlone` resources that can't be used.
+
+To prevent this issue, you have to set the DRBD module parameter `usermode_helper` to `disabled`. To check the current
+value, run:
+
+```
+# cat /sys/module/drbd/parameters/usermode_helper
+/sbin/drbdadm
+```
+
+To disable the helper without reloading the module _AND_ ensure it persist after reboots use:
+
+```
+# echo -n "disabled" > /sys/module/drbd/parameters/usermode_helper
+# echo "options drbd usermode_helper=disabled" > /etc/modprobe.d/drbd.conf
+```
+
+Checking the current value again will reveal that the helper is now disabled
+
+```
+# cat /sys/module/drbd/parameters/usermode_helper
+disabled
+```


### PR DESCRIPTION
Expand on the two different ways to install DRBD on the cluster.
* Mark injector image as the preferred install method.
* List available injector images.
* Add instructions on how to disable the usermode_helper on host installs.

Fixes #145 