### PR TITLE
CSI: add secrets RBAC for sidecar containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow the external-provisioner and external-snapshotter access to secrets. This is required to support StorageClass
+  and SnapshotClass [secrets](https://kubernetes-csi.github.io/docs/secrets-and-credentials-storage-class.html).
+- Instruct external-provisioner to pass PVC name+namespace to the CSI driver, enabling optional support for PVC based
+  names for LINSTOR volumes.
+
 ### Fixed
 
 - Use correct secret name when setting up TLS for satellites

--- a/charts/piraeus/templates/csi-controller-rbac.yml
+++ b/charts/piraeus/templates/csi-controller-rbac.yml
@@ -51,14 +51,15 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: external-provisioner-runner
 rules:
-  # The following rule should be uncommented for plugins that require secrets
-  # for provisioning.
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "create", "delete"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "list", "watch"]
@@ -147,16 +148,18 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
-    verbs: ["create", "get", "list", "watch", "update", "delete"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
-    verbs: ["update"]
-
+    verbs: ["update", "patch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/piraeus/templates/csi-controller-rbac.yml
+++ b/deploy/piraeus/templates/csi-controller-rbac.yml
@@ -32,14 +32,15 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: external-provisioner-runner
 rules:
-  # The following rule should be uncommented for plugins that require secrets
-  # for provisioning.
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "create", "delete"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "list", "watch"]
@@ -71,15 +72,18 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
-    verbs: ["create", "get", "list", "watch", "update", "delete"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
 ---
 # Source: piraeus/templates/csi-controller-rbac.yml
 kind: ClusterRole

--- a/pkg/controller/linstorcsidriver/linstorcsidriver_controller.go
+++ b/pkg/controller/linstorcsidriver/linstorcsidriver_controller.go
@@ -807,6 +807,7 @@ func newCSIControllerDeployment(csiResource *piraeusv1.LinstorCSIDriver) *appsv1
 			"--leader-election=true",
 			"--leader-election-namespace=$(NAMESPACE)",
 			"--enable-capacity",
+			"--extra-create-metadata",
 			"--capacity-ownerref-level=2",
 		},
 		Env: []corev1.EnvVar{socketAddress, podNamespace, podName},


### PR DESCRIPTION
To support secret references in storage and snapshot classes, we need
to allow the external-snapshotter and external-provisioner sidecars access
to secrets.

This commit also adds the "--extra-create-metadata" flag to the external
provisioner, which adds parameters containing the PVC name + namespace
to the CreateVolume call, meaning LINSTOR CSI can optionally create
volume names based on PVC name+namespace.