### PR TITLE
switch to livenessprobe v2.2.0 - fix memleak

### DIFF
--- a/charts/piraeus/values.cn.yaml
+++ b/charts/piraeus/values.cn.yaml
@@ -29,7 +29,7 @@ csi:
   enabled: true
   pluginImage: daocloud.io/piraeus/piraeus-csi:v0.11.0
   csiAttacherImage: daocloud.io/piraeus/csi-attacher:v3.0.2
-  csiLivenessProbeImage: daocloud.io/piraeus/livenessprobe:v2.1.0
+  csiLivenessProbeImage: daocloud.io/piraeus/livenessprobe:v2.2.0
   csiNodeDriverRegistrarImage: daocloud.io/piraeus/csi-node-driver-registrar:v2.0.1
   csiProvisionerImage: daocloud.io/piraeus/csi-provisioner:v2.0.4
   csiSnapshotterImage: daocloud.io/piraeus/csi-snapshotter:v3.0.2

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -29,7 +29,7 @@ csi:
   enabled: true
   pluginImage: quay.io/piraeusdatastore/piraeus-csi:v0.11.0
   csiAttacherImage: k8s.gcr.io/sig-storage/csi-attacher:v3.0.2
-  csiLivenessProbeImage: k8s.gcr.io/sig-storage/livenessprobe:v2.1.0
+  csiLivenessProbeImage: k8s.gcr.io/sig-storage/livenessprobe:v2.2.0
   csiNodeDriverRegistrarImage: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1
   csiProvisionerImage: k8s.gcr.io/sig-storage/csi-provisioner:v2.0.4
   csiSnapshotterImage: k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.2

--- a/deploy/piraeus/templates/operator-csi-driver.yaml
+++ b/deploy/piraeus/templates/operator-csi-driver.yaml
@@ -12,7 +12,7 @@ spec:
   csiControllerServiceAccountName: csi-controller
   csiNodeServiceAccountName: csi-node
   csiAttacherImage: "k8s.gcr.io/sig-storage/csi-attacher:v3.0.2"
-  csiLivenessProbeImage: "k8s.gcr.io/sig-storage/livenessprobe:v2.1.0"
+  csiLivenessProbeImage: "k8s.gcr.io/sig-storage/livenessprobe:v2.2.0"
   csiNodeDriverRegistrarImage: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1"
   csiProvisionerImage: "k8s.gcr.io/sig-storage/csi-provisioner:v2.0.4"
   csiResizerImage: "k8s.gcr.io/sig-storage/csi-resizer:v1.0.1"


### PR DESCRIPTION
This fixes a memory leak as discussed here:
https://github.com/kubernetes-csi/livenessprobe/issues/91

and fixed here:
https://github.com/kubernetes-csi/livenessprobe/pull/94

Signed-off-by: Roland Kammerer <roland.kammerer@linbit.com>