### PR TITLE
keep generated passphrase after uninstall

### DIFF
--- a/charts/piraeus/templates/operator-controller.yaml
+++ b/charts/piraeus/templates/operator-controller.yaml
@@ -40,6 +40,8 @@ kind: Secret
 metadata:
   name: {{ template "operator.fullname" . }}-passphrase
   namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/resource-policy: keep
 data:
 {{- /* We have to be careful not to override the original secret value, otherwise encrypted data could be lost forever */}}
 {{- $secret := lookup "v1" "Secret" .Release.Namespace (printf "%s-passphrase" ( include "operator.fullname" . )) }}

--- a/deploy/piraeus/templates/operator-controller.yaml
+++ b/deploy/piraeus/templates/operator-controller.yaml
@@ -5,6 +5,8 @@ kind: Secret
 metadata:
   name: piraeus-op-passphrase
   namespace: default
+  annotations:
+    helm.sh/resource-policy: keep
 data:
   MASTER_PASSPHRASE: "Y2hhbmdlbWVwbGVhc2U="
 ---


### PR DESCRIPTION
Instruct helm to keep a generated master passphrase, even if the chart is
uninstalled.