### PR TITLE
Add NET_RAW capability on etcd container securitycontext

### DIFF
--- a/charts/piraeus/charts/etcd/templates/statefulset.yaml
+++ b/charts/piraeus/charts/etcd/templates/statefulset.yaml
@@ -59,6 +59,9 @@ spec:
 {{- end }}
       containers:
       - name: {{ template "etcd.fullname" . }}
+        securityContext:
+          capabilities:
+            add: ["NET_RAW"]
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.global.imagePullPolicy | quote }}
         ports:

--- a/deploy/piraeus/charts/etcd/templates/statefulset.yaml
+++ b/deploy/piraeus/charts/etcd/templates/statefulset.yaml
@@ -47,6 +47,9 @@ spec:
         fsGroup: 1000
       containers:
       - name: piraeus-op-etcd
+        securityContext:
+          capabilities:
+            add: ["NET_RAW"]
         image: "gcr.io/etcd-development/etcd:v3.4.15"
         imagePullPolicy: "IfNotPresent"
         ports:


### PR DESCRIPTION
Related to https://github.com/piraeusdatastore/piraeus-operator/issues/204

Not tested under containerd but it should be working since containerd doesn't drop NET_RAW by default

The capability should be added on container that's why I'm not using the configurable value PodSecurityContext (see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podsecuritycontext-v1-core)