### PR TITLE
changed gcr.io/google_containers/kube-scheduler-amd64 to k8s.gcr.io/k…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ helm-values:
 	cp ./charts/piraeus/values.yaml ./charts/piraeus/values.cn.yaml
 	sed 's|gcr.io/etcd-development/etcd|daocloud.io/piraeus/etcd|' -i ./charts/piraeus/values.cn.yaml
 	sed 's|docker.io/openstorage/stork|daocloud.io/piraeus/stork|' -i ./charts/piraeus/values.cn.yaml
-	sed 's|gcr.io/google_containers/kube-scheduler-amd64|daocloud.io/piraeus/kube-scheduler-amd64|' -i ./charts/piraeus/values.cn.yaml
+	sed 's|k8s.gcr.io/kube-scheduler-amd64|daocloud.io/piraeus/kube-scheduler-amd64|' -i ./charts/piraeus/values.cn.yaml
 	sed 's|quay.io/piraeusdatastore|daocloud.io/piraeus|' -i ./charts/piraeus/values.cn.yaml
 	sed 's|k8s.gcr.io/sig-storage|daocloud.io/piraeus|' -i ./charts/piraeus/values.cn.yaml
 	sed 's|quay.io/k8scsi|daocloud.io/piraeus|' -i ./charts/piraeus/values.cn.yaml

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -19,7 +19,7 @@ csi-snapshotter:
 stork:
   enabled: true
   storkImage: docker.io/openstorage/stork:2.5.0
-  schedulerImage: gcr.io/google_containers/kube-scheduler-amd64
+  schedulerImage: k8s.gcr.io/kube-scheduler-amd64
   schedulerTag: ""
   replicas: 1
   storkResources: {} # resources requirements for the stork plugin containers

--- a/deploy/piraeus/templates/stork-deployment.yaml
+++ b/deploy/piraeus/templates/stork-deployment.yaml
@@ -259,7 +259,7 @@ spec:
             - --policy-configmap-namespace=default
             - --leader-elect-resource-name=piraeus-op-stork-scheduler
             - --leader-elect-resource-namespace=default
-          image: "gcr.io/google_containers/kube-scheduler-amd64:v1.18.0"
+          image: "k8s.gcr.io/kube-scheduler-amd64:v1.18.0"
           imagePullPolicy: "IfNotPresent"
           livenessProbe:
             httpGet:

--- a/doc/helm-values.adoc
+++ b/doc/helm-values.adoc
@@ -479,7 +479,7 @@ Valid values:: https://kubernetes.io/docs/concepts/configuration/manage-resource
 Description:: Resource requests and limits to apply to the kube scheduler containers.
 
 === `stork.schedulerImage`
-Default:: `gcr.io/google_containers/kube-scheduler-amd64`
+Default:: `k8s.gcr.io/kube-scheduler-amd64`
 Valid values:: image name
 Description:: (Base) name of the kube-scheduler image. Will be joined with `schedulerTag`
 


### PR DESCRIPTION
Hi,
firstly, thanks for the great product! :)

I tried piraeus-operator with tungsten fabric vRouter CNI, and it looks working well.
https://github.com/tnaganawa/tungstenfabric-docs/blob/master/TungstenFabricKnowledgeBase.md#piraeus-integration

One thing I noticed is that when I used kubernetes v1.17.16, stork-scheduler became ImagePullBackOff status, 
`
piraeus-op-stork-scheduler-57cbfdb6c8-hxpw2   0/1     ImagePullBackOff   0          70m
`

since gcr.io/google_containers/kube-scheduler-amd64 is not updated currently.
 - v1.17.10 and later is not uploaded, and moved to k8s.gcr.io/kube-scheduler-amd64 instead.
https://groups.google.com/g/kubernetes-sig-release/c/ew-k9PEBckQ/m/T7dFepHdCAAJ
https://github.com/kubernetes/kubeadm/issues/2051
https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/kube-scheduler-amd64?gcrImageListsize=30

This pull request is to fix this.


Best Regards,
Tatsuya