### PR TITLE
chart: update crds for snapshot controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - CSI Nodes no longer use `hostNetwork: true`. The pods already got the correct hostname via the downwardAPI and do not
   talk to DRBD's netlink interface directly.
+- External: CSI snapshotter subchart now packages `v1` CRDs. Fixes deprecation warnings when installing
+  the snapshot controller.
 
 ## [v1.4.0] - 2021-04-07
 

--- a/charts/piraeus/Chart.yaml
+++ b/charts/piraeus/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: "0.7.4"
     condition: etcd.enabled
   - name: "csi-snapshotter"
-    version: "1.0.0"
+    version: "1.1.0"
     condition: csi-snapshotter.enabled

--- a/charts/piraeus/charts/csi-snapshotter/Chart.yaml
+++ b/charts/piraeus/charts/csi-snapshotter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: csi-snapshotter
 description: A Helm chart for adding CSI snapshotting to Kubernetes
 type: application
-version: 1.0.0
-appVersion: 2.0.1
+version: 1.1.0
+appVersion: 3.0.3

--- a/charts/piraeus/charts/csi-snapshotter/crds/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+++ b/charts/piraeus/charts/csi-snapshotter/crds/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
@@ -1,82 +1,81 @@
-# Source: https://github.com/kubernetes-csi/external-snapshotter/blob/v2.1.1/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+# Source: https://github.com/kubernetes-csi/external-snapshotter/blob/v3.0.3/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
-    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-csi-snapshotter/pull/260"
+    controller-gen.kubebuilder.io/version: v0.3.0
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/139"
   creationTimestamp: null
   name: volumesnapshotclasses.snapshot.storage.k8s.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .driver
-    name: Driver
-    type: string
-  - JSONPath: .deletionPolicy
-    description: Determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass
-      should be deleted when its bound VolumeSnapshot is deleted.
-    name: DeletionPolicy
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: snapshot.storage.k8s.io
   names:
     kind: VolumeSnapshotClass
     listKind: VolumeSnapshotClassList
     plural: volumesnapshotclasses
     singular: volumesnapshotclass
-  preserveUnknownFields: false
   scope: Cluster
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: VolumeSnapshotClass specifies parameters that a underlying storage
-        system uses when creating a volume snapshot. A specific VolumeSnapshotClass
-        is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses
-        are non-namespaced
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        deletionPolicy:
-          description: deletionPolicy determines whether a VolumeSnapshotContent created
-            through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot
-            is deleted. Supported values are "Retain" and "Delete". "Retain" means
-            that the VolumeSnapshotContent and its physical snapshot on underlying
-            storage system are kept. "Delete" means that the VolumeSnapshotContent
-            and its physical snapshot on underlying storage system are deleted. Required.
-          enum:
-          - Delete
-          - Retain
-          type: string
-        driver:
-          description: driver is the name of the storage driver that handles this
-            VolumeSnapshotClass. Required.
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        parameters:
-          additionalProperties:
-            type: string
-          description: parameters is a key-value map with storage driver specific
-            parameters for creating snapshots. These values are opaque to Kubernetes.
-          type: object
-      required:
-      - deletionPolicy
-      - driver
-      type: object
-  version: v1beta1
   versions:
