### PR TITLE
charts: automatically select nodes for pv-hostpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `pv-hostpath`: automatically determine on which nodes PVs should be created if no override is given.
+
 ## [v1.6.0] - 2021-09-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -67,24 +67,19 @@ The operator can be deployed with Helm v3 chart in /charts as follows:
 
 ### LINSTOR etcd `hostPath` persistence
 
-You can use the included Helm templates to create `hostPath` persistent volumes.
-Create as many PVs as needed to satisfy your configured etcd `replicas`
-(default 1).
-
-Create the `hostPath` persistent volumes, substituting cluster node names
-accordingly in the `nodes=` option. For 1 replica:
+In general, we recommend using pre-provisioned persistent volumes (PB) when using Etcd as the LINSTOR database.
+You can use the included `pv-hostpath` Helm chart to quickly create such PVs.
 
 ```
-helm install linstor-etcd ./charts/pv-hostpath --set "nodes={<NODE>}"
+helm install piraeus-etcd-pv ./charts/pv-hostpath
 ```
 
-For 3 replicas:
+These PVs are of type `hostPath`, i.e. a directory on the host is shared with the container. By default, a volume is
+created on every control-plane node (those labeled with `node-role.kubernetes.io/control-plane`). You can manually
+specify on which nodes PVs should be created by using `--set nodes={<nodename1>,<nodename2>}`.
 
-```
-helm install linstor-etcd ./charts/pv-hostpath --set "nodes={<NODE0>,<NODE1>,<NODE2>}"
-```
-
-Persistence for etcd is enabled by default.
+The chart defaults to using the `/var/lib/linstor-etcd` directory on the host. You can override this by using
+`--set path=/new/path`.
 
 #### `hostPath` volumes and SELinux
 

--- a/charts/pv-hostpath/Chart.yaml
+++ b/charts/pv-hostpath/Chart.yaml
@@ -1,4 +1,4 @@
 name: pv-hostpath
 description: Hostpath volumes for etcd persistence
-version: 0.2.5
-appVersion: 0.2.5
+version: 0.3.0
+appVersion: 0.3.0

--- a/charts/pv-hostpath/templates/pv.yaml
+++ b/charts/pv-hostpath/templates/pv.yaml
@@ -67,7 +67,20 @@ subjects:
     name: {{ .Release.Name }}-chowner
 {{- end }}
 ---
-{{ range (required "A valid .Values.nodes entry required!" .Values.nodes) }}
+{{ $nodes := list }}
+{{ if .Values.nodes }}
+  {{ $nodes = .Values.nodes }}
+{{ else }}
+  {{ range (lookup "v1" "Node" "" "").items }}
+    {{ if hasKey .metadata.labels "node-role.kubernetes.io/control-plane" }}
+      {{ $nodes = append $nodes .metadata.name }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{ if not $nodes }}
+  {{ fail "Missing either control-plane nodes or a manual .nodes entry"}}
+{{ end }}
+{{ range $nodes }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/charts/pv-hostpath/values.yaml
+++ b/charts/pv-hostpath/values.yaml
@@ -10,3 +10,4 @@ tolerations:
     effect: "NoSchedule"
 pspRole: ""
 selinux: false
+nodes: []

--- a/doc/README.md
+++ b/doc/README.md
@@ -6,8 +6,8 @@ The [project README](../README.md) contains documentation on the initial deploym
 process. A quick summary can be found here:
 
 ```
-# Create an initial set of persistent volumes for etcd. Replace NODE0, NODE1 etc with your (master) nodes.
-helm install linstor-etcd ./charts/pv-hostpath --set "nodes={<NODE0>,<NODE1>,<NODE2>}"
+# Create an initial set of persistent volumes for etcd. Creates a hostpath volume on every control-plane node.
+helm install piraeus-etcd-pv ./charts/pv-hostpath
 # Deploy the piraeus operator chart. Replace <image> with the piraeus DRBD loader image matching your host OS.
 helm install piraeus-op ./charts/piraeus --set operator.satelliteSet.kernelModuleInjectionImage=<image>
 ```


### PR DESCRIPTION
If no `--set nodes` override is given, use all control-plane nodes to provision
persistent volumes.
