### PR TITLE
Evict and remove nodes with no associated K8s Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Kubernetes labels for volume scheduling, for example using `replicasOnSame: topology.kubernetes.io/zone`.
 - Support LINSTORs `k8s` backend by adding the necessary RBAC resources and [documentation](./doc/k8s-backend.md).
 - Automatically create a LINSTOR passphrase when none is configured.
+- Automatic eviction and deletion of offline satellites if the Kubernetes node object was also deleted.
 
 ### Changed
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/LINBIT/golinstor v0.34.4
+	github.com/LINBIT/golinstor v0.37.1
 	github.com/coreos/prometheus-operator v0.41.1
 	github.com/linbit/k8s-await-election v0.2.3
 	github.com/operator-framework/operator-sdk v0.19.4

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
-github.com/LINBIT/golinstor v0.34.4 h1:O+C2/r5pwyoERQkARgxWRdnaV7tFtL95AzFREVQuV6c=
-github.com/LINBIT/golinstor v0.34.4/go.mod h1:506Wb/BCd449g/u2IGXlsIKNdiEmAEsgyOPrIYjbKyg=
+github.com/LINBIT/golinstor v0.37.1 h1:Xv+jh6EQNYtCYF+xDkuvmpsvOYU9PEmy0yl3p2NbHew=
+github.com/LINBIT/golinstor v0.37.1/go.mod h1:HOOiFf97Y3Mi0LeLsTKtqhVddkrx5sY2LOEQ7I1E6jQ=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=

--- a/pkg/k8s/metadata/util/util.go
+++ b/pkg/k8s/metadata/util/util.go
@@ -5,7 +5,7 @@ import (
 )
 
 func AddFinalizer(obj metav1.Object, finalizer string) {
-	if !contains(obj.GetFinalizers(), finalizer) {
+	if !SliceContains(obj.GetFinalizers(), finalizer) {
 		obj.SetFinalizers(append(obj.GetFinalizers(), finalizer))
 	}
 }
@@ -15,7 +15,7 @@ func DeleteFinalizer(obj metav1.Object, finalizer string) {
 }
 
 func HasFinalizer(obj metav1.Object, finalizer string) bool {
-	return contains(obj.GetFinalizers(), finalizer)
+	return SliceContains(obj.GetFinalizers(), finalizer)
 }
 
 func remove(list []string, s string) []string {
@@ -27,7 +27,7 @@ func remove(list []string, s string) []string {
 	return list
 }
 
-func contains(list []string, s string) bool {
+func SliceContains(list []string, s string) bool {
 	for _, v := range list {
 		if v == s {
 			return true

--- a/pkg/k8s/metadata/util/util_test.go
+++ b/pkg/k8s/metadata/util/util_test.go
@@ -38,7 +38,7 @@ func TestContains(t *testing.T) {
 	}
 
 	for _, tt := range tableTest {
-		actual := contains(tt.in, tt.has)
+		actual := SliceContains(tt.in, tt.has)
 
 		if tt.expected != actual {
 			t.Errorf("\nexpected contains(%+v, %s)\nto be\n\t%t\ngot\n\t%t",

--- a/pkg/linstor/client/client.go
+++ b/pkg/linstor/client/client.go
@@ -27,6 +27,7 @@ const (
 	Controller       = "CONTROLLER"
 	Satellite        = "SATELLITE"
 	Online           = "ONLINE"
+	Offline          = "OFFLINE"
 	DefaultHttpPort  = 3370
 	DefaultHttpsPort = 3371
 )


### PR DESCRIPTION
In case all of the below is true for a LINSTOR node:

* Satellite is offline
* Satellite was registered by controller
* Kubernetes API does not have a node of the same name

we evict + remove the node from LINSTOR.

Some cloud providers handle upgrades by spinning up new nodes, then purging
the old ones. Using evict ensures that after an upgrade, we still have the
expected number of replicas on the new nodes.

Signed-off-by: Moritz "WanzenBug" Wanzenböck <moritz.wanzenboeck@linbit.com>