-  - name: v1beta1
-    served: true
-    storage: true
+    - additionalPrinterColumns:
+        - jsonPath: .driver
+          name: Driver
+          type: string
+        - description: Determines whether a VolumeSnapshotContent created through the
+            VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted.
+          jsonPath: .deletionPolicy
+          name: DeletionPolicy
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: VolumeSnapshotClass specifies parameters that a underlying storage
+            system uses when creating a volume snapshot. A specific VolumeSnapshotClass
+            is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses
+            are non-namespaced
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            deletionPolicy:
+              description: deletionPolicy determines whether a VolumeSnapshotContent
+                created through the VolumeSnapshotClass should be deleted when its bound
+                VolumeSnapshot is deleted. Supported values are "Retain" and "Delete".
+                "Retain" means that the VolumeSnapshotContent and its physical snapshot
+                on underlying storage system are kept. "Delete" means that the VolumeSnapshotContent
+                and its physical snapshot on underlying storage system are deleted.
+                Required.
+              enum:
+                - Delete
+                - Retain
+              type: string
+            driver:
+              description: driver is the name of the storage driver that handles this
+                VolumeSnapshotClass. Required.
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            parameters:
+              additionalProperties:
+                type: string
+              description: parameters is a key-value map with storage driver specific
+                parameters for creating snapshots. These values are opaque to Kubernetes.
+              type: object
+          required:
+            - deletionPolicy
+            - driver
+          type: object
+      served: true
+      storage: true
+      subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/piraeus/charts/csi-snapshotter/crds/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+++ b/charts/piraeus/charts/csi-snapshotter/crds/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
@@ -1,230 +1,230 @@
-# Source: https://github.com/kubernetes-csi/external-snapshotter/blob/v2.1.1/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+# Source: https://github.com/kubernetes-csi/external-snapshotter/blob/v3.0.3/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
-    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-csi-snapshotter/pull/260"
+    controller-gen.kubebuilder.io/version: v0.3.0
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/139"
   creationTimestamp: null
   name: volumesnapshotcontents.snapshot.storage.k8s.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.readyToUse
-    description: Indicates if a snapshot is ready to be used to restore a volume.
-    name: ReadyToUse
-    type: boolean
-  - JSONPath: .status.restoreSize
-    description: Represents the complete size of the snapshot in bytes
-    name: RestoreSize
-    type: integer
-  - JSONPath: .spec.deletionPolicy
-    description: Determines whether this VolumeSnapshotContent and its physical snapshot
-      on the underlying storage system should be deleted when its bound VolumeSnapshot
-      is deleted.
-    name: DeletionPolicy
-    type: string
-  - JSONPath: .spec.driver
-    description: Name of the CSI driver used to create the physical snapshot on the
-      underlying storage system.
-    name: Driver
-    type: string
-  - JSONPath: .spec.volumeSnapshotClassName
-    description: Name of the VolumeSnapshotClass to which this snapshot belongs.
-    name: VolumeSnapshotClass
-    type: string
-  - JSONPath: .spec.volumeSnapshotRef.name
-    description: Name of the VolumeSnapshot object to which this VolumeSnapshotContent
-      object is bound.
-    name: VolumeSnapshot
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: snapshot.storage.k8s.io
   names:
     kind: VolumeSnapshotContent
     listKind: VolumeSnapshotContentList
     plural: volumesnapshotcontents
     singular: volumesnapshotcontent
-  preserveUnknownFields: false
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: VolumeSnapshotContent represents the actual "on-disk" snapshot
-        object in the underlying storage system
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+  versions:
+    - additionalPrinterColumns:
+        - description: Indicates if a snapshot is ready to be used to restore a volume.
+          jsonPath: .status.readyToUse
+          name: ReadyToUse
+          type: boolean
+        - description: Represents the complete size of the snapshot in bytes
+          jsonPath: .status.restoreSize
+          name: RestoreSize
+          type: integer
+        - description: Determines whether this VolumeSnapshotContent and its physical
+            snapshot on the underlying storage system should be deleted when its bound
+            VolumeSnapshot is deleted.
+          jsonPath: .spec.deletionPolicy
+          name: DeletionPolicy
           type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        - description: Name of the CSI driver used to create the physical snapshot on
+            the underlying storage system.
+          jsonPath: .spec.driver
+          name: Driver
           type: string
-        spec:
-          description: spec defines properties of a VolumeSnapshotContent created
-            by the underlying storage system. Required.
+        - description: Name of the VolumeSnapshotClass to which this snapshot belongs.
+          jsonPath: .spec.volumeSnapshotClassName
+          name: VolumeSnapshotClass
+          type: string
+        - description: Name of the VolumeSnapshot object to which this VolumeSnapshotContent
+            object is bound.
+          jsonPath: .spec.volumeSnapshotRef.name
+          name: VolumeSnapshot
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: VolumeSnapshotContent represents the actual "on-disk" snapshot
+            object in the underlying storage system
           properties:
