### PR TITLE
Enable csi storage capacity tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow CSI to work with distributions that use a kubelet working directory other than `/var/lib/kubelet`. See
   the [`csi.kubeletPath`](./doc/helm-values.adoc#csikubeletpath) option.
+- Enable [Storage Capacity Tacking]. This enables Kubernetes to base Pod scheduling decisions on remaining storage
+  capacity. The feature is in beta and enabled by default starting with Kubernetes 1.21.
+
+[Storage Capacity Tacking]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1472-storage-capacity-tracking
 
 ### Changed
 

--- a/charts/piraeus/templates/csi-controller-rbac.yml
+++ b/charts/piraeus/templates/csi-controller-rbac.yml
@@ -93,7 +93,51 @@ roleRef:
   kind: ClusterRole
   name: external-provisioner-runner
   apiGroup: rbac.authorization.k8s.io
-
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-capacity-syncer
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csistoragecapacities
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-provisioner-capacity-syncer
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: csi-controller
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: csi-capacity-syncer
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/piraeus/values.cn.yaml
+++ b/charts/piraeus/values.cn.yaml
@@ -26,7 +26,7 @@ csi:
   csiAttacherImage: daocloud.io/piraeus/csi-attacher:v3.1.0
   csiLivenessProbeImage: daocloud.io/piraeus/livenessprobe:v2.2.0
   csiNodeDriverRegistrarImage: daocloud.io/piraeus/csi-node-driver-registrar:v2.1.0
-  csiProvisionerImage: daocloud.io/piraeus/csi-provisioner:v2.1.2
+  csiProvisionerImage: daocloud.io/piraeus/csi-provisioner:v2.2.2
   csiSnapshotterImage: daocloud.io/piraeus/csi-snapshotter:v3.0.3
   csiResizerImage: daocloud.io/piraeus/csi-resizer:v1.1.0
   controllerReplicas: 1

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -26,7 +26,7 @@ csi:
   csiAttacherImage: k8s.gcr.io/sig-storage/csi-attacher:v3.1.0
   csiLivenessProbeImage: k8s.gcr.io/sig-storage/livenessprobe:v2.2.0
   csiNodeDriverRegistrarImage: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.1.0
-  csiProvisionerImage: k8s.gcr.io/sig-storage/csi-provisioner:v2.1.2
+  csiProvisionerImage: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
   csiSnapshotterImage: k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3
   csiResizerImage: k8s.gcr.io/sig-storage/csi-resizer:v1.1.0
   controllerReplicas: 1

--- a/deploy/piraeus/templates/csi-controller-rbac.yml
+++ b/deploy/piraeus/templates/csi-controller-rbac.yml
@@ -160,12 +160,59 @@ roleRef:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  name: csi-capacity-syncer
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csistoragecapacities
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+---
+# Source: piraeus/templates/csi-controller-rbac.yml
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
   name: csi-leader-elector
   namespace: default
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
+---
+# Source: piraeus/templates/csi-controller-rbac.yml
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-provisioner-capacity-syncer
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: csi-controller
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: csi-capacity-syncer
 ---
 # Source: piraeus/templates/csi-controller-rbac.yml
 kind: RoleBinding

--- a/deploy/piraeus/templates/operator-csi-driver.yaml
+++ b/deploy/piraeus/templates/operator-csi-driver.yaml
@@ -14,7 +14,7 @@ spec:
   csiAttacherImage: "k8s.gcr.io/sig-storage/csi-attacher:v3.1.0"
   csiLivenessProbeImage: "k8s.gcr.io/sig-storage/livenessprobe:v2.2.0"
   csiNodeDriverRegistrarImage: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.1.0"
-  csiProvisionerImage: "k8s.gcr.io/sig-storage/csi-provisioner:v2.1.2"
+  csiProvisionerImage: "k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2"
   csiResizerImage: "k8s.gcr.io/sig-storage/csi-resizer:v1.1.0"
   csiSnapshotterImage: "k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3"
   linstorHttpsClientSecret: ""


### PR DESCRIPTION
Storage Capacity Tracking can be used to influence Kubernetes default
scheduler when placing Pods with lazy-bound PVCs.

Linstor CSI supports the necessary CSI spec, this just enables the feature
in the csi sidecar.