### PR TITLE
Use "nonroot" user instead of hardcoded uid

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -7,5 +7,6 @@ RUN CGO_ENABLED=0 go build -o ./_output/bin/piraeus-operator --ldflags '-extldfl
 FROM gcr.io/distroless/static:latest
 # install operator binary
 COPY --from=builder /build/_output/bin/piraeus-operator /usr/local/bin/piraeus-operator
-USER 1001
+
+USER nonroot
 ENTRYPOINT ["/usr/local/bin/piraeus-operator"]


### PR DESCRIPTION
`gcr.io/distroless/static` has a predefined "nonroot" user with a
dedicated home directory. While not strictly needed, it's probably
still a good idea to use one of the provided user instead of hard-coding
a random uid.

Note: `gcr.io/distroless/static` was added in #207 