-            deletionPolicy:
-              description: deletionPolicy determines whether this VolumeSnapshotContent
-                and its physical snapshot on the underlying storage system should
-                be deleted when its bound VolumeSnapshot is deleted. Supported values
-                are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent
-                and its physical snapshot on underlying storage system are kept. "Delete"
-                means that the VolumeSnapshotContent and its physical snapshot on
-                underlying storage system are deleted. In dynamic snapshot creation
-                case, this field will be filled in with the "DeletionPolicy" field
-                defined in the VolumeSnapshotClass the VolumeSnapshot refers to. For
-                pre-existing snapshots, users MUST specify this field when creating
-                the VolumeSnapshotContent object. Required.
-              enum:
-              - Delete
-              - Retain
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
-            driver:
-              description: driver is the name of the CSI driver used to create the
-                physical snapshot on the underlying storage system. This MUST be the
-                same as the name returned by the CSI GetPluginName() call for that
-                driver. Required.
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
-            source:
-              description: source specifies from where a snapshot will be created.
-                This field is immutable after creation. Required.
+            spec:
+              description: spec defines properties of a VolumeSnapshotContent created
+                by the underlying storage system. Required.
               properties:
-                snapshotHandle:
-                  description: snapshotHandle specifies the CSI "snapshot_id" of a
-                    pre-existing snapshot on the underlying storage system. This field
-                    is immutable.
+                deletionPolicy:
+                  description: deletionPolicy determines whether this VolumeSnapshotContent
+                    and its physical snapshot on the underlying storage system should
+                    be deleted when its bound VolumeSnapshot is deleted. Supported values
+                    are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent
+                    and its physical snapshot on underlying storage system are kept.
+                    "Delete" means that the VolumeSnapshotContent and its physical snapshot
+                    on underlying storage system are deleted. In dynamic snapshot creation
+                    case, this field will be filled in with the "DeletionPolicy" field
+                    defined in the VolumeSnapshotClass the VolumeSnapshot refers to.
+                    For pre-existing snapshots, users MUST specify this field when creating
+                    the VolumeSnapshotContent object. Required.
+                  enum:
+                    - Delete
+                    - Retain
                   type: string
-                volumeHandle:
-                  description: volumeHandle specifies the CSI "volume_id" of the volume
-                    from which a snapshot should be dynamically taken from. This field
-                    is immutable.
+                driver:
+                  description: driver is the name of the CSI driver used to create the
+                    physical snapshot on the underlying storage system. This MUST be
+                    the same as the name returned by the CSI GetPluginName() call for
+                    that driver. Required.
                   type: string
+                source:
+                  description: source specifies from where a snapshot will be created.
+                    This field is immutable after creation. Required.
+                  properties:
+                    snapshotHandle:
+                      description: snapshotHandle specifies the CSI "snapshot_id" of
+                        a pre-existing snapshot on the underlying storage system. This
+                        field is immutable.
+                      type: string
+                    volumeHandle:
+                      description: volumeHandle specifies the CSI "volume_id" of the
+                        volume from which a snapshot should be dynamically taken from.
+                        This field is immutable.
+                      type: string
+                  type: object
+                volumeSnapshotClassName:
+                  description: name of the VolumeSnapshotClass to which this snapshot
+                    belongs.
+                  type: string
+                volumeSnapshotRef:
+                  description: volumeSnapshotRef specifies the VolumeSnapshot object
+                    to which this VolumeSnapshotContent object is bound. VolumeSnapshot.Spec.VolumeSnapshotContentName
+                    field must reference to this VolumeSnapshotContent's name for the
+                    bidirectional binding to be valid. For a pre-existing VolumeSnapshotContent
+                    object, name and namespace of the VolumeSnapshot object MUST be
+                    provided for binding to happen. This field is immutable after creation.
+                    Required.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+              required:
+                - deletionPolicy
+                - driver
+                - source
+                - volumeSnapshotRef
               type: object
