### PR TITLE
Allow customizing controller env and properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Additional environment variables and Linstor properties can now be set in the `LinstorController` CRD.
 * Set node name variable for Controller Pods, enabling [k8s-await-election] to correctly set up the endpoint for
   hairpin mode.
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,15 @@ REGISTRY ?= piraeusdatastore
 TAG ?= latest
 NOCACHE ?= false
 
+# Some operator-sdk versions struggle when these are not set, even if go
+# is perfectly content with using sane defaults. So we just query go on
+# what these defaults are
+GOROOT ?= $(shell go env GOROOT)
+GOPATH ?= $(shell go env GOPATH)
+OPERATORSDK ?= operator-sdk
+
+OPERATORSDKCMD := GOROOT=$(GOROOT) GOPATH=$(GOPATH) $(OPERATORSDK)
+
 help:
 	@echo "Useful targets: 'update', 'upload'"
 
@@ -10,7 +19,7 @@ all: update upload
 
 .PHONY: update
 update:
-	operator-sdk build --image-build-args "--no-cache=$(NOCACHE)" $(PROJECT):$(TAG)
+	$(OPERATORSDKCMD) build --image-build-args "--no-cache=$(NOCACHE)" $(PROJECT):$(TAG)
 	docker tag $(PROJECT):$(TAG) $(PROJECT):latest
 
 .PHONY: upload
@@ -26,10 +35,10 @@ test:
 	go test ./...
 
 deep-copy:
-	operator-sdk generate k8s
+	$(OPERATORSDKCMD) generate k8s
 
 crds:
