### PR TITLE
Make ControllerProperties optional in status

### DIFF
--- a/charts/piraeus/crds/piraeus.linbit.com_linstorcontrollers_crd.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstorcontrollers_crd.yaml
@@ -879,6 +879,11 @@ spec:
           status:
             description: LinstorControllerStatus defines the observed state of LinstorController
             properties:
+              ControllerProperties:
+                additionalProperties:
+                  type: string
+                description: properties set on the Linstor controller
+                type: object
               ControllerStatus:
                 description: ControllerStatus information.
                 properties:
@@ -947,11 +952,6 @@ spec:
                   - storagePoolStatus
                   type: object
                 type: array
-              controllerProperties:
-                additionalProperties:
-                  type: string
-                description: properties set on the Linstor controller
-                type: object
               errors:
                 description: Errors remaining that will trigger reconciliations.
                 items:
@@ -960,7 +960,6 @@ spec:
             required:
             - ControllerStatus
             - SatelliteStatuses
-            - controllerProperties
             - errors
             type: object
         type: object

--- a/pkg/apis/piraeus/v1/linstorcontroller_types.go
+++ b/pkg/apis/piraeus/v1/linstorcontroller_types.go
@@ -119,7 +119,8 @@ type LinstorControllerStatus struct {
 	// SatelliteStatuses by hostname.
 	SatelliteStatuses []*shared.SatelliteStatus `json:"SatelliteStatuses"`
 	// properties set on the Linstor controller
-	ControllerProperties map[string]string `json:"controllerProperties"`
+	// +optional
+	ControllerProperties map[string]string `json:"ControllerProperties"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
To stay compatible with existing CRs, we need mark additional fields in the
status section optional as well. In addition, the ControllerProperties should
be capitalized, so the error section is always order last when printing.

Signed-off-by: Moritz "WanzenBug" Wanzenböck <moritz.wanzenboeck@linbit.com>