-            volumeSnapshotClassName:
-              description: name of the VolumeSnapshotClass to which this snapshot
-                belongs.
-              type: string
-            volumeSnapshotRef:
-              description: volumeSnapshotRef specifies the VolumeSnapshot object to
-                which this VolumeSnapshotContent object is bound. VolumeSnapshot.Spec.VolumeSnapshotContentName
-                field must reference to this VolumeSnapshotContent's name for the
-                bidirectional binding to be valid. For a pre-existing VolumeSnapshotContent
-                object, name and namespace of the VolumeSnapshot object MUST be provided
-                for binding to happen. This field is immutable after creation. Required.
+            status:
+              description: status represents the current information of a snapshot.
               properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                creationTime:
+                  description: creationTime is the timestamp when the point-in-time
+                    snapshot is taken by the underlying storage system. In dynamic snapshot
+                    creation case, this field will be filled in with the "creation_time"
+                    value returned from CSI "CreateSnapshotRequest" gRPC call. For a
+                    pre-existing snapshot, this field will be filled with the "creation_time"
+                    value returned from the CSI "ListSnapshots" gRPC call if the driver
+                    supports it. If not specified, it indicates the creation time is
+                    unknown. The format of this field is a Unix nanoseconds time encoded
+                    as an int64. On Unix, the command `date +%s%N` returns the current
+                    time in nanoseconds since 1970-01-01 00:00:00 UTC.
+                  format: int64
+                  type: integer
+                error:
+                  description: error is the latest observed error during snapshot creation,
+                    if any.
+                  properties:
+                    message:
+                      description: 'message is a string detailing the encountered error
+                      during snapshot creation if specified. NOTE: message may be
+                      logged, and it should not contain sensitive information.'
+                      type: string
+                    time:
+                      description: time is the timestamp when the error was encountered.
+                      format: date-time
+                      type: string
+                  type: object
+                readyToUse:
+                  description: readyToUse indicates if a snapshot is ready to be used
+                    to restore a volume. In dynamic snapshot creation case, this field
+                    will be filled in with the "ready_to_use" value returned from CSI
+                    "CreateSnapshotRequest" gRPC call. For a pre-existing snapshot,
+                    this field will be filled with the "ready_to_use" value returned
+                    from the CSI "ListSnapshots" gRPC call if the driver supports it,
+                    otherwise, this field will be set to "True". If not specified, it
+                    means the readiness of a snapshot is unknown.
+                  type: boolean
+                restoreSize:
+                  description: restoreSize represents the complete size of the snapshot
+                    in bytes. In dynamic snapshot creation case, this field will be
+                    filled in with the "size_bytes" value returned from CSI "CreateSnapshotRequest"
+                    gRPC call. For a pre-existing snapshot, this field will be filled
+                    with the "size_bytes" value returned from the CSI "ListSnapshots"
+                    gRPC call if the driver supports it. When restoring a volume from
+                    this snapshot, the size of the volume MUST NOT be smaller than the
+                    restoreSize if it is specified, otherwise the restoration will fail.
+                    If not specified, it indicates that the size is unknown.
+                  format: int64
+                  minimum: 0
+                  type: integer
+                snapshotHandle:
+                  description: snapshotHandle is the CSI "snapshot_id" of a snapshot
+                    on the underlying storage system. If not specified, it indicates
+                    that dynamic snapshot creation has either failed or it is still
+                    in progress.
                   type: string
               type: object
           required:
-          - deletionPolicy
-          - driver
-          - source
-          - volumeSnapshotRef
+            - spec
           type: object