-	operator-sdk generate crds
+	$(OPERATORSDKCMD) generate crds
 	mv ./deploy/crds/* ./charts/piraeus/crds
 
 helm-values:

--- a/charts/piraeus/crds/piraeus.linbit.com_linstorcontrollers_crd.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstorcontrollers_crd.yaml
@@ -31,6 +31,118 @@ spec:
           spec:
             description: LinstorControllerSpec defines the desired state of LinstorController
             properties:
+              additionalEnv:
+                description: AdditionalEnv is a list of extra environments variables
+                  to pass to the controller container
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: 'Variable references $(VAR_NAME) are expanded using
+                        the previous defined environment variables in the container
+                        and any service environment variables. If a variable cannot
+                        be resolved, the reference in the input string will be unchanged.
+                        The $(VAR_NAME) syntax can be escaped with a double $$, ie:
+                        $$(VAR_NAME). Escaped references will never be expanded, regardless
+                        of whether the variable exists or not. Defaults to "".'
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, metadata.labels, metadata.annotations,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP,
+                            status.podIP, status.podIPs.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only
+                            resources limits and requests (limits.cpu, limits.memory,
+                            limits.ephemeral-storage, requests.cpu, requests.memory
+                            and requests.ephemeral-storage) are currently supported.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                nullable: true
+                type: array
+              additionalProperties:
+                additionalProperties:
+                  type: string
+                description: AdditionalProperties is a map of additional properties
+                  to set on the Linstor controller
+                nullable: true
+                type: object
               affinity:
                 description: Affinity for scheduling the controller pod
                 nullable: true
@@ -835,6 +947,11 @@ spec:
                   - storagePoolStatus
                   type: object
                 type: array
+              controllerProperties:
+                additionalProperties:
+                  type: string
+                description: properties set on the Linstor controller
+                type: object
               errors:
                 description: Errors remaining that will trigger reconciliations.
                 items:
@@ -843,6 +960,7 @@ spec:
             required:
             - ControllerStatus
             - SatelliteStatuses
+            - controllerProperties
             - errors
             type: object
         type: object

--- a/charts/piraeus/templates/operator-controller.yaml
+++ b/charts/piraeus/templates/operator-controller.yaml
@@ -22,4 +22,6 @@ spec:
   tolerations: {{ .Values.operator.controller.tolerations | toJson}}
   resources: {{ .Values.operator.controller.resources | toJson }}
   replicas: {{ .Values.operator.controller.replicas }}
+  additionalEnv: {{ .Values.operator.controller.additionalEnv | toJson }}
+  additionalProperties: {{ .Values.operator.controller.additionalProperties | toJson }}
 {{- end }}

--- a/charts/piraeus/values.cn.yaml
+++ b/charts/piraeus/values.cn.yaml
@@ -70,6 +70,8 @@ operator:
         effect: "NoSchedule"
     resources: {}
     replicas: 1
+    additionalEnv: []
+    additionalProperties: {}
   satelliteSet:
     enabled: true
     satelliteImage: daocloud.io/piraeus/piraeus-server:v1.11.1

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -70,6 +70,8 @@ operator:
         effect: "NoSchedule"
     resources: {}
     replicas: 1
+    additionalEnv: []
+    additionalProperties: {}
   satelliteSet:
     enabled: true
     satelliteImage: quay.io/piraeusdatastore/piraeus-server:v1.11.1

--- a/deploy/piraeus/templates/operator-controller.yaml
+++ b/deploy/piraeus/templates/operator-controller.yaml
@@ -20,3 +20,5 @@ spec:
   tolerations: [{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"}]
   resources: {}
   replicas: 1
+  additionalEnv: []
+  additionalProperties: {}

--- a/doc/helm-values.adoc
+++ b/doc/helm-values.adoc
@@ -356,6 +356,18 @@ Valid values:: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and
 Description:: Tolerations to pass to the controller pods.
 
 
+=== `operator.controller.additonalEnv`
+Default:: `[]`
+Valid values:: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/[EnvVar list]
+Description:: A list of additional environment variables to pass to the Linstor controller container.
+
+
+=== `operator.controller.additionalProperties`
+Default:: `{}`
+Valid values:: A map with string keys and values
+Description:: A map of properties to set on the Linstor Controller, equivalent to
+calling `linstor controller set-property <key> <value>`
+
 == Piraeus Satellites
 
 === `operator.satelliteSet.enabled`

--- a/pkg/apis/piraeus/v1/linstorcontroller_types.go
+++ b/pkg/apis/piraeus/v1/linstorcontroller_types.go
@@ -93,6 +93,16 @@ type LinstorControllerSpec struct {
 	// +nullable
 	Replicas *int32 `json:"replicas"`
 
+	// AdditionalEnv is a list of extra environments variables to pass to the controller container
+	// +optional
+	// +nullable
+	AdditionalEnv []corev1.EnvVar `json:"additionalEnv"`
+
+	// AdditionalProperties is a map of additional properties to set on the Linstor controller
+	// +optional
+	// +nullable
+	AdditionalProperties map[string]string `json:"additionalProperties"`
+
 	// Name of the service account that runs leader elections for linstor
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName"`
@@ -108,6 +118,8 @@ type LinstorControllerStatus struct {
 	ControllerStatus *shared.NodeStatus `json:"ControllerStatus"`
 	// SatelliteStatuses by hostname.
 	SatelliteStatuses []*shared.SatelliteStatus `json:"SatelliteStatuses"`
+	// properties set on the Linstor controller
+	ControllerProperties map[string]string `json:"controllerProperties"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/piraeus/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/piraeus/v1/zz_generated.deepcopy.go
@@ -243,6 +243,20 @@ func (in *LinstorControllerSpec) DeepCopyInto(out *LinstorControllerSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.AdditionalEnv != nil {
+		in, out := &in.AdditionalEnv, &out.AdditionalEnv
+		*out = make([]corev1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.AdditionalProperties != nil {
+		in, out := &in.AdditionalProperties, &out.AdditionalProperties
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	out.LinstorClientConfig = in.LinstorClientConfig
 	return
 }
@@ -279,6 +293,13 @@ func (in *LinstorControllerStatus) DeepCopyInto(out *LinstorControllerStatus) {
 				*out = new(shared.SatelliteStatus)
 				(*in).DeepCopyInto(*out)
 			}
+		}
+	}
+	if in.ControllerProperties != nil {
+		in, out := &in.ControllerProperties, &out.ControllerProperties
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
 		}
 	}
 	return

--- a/pkg/k8s/metadata/util/util_test.go
+++ b/pkg/k8s/metadata/util/util_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestContains(t *testing.T) {
-	var tableTest = []struct {
+	tableTest := []struct {
 		in       []string
 		has      string
 		expected bool
@@ -48,7 +48,7 @@ func TestContains(t *testing.T) {
 }
 
 func TestRemove(t *testing.T) {
-	var tableTest = []struct {
+	tableTest := []struct {
 		in       []string
 		remove   string
 		expected []string


### PR DESCRIPTION
Adds two new fields to the LinstorController CRD:
spec.additionalEnv, which is appended to the linstor controller env
spec.additionalProperties, which will set the given properties on the
  controller.

Closes #164 