### PR TITLE
copy labels from k8s node to satellite properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `pv-hostpath`: automatically determine on which nodes PVs should be created if no override is given.
+- Automatically add labels on Kubernetes Nodes to LINSTOR satellites as Auxiliary Properties. This enables using
+  Kubernetes labels for volume scheduling, for example using `replicasOnSame: topology.kubernetes.io/zone`.
 
 ## [v1.6.0] - 2021-09-02
 

--- a/charts/piraeus/templates/operator-serviceaccount.yaml
+++ b/charts/piraeus/templates/operator-serviceaccount.yaml
@@ -171,3 +171,31 @@ roleRef:
   kind: ClusterRole
   name: csi-driver-registrar
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: linstor-node-syncer
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - watch
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linstor-node-syncer
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "operator.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: linstor-node-syncer
+  apiGroup: rbac.authorization.k8s.io
+---

--- a/deploy/piraeus/templates/operator-serviceaccount.yaml
+++ b/deploy/piraeus/templates/operator-serviceaccount.yaml
@@ -34,6 +34,21 @@ rules:
 ---
 # Source: piraeus/templates/operator-serviceaccount.yaml
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: linstor-node-syncer
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - watch
+      - list
+---
+# Source: piraeus/templates/operator-serviceaccount.yaml
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: csi-driver-registrar
@@ -44,6 +59,20 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: csi-driver-registrar
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: piraeus/templates/operator-serviceaccount.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linstor-node-syncer
+subjects:
+  - kind: ServiceAccount
+    name: piraeus-op
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: linstor-node-syncer
   apiGroup: rbac.authorization.k8s.io
 ---
 # Source: piraeus/templates/operator-serviceaccount.yaml


### PR DESCRIPTION
Automatically apply all node labels as auxiliary properties, ready
to be used during volume scheduling (see replicasOnSame and
replicasOnDifferent in the CSI driver).

Signed-off-by: Moritz "WanzenBug" Wanzenböck <moritz.wanzenboeck@linbit.com>