-        status:
-          description: status represents the current information of a snapshot.
-          properties:
-            creationTime:
-              description: creationTime is the timestamp when the point-in-time snapshot
-                is taken by the underlying storage system. In dynamic snapshot creation
-                case, this field will be filled in with the "creation_time" value
-                returned from CSI "CreateSnapshotRequest" gRPC call. For a pre-existing
-                snapshot, this field will be filled with the "creation_time" value
-                returned from the CSI "ListSnapshots" gRPC call if the driver supports
-                it. If not specified, it indicates the creation time is unknown. The
-                format of this field is a Unix nanoseconds time encoded as an int64.
-                On Unix, the command `date +%s%N` returns the current time in nanoseconds
-                since 1970-01-01 00:00:00 UTC.
-              format: int64
-              type: integer
-            error:
-              description: error is the latest observed error during snapshot creation,
-                if any.
-              properties:
-                message:
-                  description: 'message is a string detailing the encountered error
-                    during snapshot creation if specified. NOTE: message may be logged,
-                    and it should not contain sensitive information.'
-                  type: string
-                time:
-                  description: time is the timestamp when the error was encountered.
-                  format: date-time
-                  type: string
-              type: object
-            readyToUse:
-              description: readyToUse indicates if a snapshot is ready to be used
-                to restore a volume. In dynamic snapshot creation case, this field
-                will be filled in with the "ready_to_use" value returned from CSI
-                "CreateSnapshotRequest" gRPC call. For a pre-existing snapshot, this
-                field will be filled with the "ready_to_use" value returned from the
-                CSI "ListSnapshots" gRPC call if the driver supports it, otherwise,
-                this field will be set to "True". If not specified, it means the readiness
-                of a snapshot is unknown.
-              type: boolean
-            restoreSize:
-              description: restoreSize represents the complete size of the snapshot
-                in bytes. In dynamic snapshot creation case, this field will be filled
-                in with the "size_bytes" value returned from CSI "CreateSnapshotRequest"
-                gRPC call. For a pre-existing snapshot, this field will be filled
-                with the "size_bytes" value returned from the CSI "ListSnapshots"
-                gRPC call if the driver supports it. When restoring a volume from
-                this snapshot, the size of the volume MUST NOT be smaller than the
-                restoreSize if it is specified, otherwise the restoration will fail.
-                If not specified, it indicates that the size is unknown.
-              format: int64
-              minimum: 0
-              type: integer
-            snapshotHandle:
-              description: snapshotHandle is the CSI "snapshot_id" of a snapshot on
-                the underlying storage system. If not specified, it indicates that
-                dynamic snapshot creation has either failed or it is still in progress.
-              type: string
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1beta1
-  versions:
-  - name: v1beta1
-    served: true
-    storage: true
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/piraeus/charts/csi-snapshotter/crds/snapshot.storage.k8s.io_volumesnapshots.yaml
+++ b/charts/piraeus/charts/csi-snapshotter/crds/snapshot.storage.k8s.io_volumesnapshots.yaml
@@ -1,185 +1,181 @@
-# Source: https://github.com/kubernetes-csi/external-snapshotter/blob/v2.1.1/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+# Source: https://github.com/kubernetes-csi/external-snapshotter/blob/v3.0.3/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
-    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-csi-snapshotter/pull/260"
+    controller-gen.kubebuilder.io/version: v0.3.0
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/139"
   creationTimestamp: null
   name: volumesnapshots.snapshot.storage.k8s.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.readyToUse
