### PR TITLE
pv-hostpath: support k8s <1.20 for node selection

### DIFF
--- a/charts/pv-hostpath/Chart.yaml
+++ b/charts/pv-hostpath/Chart.yaml
@@ -1,4 +1,4 @@
 name: pv-hostpath
 description: Hostpath volumes for etcd persistence
-version: 0.3.0
+version: 0.3.1
 appVersion: 0.3.0

--- a/charts/pv-hostpath/templates/pv.yaml
+++ b/charts/pv-hostpath/templates/pv.yaml
@@ -72,7 +72,7 @@ subjects:
   {{ $nodes = .Values.nodes }}
 {{ else }}
   {{ range (lookup "v1" "Node" "" "").items }}
-    {{ if hasKey .metadata.labels "node-role.kubernetes.io/control-plane" }}
+    {{ if or (hasKey .metadata.labels "node-role.kubernetes.io/control-plane") (hasKey .metadata.labels "node-role.kubernetes.io/master") }}
       {{ $nodes = append $nodes .metadata.name }}
     {{ end }}
   {{ end }}


### PR DESCRIPTION
the canonical role for control plane nodes prior to k8s 1.20 was "master".
Since 1.19 is still a stable k8s version, we should support it, too.