### PR TITLE
chart: always create linstor passphrase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Automatically add labels on Kubernetes Nodes to LINSTOR satellites as Auxiliary Properties. This enables using
   Kubernetes labels for volume scheduling, for example using `replicasOnSame: topology.kubernetes.io/zone`.
 - Support LINSTORs `k8s` backend by adding the necessary RBAC resources and [documentation](./doc/k8s-backend.md).
+- Automatically create a LINSTOR passphrase when none is configured.
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -105,4 +105,4 @@ release:
 deploy/piraeus:
 	rm -rf "$@"
 	mkdir -p "$@"
-	helm template -n default piraeus-op charts/piraeus --set stork.schedulerTag=v1.18.0 --output-dir deploy >/dev/null
+	helm template -n default piraeus-op charts/piraeus --set stork.schedulerTag=v1.18.0 --set operator.controller.masterPassphrase=changemeplease --output-dir deploy >/dev/null

--- a/charts/piraeus/templates/operator-controller.yaml
+++ b/charts/piraeus/templates/operator-controller.yaml
@@ -8,7 +8,11 @@ spec:
   priorityClassName: {{ .Values.priorityClassName | default "" | quote }}
   # TODO: switch to k8s db by default
   dbConnectionURL:  {{ .Values.operator.controller.dbConnectionURL | default (print "etcd://" .Release.Name "-etcd:2379") }}
+{{- if .Values.operator.controller.luksSecret }}
   luksSecret: {{ .Values.operator.controller.luksSecret }}
+{{- else }}
+  luksSecret: {{ template "operator.fullname" . }}-passphrase
+{{- end}}
   sslSecret: {{ .Values.operator.controller.sslSecret }}
   dbCertSecret: {{ .Values.operator.controller.dbCertSecret | default "" }}
   dbUseClientCert: {{ .Values.operator.controller.dbUseClientCert }}
@@ -29,4 +33,20 @@ spec:
   {{- if .Values.operator.controller.additionalProperties }}
   additionalProperties: {{ .Values.operator.controller.additionalProperties | toJson }}
   {{- end }}
+---
+{{- if not .Values.operator.controller.luksSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "operator.fullname" . }}-passphrase
+  namespace: {{ .Release.Namespace }}
+data:
+{{- /* We have to be careful not to override the original secret value, otherwise encrypted data could be lost forever */}}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace (printf "%s-passphrase" ( include "operator.fullname" . )) }}
+{{- if $secret }}
+  MASTER_PASSPHRASE: {{ $secret.data.MASTER_PASSPHRASE | quote }}
+{{- else }}
+  MASTER_PASSPHRASE: {{ .Values.operator.controller.masterPassphrase | default (randAlphaNum 40) | b64enc | quote }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/deploy/piraeus/templates/operator-controller.yaml
+++ b/deploy/piraeus/templates/operator-controller.yaml
@@ -1,5 +1,14 @@
 ---
 # Source: piraeus/templates/operator-controller.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: piraeus-op-passphrase
+  namespace: default
+data:
+  MASTER_PASSPHRASE: "Y2hhbmdlbWVwbGVhc2U="
+---
+# Source: piraeus/templates/operator-controller.yaml
 apiVersion: piraeus.linbit.com/v1
 kind: LinstorController
 metadata:
@@ -9,7 +18,7 @@ spec:
   priorityClassName: ""
   # TODO: switch to k8s db by default
   dbConnectionURL:  etcd://piraeus-op-etcd:2379
-  luksSecret: 
+  luksSecret: piraeus-op-passphrase
   sslSecret: 
   dbCertSecret: 
   dbUseClientCert: false

--- a/doc/helm-values.adoc
+++ b/doc/helm-values.adoc
@@ -289,7 +289,9 @@ Description:: Enable to use client certificates when authenticating on the datab
 === `operator.controller.luksSecret`
 Default:: `""`
 Valid values:: secret name
-Description:: Name of the secret that contains the master passphrase to use for encrypted volumes. Check link:./security.md#automatically-set-the-passphrase-for-encrypted-volumes[the security guide].
+Description:: Name of the secret that contains the master passphrase LINSTOR uses for encrypted volumes and securing secrets. Check link:./security.md#automatically-set-the-passphrase-for-linstor[the security guide].
++
+If not specified, a random passphrase will be created by helm.
 
 === `operator.controller.replicas`
 Default:: `1`

--- a/doc/security.md
+++ b/doc/security.md
@@ -120,10 +120,14 @@ The names of the secrets can be passed to `helm install` to configure all client
 --set linstorHttpsControllerSecret=http-controller  --set linstorHttpsClientSecret=http-client
 ```
 
-## Automatically set the passphrase for encrypted volumes
+## Automatically set the passphrase for LINSTOR
 
-Linstor can be used to create encrypted volumes using LUKS. The passphrase used when creating these volumes can
-be set via a secret:
+LINSTOR may need to store sensitive information in its database, for example for encrypted volumes using the LUKS layer,
+or when storing credentials for backup locations. To protect this information, LINSTOR will encrypt it using a master
+passphrase before storing. When using Piraeus, this master passphrase is automatically created by helm and stored in a
+Kubernetes secret.
+
+If you want to manually set the passphrase, use:
 
 ```
 kubectl create secret generic linstor-pass --from-literal=MASTER_PASSPHRASE=<password>


### PR DESCRIPTION
Since LINSTOR can now access S3, it needs a way to securely store these
credentials. This was already supported, using the now confusingely-named
"luksSecret". This secret contains only the passphrase LINSTOR itself uses
to securely store all kinds of secret data, for example LUKS passphrases
(who would have thought...).

Since the actual passphrase itself is not required to be manually configured,
we just create a secret with a random passphrase. We need to be careful with
not re-generating the secret when we upgrade the chart however. Otherwise
we could make some data permanently inaccesible.

Signed-off-by: Moritz "WanzenBug" Wanzenböck <moritz.wanzenboeck@linbit.com>