-    description: Indicates if a snapshot is ready to be used to restore a volume.
-    name: ReadyToUse
-    type: boolean
-  - JSONPath: .spec.source.persistentVolumeClaimName
-    description: Name of the source PVC from where a dynamically taken snapshot will
-      be created.
-    name: SourcePVC
-    type: string
-  - JSONPath: .spec.source.volumeSnapshotContentName
-    description: Name of the VolumeSnapshotContent which represents a pre-provisioned
-      snapshot.
-    name: SourceSnapshotContent
-    type: string
-  - JSONPath: .status.restoreSize
-    description: Represents the complete size of the snapshot.
-    name: RestoreSize
-    type: string
-  - JSONPath: .spec.volumeSnapshotClassName
-    description: The name of the VolumeSnapshotClass requested by the VolumeSnapshot.
-    name: SnapshotClass
-    type: string
-  - JSONPath: .status.boundVolumeSnapshotContentName
-    description: The name of the VolumeSnapshotContent to which this VolumeSnapshot
-      is bound.
-    name: SnapshotContent
-    type: string
-  - JSONPath: .status.creationTime
-    description: Timestamp when the point-in-time snapshot is taken by the underlying
-      storage system.
-    name: CreationTime
-    type: date
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: snapshot.storage.k8s.io
   names:
     kind: VolumeSnapshot
     listKind: VolumeSnapshotList
     plural: volumesnapshots
     singular: volumesnapshot
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: VolumeSnapshot is a user's request for either creating a point-in-time
-        snapshot of a persistent volume, or binding to a pre-existing snapshot.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+  versions:
+    - additionalPrinterColumns:
+        - description: Indicates if a snapshot is ready to be used to restore a volume.
+          jsonPath: .status.readyToUse
+          name: ReadyToUse
+          type: boolean
+        - description: Name of the source PVC from where a dynamically taken snapshot
+            will be created.
+          jsonPath: .spec.source.persistentVolumeClaimName
+          name: SourcePVC
           type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        - description: Name of the VolumeSnapshotContent which represents a pre-provisioned
+            snapshot.
+          jsonPath: .spec.source.volumeSnapshotContentName
+          name: SourceSnapshotContent
           type: string
-        spec:
-          description: 'spec defines the desired characteristics of a snapshot requested
-            by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots
-            Required.'
+        - description: Represents the complete size of the snapshot.
+          jsonPath: .status.restoreSize
+          name: RestoreSize
+          type: string
+        - description: The name of the VolumeSnapshotClass requested by the VolumeSnapshot.
+          jsonPath: .spec.volumeSnapshotClassName
+          name: SnapshotClass
+          type: string
+        - description: The name of the VolumeSnapshotContent to which this VolumeSnapshot
+            is bound.
+          jsonPath: .status.boundVolumeSnapshotContentName
+          name: SnapshotContent
+          type: string
+        - description: Timestamp when the point-in-time snapshot is taken by the underlying
+            storage system.
+          jsonPath: .status.creationTime
+          name: CreationTime
+          type: date
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: VolumeSnapshot is a user's request for either creating a point-in-time
+            snapshot of a persistent volume, or binding to a pre-existing snapshot.
           properties:
-            source:
-              description: source specifies where a snapshot will be created from.
-                This field is immutable after creation. Required.
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            spec:
+              description: 'spec defines the desired characteristics of a snapshot requested
+              by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots
+              Required.'
               properties:
-                persistentVolumeClaimName:
-                  description: persistentVolumeClaimName specifies the name of the
-                    PersistentVolumeClaim object in the same namespace as the VolumeSnapshot
-                    object where the snapshot should be dynamically taken from. This
-                    field is immutable.
+                source:
+                  description: source specifies where a snapshot will be created from.
+                    This field is immutable after creation. Required.
+                  properties:
+                    persistentVolumeClaimName:
+                      description: persistentVolumeClaimName specifies the name of the
+                        PersistentVolumeClaim object in the same namespace as the VolumeSnapshot
+                        object where the snapshot should be dynamically taken from.
+                        This field is immutable.
+                      type: string
+                    volumeSnapshotContentName:
+                      description: volumeSnapshotContentName specifies the name of a
+                        pre-existing VolumeSnapshotContent object. This field is immutable.
+                      type: string
+                  type: object
+                volumeSnapshotClassName:
+                  description: 'volumeSnapshotClassName is the name of the VolumeSnapshotClass
+                  requested by the VolumeSnapshot. If not specified, the default snapshot
+                  class will be used if one exists. If not specified, and there is
+                  no default snapshot class, dynamic snapshot creation will fail.
+                  Empty string is not allowed for this field. TODO(xiangqian): a webhook
+                  validation on empty string. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes'
                   type: string
