### PR TITLE
Add option to set kubelet directory for CSI driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow CSI to work with distributions that use a kubelet working directory other than `/var/lib/kubelet`. See
+  the [`csi.kubeletPath`](./doc/helm-values.adoc#csikubeletpath) option.
+
 ### Changed
 
 - Disable Stork Health Monitoring by default. Stork cannot distinguish between control plane and data plane issues,

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -12,6 +12,12 @@ The `csi-snapshotter` subchart was removed from this repository. Users who relie
 should switch to the seperate charts provided by the Piraeus team on [artifacthub.io](https://artifacthub.io/packages/search?repo=piraeus-charts)
 The new charts also include notes on how to upgrade to newer CRD versions.
 
+To support the new `csi.kubeletPath` option an update to the LinstorCSIDriver CRD is required:
+
+```
+$ kubectl replace -f ./charts/piraeus/crds
+```
+
 # Upgrade from v1.4 to v1.5
 
 To make use of the new `monitoringImage` value in the LinstorSatelliteSet CRD, you need to replace the existing CRDs

--- a/charts/piraeus/crds/piraeus.linbit.com_linstorcsidrivers_crd.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstorcsidrivers_crd.yaml
@@ -716,6 +716,12 @@ spec:
                 description: Name of a secret with authentication details for the
                   `LinstorPluginImage` registry
                 type: string
+              kubeletPath:
+                description: KubeletPath is the common parent path of mount targets
+                  and plugin registration directories of Kubelet. Typically this should
+                  be set to /var/lib/kubelet, but some distributions require a different
+                  path.
+                type: string
               linstorHttpsClientSecret:
                 description: 'Name of the secret containing: (a) `ca.pem`: root certificate
                   used to validate HTTPS connections with Linstor (PEM format, without

--- a/charts/piraeus/templates/operator-csi-driver.yaml
+++ b/charts/piraeus/templates/operator-csi-driver.yaml
@@ -28,4 +28,5 @@ spec:
   controllerTolerations: {{ .Values.csi.controllerTolerations | toJson}}
   enableTopology: {{ .Values.csi.enableTopology }}
   resources: {{ .Values.csi.resources | toJson }}
+  kubeletPath: {{ .Values.csi.kubeletPath | quote }}
 {{- end }}

--- a/charts/piraeus/values.cn.yaml
+++ b/charts/piraeus/values.cn.yaml
@@ -36,6 +36,7 @@ csi:
   controllerTolerations: []
   enableTopology: false
   resources: {}
+  kubeletPath: /var/lib/kubelet
 priorityClassName: ""
 drbdRepoCred: "" # <- Specify the kubernetes secret name here
 linstorHttpsControllerSecret: "" # <- name of secret containing linstor server certificates+key. See docs/security.md

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -36,6 +36,7 @@ csi:
   controllerTolerations: []
   enableTopology: false
   resources: {}
+  kubeletPath: /var/lib/kubelet
 priorityClassName: ""
 drbdRepoCred: "" # <- Specify the kubernetes secret name here
 linstorHttpsControllerSecret: "" # <- name of secret containing linstor server certificates+key. See docs/security.md

--- a/deploy/piraeus/templates/operator-csi-driver.yaml
+++ b/deploy/piraeus/templates/operator-csi-driver.yaml
@@ -26,3 +26,4 @@ spec:
   controllerTolerations: []
   enableTopology: false
   resources: {}
+  kubeletPath: "/var/lib/kubelet"

--- a/doc/distributions.md
+++ b/doc/distributions.md
@@ -1,0 +1,30 @@
+# Distributions
+
+Some Kubernetes distributions require changes to the default configuration to work.
+
+## Openshift
+
+We provide an example override file for Openshift. You can find it [here](../charts/piraeus/values-openshift.yaml).
+
+Depending on your host OS, you might also need to create your own DRBD injector image. Read more
+[here](./host-setup.md#injector-image-for-compiling-without-headers-on-host).
+
+## microk8s
+
+MicroK8s doesn't use the traditional `/var/lib/kubelet` directory for kubelet data. Instead, it uses
+`/var/snap/microk8s/common/var/lib/kubelet`. To get the CSI driver to work on microk8s, use the following override
+during installation:
+
+```
+--set csi.kubeletPath=/var/snap/microk8s/common/var/lib/kubelet
+```
+
+## k0s
+
+MicroK8s doesn't use the traditional `/var/lib/kubelet` directory for kubelet data. Instead, it uses
+`/var/lib/k0s/kubelet`. To get the CSI driver to work on k0s, use the following override
+during installation:
+
+```
+--set csi.kubeletPath=/var/lib/k0s/kubelet
+```

--- a/doc/helm-values.adoc
+++ b/doc/helm-values.adoc
@@ -179,6 +179,12 @@ Description:: Resource requests and limits to apply to the CSI driver pods.
 
 Note: This will apply to every container individually, their resource usage is quite similar.
 
+=== `csi.kubeletPath`
+Default:: `/var/lib/kubelet`
+Valid values:: string
+Description:: Path to the working directory of kubelet. Some distributions require changing this path for CSI to work.
+See link:distributions.md[here] for more information
+
 == ETCD
 
 === `etcd.image.repository`

--- a/pkg/apis/piraeus/v1/linstorcsidriver_types.go
+++ b/pkg/apis/piraeus/v1/linstorcsidriver_types.go
@@ -112,6 +112,11 @@ type LinstorCSIDriverSpec struct {
 	// +optional
 	EnableTopology bool `json:"enableTopology"`
 
+	// KubeletPath is the common parent path of mount targets and plugin registration directories of Kubelet. Typically
+	// this should be set to /var/lib/kubelet, but some distributions require a different path.
+	// +optional
+	KubeletPath string `json:"kubeletPath"`
+
 	shared.LinstorClientConfig `json:",inline"`
 }
 


### PR DESCRIPTION
Some distributions (for example: microk8s) use a different directory for
storing kubelet state. This becomes a problem when kubelet asks the CSI
driver to mount a volume at a path in a different directory then the
one we bind-mounted from the host.

This commits adds a new `kubeletPath` key to the CSIDriver CRD that is used
as the basis for all kubelet-path related mounts.