### PR TITLE
reconcile network interfaces in Linstor clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Set node name variable for Controller Pods, enabling [k8s-await-election] to correctly set up the endpoint for
   hairpin mode.
 
+### Fixed
+
+* Update the network address of controller pods if they diverged between Linstor and kubernetes. This can happen after
+  a node restart, where a pod is recreated with the same name but different IP address.
+
 [k8s-await-election]: https://github.com/LINBIT/k8s-await-election/commit/60748fcec722e4c32b8881c4c84957cc50543db2
 
 ## [v1.3.1] - 2021-01-14

--- a/pkg/controller/linstorcontroller/linstorcontroller_controller.go
+++ b/pkg/controller/linstorcontroller/linstorcontroller_controller.go
@@ -290,6 +290,7 @@ func (r *ReconcileLinstorController) reconcileControllers(ctx context.Context, c
 				{
 					Name:                    "default",
 					Address:                 pod.Status.PodIP,
+					IsActive:                true,
 					SatellitePort:           controllerResource.Spec.SslConfig.Port(),
 					SatelliteEncryptionType: controllerResource.Spec.SslConfig.Type(),
 				},

--- a/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
+++ b/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
@@ -436,6 +436,7 @@ func (r *ReconcileLinstorSatelliteSet) reconcileSingleNodeRegistration(ctx conte
 			{
 				Name:                    "default",
 				Address:                 pod.Status.HostIP,
+				IsActive:                true,
 				SatellitePort:           satelliteSet.Spec.SslConfig.Port(),
 				SatelliteEncryptionType: satelliteSet.Spec.SslConfig.Type(),
 			},


### PR DESCRIPTION
In some cases, such as a k8s node restart, a pod can change IP address, which
requires updating the net-interface of the node in Linstor.