### PR TITLE
monitoring: configure TLS for ServiceMonitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Use correct secret name when setting up TLS for satellites
+- Correctly configure ServiceMonitor resource if TLS is enabled for LINSTOR Controller.
 
 ## [v1.7.0] - 2021-12-14
 

--- a/pkg/k8s/reconcileutil/resources.go
+++ b/pkg/k8s/reconcileutil/resources.go
@@ -117,7 +117,7 @@ func CreateOrUpdate(ctx context.Context, kubeClient client.Client, scheme *runti
 
 	err = kubeClient.Patch(ctx, obj, client.RawPatch(types.StrategicMergePatchType, patch), client.FieldOwner(fieldOwner))
 	if err != nil {
-		if apierrors.IsInvalid(err) && onPatchErr != nil {
+		if (apierrors.IsInvalid(err) || apierrors.IsUnsupportedMediaType(err)) && onPatchErr != nil {
 			err := onPatchErr(ctx, kubeClient, current, obj)
 
 			return err == nil, err


### PR DESCRIPTION
Prometheus requires special configuration when HTTPS is enabled on the
Controller.

This also fixes an issue caused by missing patch metadata for the
ServiceMonitor resource: Instead of patch, the resource is re-created if
this error is encountered

Fixes #251 