-                volumeSnapshotContentName:
-                  description: volumeSnapshotContentName specifies the name of a pre-existing
-                    VolumeSnapshotContent object. This field is immutable.
-                  type: string
+              required:
+                - source
               type: object
-            volumeSnapshotClassName:
-              description: 'volumeSnapshotClassName is the name of the VolumeSnapshotClass
-                requested by the VolumeSnapshot. If not specified, the default snapshot
-                class will be used if one exists. If not specified, and there is no
-                default snapshot class, dynamic snapshot creation will fail. Empty
-                string is not allowed for this field. TODO(xiangqian): a webhook validation
-                on empty string. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes'
-              type: string
-          required:
-          - source
-          type: object
-        status:
-          description: 'status represents the current information of a snapshot. NOTE:
-            status can be modified by sources other than system controllers, and must
-            not be depended upon for accuracy. Controllers should only use information
-            from the VolumeSnapshotContent object after verifying that the binding
-            is accurate and complete.'
-          properties:
-            boundVolumeSnapshotContentName:
-              description: 'boundVolumeSnapshotContentName represents the name of
-                the VolumeSnapshotContent object to which the VolumeSnapshot object
-                is bound. If not specified, it indicates that the VolumeSnapshot object
-                has not been successfully bound to a VolumeSnapshotContent object
-                yet. NOTE: Specified boundVolumeSnapshotContentName alone does not
-                mean binding       is valid. Controllers MUST always verify bidirectional
-                binding between       VolumeSnapshot and VolumeSnapshotContent to
-                avoid possible security issues.'
-              type: string
-            creationTime:
-              description: creationTime is the timestamp when the point-in-time snapshot
-                is taken by the underlying storage system. In dynamic snapshot creation
-                case, this field will be filled in with the "creation_time" value
-                returned from CSI "CreateSnapshotRequest" gRPC call. For a pre-existing
-                snapshot, this field will be filled with the "creation_time" value
-                returned from the CSI "ListSnapshots" gRPC call if the driver supports
-                it. If not specified, it indicates that the creation time of the snapshot
-                is unknown.
-              format: date-time
-              type: string
-            error:
-              description: error is the last observed error during snapshot creation,
-                if any. This field could be helpful to upper level controllers(i.e.,
-                application controller) to decide whether they should continue on
-                waiting for the snapshot to be created based on the type of error
-                reported.
+            status:
+              description: 'status represents the current information of a snapshot.
+              NOTE: status can be modified by sources other than system controllers,
+              and must not be depended upon for accuracy. Controllers should only
+              use information from the VolumeSnapshotContent object after verifying
+              that the binding is accurate and complete.'
               properties:
-                message:
-                  description: 'message is a string detailing the encountered error
-                    during snapshot creation if specified. NOTE: message may be logged,
-                    and it should not contain sensitive information.'
+                boundVolumeSnapshotContentName:
+                  description: 'boundVolumeSnapshotContentName represents the name of
+                  the VolumeSnapshotContent object to which the VolumeSnapshot object
+                  is bound. If not specified, it indicates that the VolumeSnapshot
+                  object has not been successfully bound to a VolumeSnapshotContent
+                  object yet. NOTE: Specified boundVolumeSnapshotContentName alone
+                  does not mean binding       is valid. Controllers MUST always verify
+                  bidirectional binding between       VolumeSnapshot and VolumeSnapshotContent
+                  to avoid possible security issues.'
                   type: string
-                time:
-                  description: time is the timestamp when the error was encountered.
+                creationTime:
+                  description: creationTime is the timestamp when the point-in-time
+                    snapshot is taken by the underlying storage system. In dynamic snapshot
+                    creation case, this field will be filled in with the "creation_time"
+                    value returned from CSI "CreateSnapshotRequest" gRPC call. For a
+                    pre-existing snapshot, this field will be filled with the "creation_time"
+                    value returned from the CSI "ListSnapshots" gRPC call if the driver
+                    supports it. If not specified, it indicates that the creation time
+                    of the snapshot is unknown.
                   format: date-time
                   type: string
