### PR TITLE
add nodename to controller pod

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -75,6 +75,7 @@ linters:
     - gochecknoinits
     - dupl
     - goerr113
+    - exhaustivestruct
   fast: false
 
 issues:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Set node name variable for Controller Pods, enabling [k8s-await-election] to correctly set up the endpoint for
+  hairpin mode.
+
+[k8s-await-election]: https://github.com/LINBIT/k8s-await-election/commit/60748fcec722e4c32b8881c4c84957cc50543db2
+
 ## [v1.3.1] - 2021-01-14
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,12 @@ go 1.13
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/LINBIT/golinstor v0.33.0
-	github.com/linbit/k8s-await-election v0.2.0
+	github.com/linbit/k8s-await-election v0.2.3
 	github.com/operator-framework/operator-sdk v0.19.4
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/pflag v1.0.5
 	gopkg.in/ini.v1 v1.51.0
-	k8s.io/api v0.18.2
+	k8s.io/api v0.18.4
 	k8s.io/apimachinery v0.18.4
 	k8s.io/client-go v12.0.0+incompatible
 	sigs.k8s.io/controller-runtime v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -620,8 +620,8 @@ github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhn
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.0/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
-github.com/linbit/k8s-await-election v0.2.0 h1:ICvl2wd4h6mWgsdMumJ6e2/NS0Mp11DvK2cM/a3l2jw=
-github.com/linbit/k8s-await-election v0.2.0/go.mod h1:VCRtUTvVQmfNyqW7OSNyCOCh9mi29fgQ75XtUIfP5WE=
+github.com/linbit/k8s-await-election v0.2.3 h1:tkPE8uZlfc11CoN2fb60G/6g9Jo+jASnEhri3Yda3jU=
+github.com/linbit/k8s-await-election v0.2.3/go.mod h1:IMIPDtDARsF51IqxI6PQ/Rk4lf40awlwDEyPIpuua2c=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/lithammer/shortuuid v3.0.0+incompatible h1:NcD0xWW/MZYXEHa6ITy6kaXN5nwm/V115vj2YXfhS0w=
 github.com/lithammer/shortuuid v3.0.0+incompatible/go.mod h1:FR74pbAuElzOUuenUHTK2Tciko1/vKuIKS9dSkDrA4w=
@@ -1371,6 +1371,8 @@ k8s.io/api v0.0.0-20191122220107-b5267f2975e0/go.mod h1:vYpRfxYkMrmPPSesoHEkGNHx
 k8s.io/api v0.18.0/go.mod h1:q2HRQkfDzHMBZL9l/y9rH63PkQl4vae0xRT+8prbrK8=
 k8s.io/api v0.18.2 h1:wG5g5ZmSVgm5B+eHMIbI9EGATS2L8Z72rda19RIEgY8=
 k8s.io/api v0.18.2/go.mod h1:SJCWI7OLzhZSvbY7U8zwNl9UA4o1fizoug34OV/2r78=
+k8s.io/api v0.18.4 h1:8x49nBRxuXGUlDlwlWd3RMY1SayZrzFfxea3UZSkFw4=
+k8s.io/api v0.18.4/go.mod h1:lOIQAKYgai1+vz9J7YcDZwC26Z0zQewYOGWdyIPUUQ4=
 k8s.io/apiextensions-apiserver v0.0.0-20190918161926-8f644eb6e783/go.mod h1:xvae1SZB3E17UpV59AWc271W/Ph25N+bjPyR63X6tPY=
 k8s.io/apiextensions-apiserver v0.18.0/go.mod h1:18Cwn1Xws4xnWQNC00FLq1E350b9lUF+aOdIWDOZxgo=
 k8s.io/apiextensions-apiserver v0.18.2 h1:I4v3/jAuQC+89L3Z7dDgAiN4EOjN6sbm6iBqQwHTah8=

--- a/pkg/controller/linstorcontroller/linstorcontroller_controller.go
+++ b/pkg/controller/linstorcontroller/linstorcontroller_controller.go
@@ -607,6 +607,14 @@ func newDeploymentForResource(controllerResource *piraeusv1.LinstorController) *
 			},
 		},
 		{
+			Name: awaitelection.AwaitElectionNodeName,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "spec.nodeName",
+				},
+			},
+		},
+		{
 			Name:  awaitelection.AwaitElectionServiceName,
 			Value: controllerResource.Name,
 		},


### PR DESCRIPTION
When the nodename environment variable is set, newer versions of
k8s-await-election will use it to set the node name on created endpoints.
This enables Kubernetes' "hairpin mode", which is required for pods to
access their own service. This fixes an issue were linstor client commands
executed from the controller Pod would time out.