### PR TITLE
Helm: Disable Stork Health Monitor by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disable Stork Health Monitoring by default. Stork cannot distinguish between control plane and data plane issues,
+  which can lead to instances where Stork will migrate a volume that is still mounted on another node, making the
+  volume effectively unusable.
+
 ## [v1.5.1] - 2021-06-21
 
 ### Changed
+
 - Default images:
   * Piraeus Server v1.13.0
   * Piraeus CSI v0.13.1

--- a/charts/piraeus/templates/stork-deployment.yaml
+++ b/charts/piraeus/templates/stork-deployment.yaml
@@ -111,6 +111,7 @@ spec:
             - --leader-elect=true
             - --snapshotter=false
             - --cluster-domain-controllers=false
+            - --health-monitor=false
           imagePullPolicy: {{ .Values.global.imagePullPolicy | quote }}
           image: {{ .Values.stork.storkImage }}
           ports:

--- a/deploy/piraeus/templates/stork-deployment.yaml
+++ b/deploy/piraeus/templates/stork-deployment.yaml
@@ -195,6 +195,7 @@ spec:
             - --leader-elect=true
             - --snapshotter=false
             - --cluster-domain-controllers=false
+            - --health-monitor=false
           imagePullPolicy: "IfNotPresent"
           image: docker.io/openstorage/stork:2.6.2
           ports:


### PR DESCRIPTION
The Health Monitor does not properly distinguish between control plane and data
plane issues, leading to instances where stork will migrate a pod whose volume
is working fine. The way Stork forces the migration to occur mean that the
volume is almost certainly unusable afterwards, until it is again scheduled
on the original volume.