### PR TITLE
truncate hostname in Job name

### DIFF
--- a/charts/pv-hostpath/templates/pv.yaml
+++ b/charts/pv-hostpath/templates/pv.yaml
@@ -94,7 +94,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ $.Release.Name }}-{{ . }}-chown
+  name: {{ $.Release.Name }}-{{ . | trunc 43 }}-chown
   namespace: {{ $.Release.Namespace | default "default" }}
   labels:
 {{ include "post-install-labels" $ | indent 4 }}


### PR DESCRIPTION
When hostname is long, Job name also could be longer than 63 characters and Job creation fail.
Add trunc to avoid this.

Signed-off-by: Tatsuya Naganawa <tatsuyan201101@gmail.com>