### PR TITLE
Fix tls secret fetcher for satellite operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use correct secret name when setting up TLS for satellites
+
 ## [v1.7.0] - 2021-12-14
 
 ### Added

--- a/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
+++ b/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
@@ -383,7 +383,7 @@ func (r *ReconcileLinstorSatelliteSet) reconcileAllNodesOnController(ctx context
 	linstorClient, err := lc.NewHighLevelLinstorClientFromConfig(
 		satelliteSet.Spec.ControllerEndpoint,
 		&satelliteSet.Spec.LinstorClientConfig,
-		lc.NamedSecret(ctx, r.client, satelliteSet.Spec.LinstorHttpsClientSecret),
+		lc.NamedSecret(ctx, r.client, satelliteSet.Namespace),
 	)
 	if err != nil {
 		return []error{err}
@@ -740,7 +740,7 @@ func (r *ReconcileLinstorSatelliteSet) reconcileLinstorStatus(ctx context.Contex
 	linstorClient, err := lc.NewHighLevelLinstorClientFromConfig(
 		satelliteSet.Spec.ControllerEndpoint,
 		&satelliteSet.Spec.LinstorClientConfig,
-		lc.NamedSecret(ctx, r.client, satelliteSet.Spec.LinstorHttpsClientSecret),
+		lc.NamedSecret(ctx, r.client, satelliteSet.Namespace),
 	)
 	if err != nil {
 		return err
@@ -1318,7 +1318,7 @@ func (r *ReconcileLinstorSatelliteSet) finalizeSatelliteSet(ctx context.Context,
 	linstorClient, err := lc.NewHighLevelLinstorClientFromConfig(
 		satelliteSet.Spec.ControllerEndpoint,
 		&satelliteSet.Spec.LinstorClientConfig,
-		lc.NamedSecret(ctx, r.client, satelliteSet.Spec.LinstorHttpsClientSecret),
+		lc.NamedSecret(ctx, r.client, satelliteSet.Namespace),
 	)
 	if err != nil {
 		return []error{err}


### PR DESCRIPTION
2f0765a5a95 introduced a bug were the TLS secret to access LINSTOR was
requested from the wrong namespace. This commit fixes this issue by
passing the correct parameters to the NamedSecret function.