### PR TITLE
csidriver: restart node pods if topology labels changed

### DIFF
--- a/charts/piraeus/templates/operator-serviceaccount.yaml
+++ b/charts/piraeus/templates/operator-serviceaccount.yaml
@@ -60,12 +60,6 @@ rules:
       - create
       - get
       - update
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
   # Created by Deployments, used by the metrics service
   - apiGroups:
       - apps
@@ -146,18 +140,28 @@ rules:
     resourceNames:
       - linstor.csi.linbit.com
     verbs:
-    - get
-    - update
-    - patch
-    - delete
+      - get
+      - update
+      - patch
+      - delete
   - apiGroups:
-    - storage.k8s.io
+      - storage.k8s.io
     resources:
-    - csidrivers
+      - csidrivers
     verbs:
-    - create
-    - list
-    - watch
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csinodes
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/piraeus/templates/operator-serviceaccount.yaml
+++ b/deploy/piraeus/templates/operator-serviceaccount.yaml
@@ -19,18 +19,28 @@ rules:
     resourceNames:
       - linstor.csi.linbit.com
     verbs:
-    - get
-    - update
-    - patch
-    - delete
+      - get
+      - update
+      - patch
+      - delete
   - apiGroups:
-    - storage.k8s.io
+      - storage.k8s.io
     resources:
-    - csidrivers
+      - csidrivers
     verbs:
-    - create
-    - list
-    - watch
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csinodes
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
 ---
 # Source: piraeus/templates/operator-serviceaccount.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -129,12 +139,6 @@ rules:
       - create
       - get
       - update
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
   # Created by Deployments, used by the metrics service
   - apiGroups:
       - apps


### PR DESCRIPTION
The satellite operator applies k8s node labels as aux properties. These are
then reported by the csi nodes as supported topology keys. This report
only happens once on plugin startup. Later changes are not reflected, leaving
the volume provisioning steps with old or outdated topology keys.

The only way to force a re-sync of those keys is to delete pod. This change
compares the LINSTOR Node auxilliary properties with the keys reported by
the csi plugin registration. If keys are present in LINSTOR but not
in the registration, the registration and pod is deleted. After the daemonset
restarts the pod, kubelet will trigger a new registration, making the updated
keys available.