### PR TITLE
Use recommended labels for created resources

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,9 +11,13 @@ output:
 # all available settings of specific linters
 linters-settings:
   errcheck:
+  gci:
+    local-prefixes: github.com/piraeusdatastore/piraeus-operator
+  funlen:
+    lines: 120
   gocyclo:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 10
+    min-complexity: 15
   maligned:
     # print struct with more effective memory layout or not, false by default
     suggest-new: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- All operator-managed workloads apply recommended labels. This requires the recreation of Deployments and DaemonSets
+  on upgrade. This is automatically handled by the operator, however any customizations applied to the deployments
+  not managed by the operator will be reverted in the process.
+
 ### Changed
 
 - CSI Nodes no longer use `hostNetwork: true`. The pods already got the correct hostname via the downwardAPI and do not

--- a/charts/piraeus/templates/operator-serviceaccount.yaml
+++ b/charts/piraeus/templates/operator-serviceaccount.yaml
@@ -120,9 +120,25 @@ kind: ClusterRole
 metadata:
   name: csi-driver-registrar
 rules:
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["csidrivers"]
-    verbs: ["create", "get", "list", "watch", "delete"]
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    resourceNames:
+      - linstor.csi.linbit.com
+    verbs:
+    - get
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - storage.k8s.io
+    resources:
+    - csidrivers
+    verbs:
+    - create
+    - list
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/piraeus/templates/operator-serviceaccount.yaml
+++ b/deploy/piraeus/templates/operator-serviceaccount.yaml
@@ -12,9 +12,25 @@ kind: ClusterRole
 metadata:
   name: csi-driver-registrar
 rules:
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["csidrivers"]
-    verbs: ["create", "get", "list", "watch", "delete"]
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    resourceNames:
+      - linstor.csi.linbit.com
+    verbs:
+    - get
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - storage.k8s.io
+    resources:
+    - csidrivers
+    verbs:
+    - create
+    - list
+    - watch
 ---
 # Source: piraeus/templates/operator-serviceaccount.yaml
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Replaces the different labels applied to deployments, daemonsets, etc. with
a set of recommended labels [1]. This makes it easier to track which resources
are created by the operator.

Updating the existing deployments and daemonsets requires some extra work:
the label selector used internally by the workload manager is immutable.
Updates to the pod template labels and label selector gets rejected by the
API. As a workaround, we first delete the resource and recreate it with the
new labels afterwards.

[1]: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/