### PR TITLE
satellites: allow restarting all pods at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- recreates or updates to the satellite pods are now applied at once, instead of waiting for a node to complete before
+  moving to the next.
+
 ### Fixed
 
 - Fixed a deadlock when reconciling satellites

--- a/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
+++ b/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
@@ -874,6 +874,12 @@ func newSatelliteDaemonSet(satelliteSet *piraeusv1.LinstorSatelliteSet, satellit
 		ObjectMeta: meta,
 		Spec: apps.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: meta.Labels},
+			UpdateStrategy: apps.DaemonSetUpdateStrategy{
+				Type: apps.RollingUpdateDaemonSetStrategyType,
+				RollingUpdate: &apps.RollingUpdateDaemonSet{
+					MaxUnavailable: &intstr.IntOrString{Type: intstr.String, StrVal: "100%"},
+				},
+			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: meta,
 				Spec: corev1.PodSpec{


### PR DESCRIPTION
in case of version upgrades, it makes no sense to have a rolling upgrade
were only one node is updated at a time: LINSTOR can't deal with version skew.

we set the "MaxUnavailable" pods to 100%, i.e. all pods can be updated at once.