+                error:
+                  description: error is the last observed error during snapshot creation,
+                    if any. This field could be helpful to upper level controllers(i.e.,
+                    application controller) to decide whether they should continue on
+                    waiting for the snapshot to be created based on the type of error
+                    reported.
+                  properties:
+                    message:
+                      description: 'message is a string detailing the encountered error
+                      during snapshot creation if specified. NOTE: message may be
+                      logged, and it should not contain sensitive information.'
+                      type: string
+                    time:
+                      description: time is the timestamp when the error was encountered.
+                      format: date-time
+                      type: string
+                  type: object
+                readyToUse:
+                  description: readyToUse indicates if a snapshot is ready to be used
+                    to restore a volume. In dynamic snapshot creation case, this field
+                    will be filled in with the "ready_to_use" value returned from CSI
+                    "CreateSnapshotRequest" gRPC call. For a pre-existing snapshot,
+                    this field will be filled with the "ready_to_use" value returned
+                    from the CSI "ListSnapshots" gRPC call if the driver supports it,
+                    otherwise, this field will be set to "True". If not specified, it
+                    means the readiness of a snapshot is unknown.
+                  type: boolean
+                restoreSize:
+                  type: string
+                  description: restoreSize represents the complete size of the snapshot
+                    in bytes. In dynamic snapshot creation case, this field will be
+                    filled in with the "size_bytes" value returned from CSI "CreateSnapshotRequest"
+                    gRPC call. For a pre-existing snapshot, this field will be filled
+                    with the "size_bytes" value returned from the CSI "ListSnapshots"
+                    gRPC call if the driver supports it. When restoring a volume from
+                    this snapshot, the size of the volume MUST NOT be smaller than the
+                    restoreSize if it is specified, otherwise the restoration will fail.
+                    If not specified, it indicates that the size is unknown.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
               type: object
-            readyToUse:
-              description: readyToUse indicates if a snapshot is ready to be used
-                to restore a volume. In dynamic snapshot creation case, this field
-                will be filled in with the "ready_to_use" value returned from CSI
-                "CreateSnapshotRequest" gRPC call. For a pre-existing snapshot, this
-                field will be filled with the "ready_to_use" value returned from the
-                CSI "ListSnapshots" gRPC call if the driver supports it, otherwise,
-                this field will be set to "True". If not specified, it means the readiness
-                of a snapshot is unknown.
-              type: boolean
-            restoreSize:
-              anyOf:
-              - type: integer
-              - type: string
-              description: restoreSize represents the complete size of the snapshot
-                in bytes. In dynamic snapshot creation case, this field will be filled
-                in with the "size_bytes" value returned from CSI "CreateSnapshotRequest"
-                gRPC call. For a pre-existing snapshot, this field will be filled
-                with the "size_bytes" value returned from the CSI "ListSnapshots"
-                gRPC call if the driver supports it. When restoring a volume from
-                this snapshot, the size of the volume MUST NOT be smaller than the
-                restoreSize if it is specified, otherwise the restoration will fail.
-                If not specified, it indicates that the size is unknown.
-              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-              x-kubernetes-int-or-string: true
+          required:
+            - spec
           type: object
-      required:
-      - spec
-      type: object
-  version: v1beta1
-  versions:
-  - name: v1beta1
-    served: true
-    storage: true
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/piraeus/charts/csi-snapshotter/values.yaml
+++ b/charts/piraeus/charts/csi-snapshotter/values.yaml
@@ -1,4 +1,4 @@
-image: quay.io/k8scsi/snapshot-controller:v2.0.1
+image: quay.io/k8scsi/snapshot-controller:v3.0.3
 replicas: 1
 resources: {}
 podsecuritycontext: {}


### PR DESCRIPTION
Update the CRDs packaged for the cluster-wide CSI snapshot controller
to v1. v1beta1 CRDs are deprecated and scheduled for removal.