### PR TITLE
Remove csi node pods from host-network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- CSI Nodes no longer use `hostNetwork: true`. The pods already got the correct hostname via the downwardAPI and do not
+  talk to DRBD's netlink interface directly.
+
 ## [v1.4.0] - 2021-04-07
 
 ### Added

--- a/pkg/controller/linstorcsidriver/linstorcsidriver_controller.go
+++ b/pkg/controller/linstorcsidriver/linstorcsidriver_controller.go
@@ -551,7 +551,6 @@ func newCSINodeDaemonSet(csiResource *piraeusv1.LinstorCSIDriver) *appsv1.Daemon
 						podsMountDir,
 						registrationDir,
 					},
-					HostNetwork:      true,
 					DNSPolicy:        corev1.DNSClusterFirstWithHostNet,
 					ImagePullSecrets: pullSecrets,
 					Affinity:         csiResource.Spec.NodeAffinity,


### PR DESCRIPTION
CSI Pods work just fine in the normal pod network. This way they also
play nicer with NetworkPolicies.