### PR TITLE
allow setting components log level via CRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and SnapshotClass [secrets](https://kubernetes-csi.github.io/docs/secrets-and-credentials-storage-class.html).
 - Instruct external-provisioner to pass PVC name+namespace to the CSI driver, enabling optional support for PVC based
   names for LINSTOR volumes.
+- Allow setting the log level of LINSTOR components via CRs. Other components are left using their default log level.
+  The new default log level is INFO (was DEBUG previously, which was often too verbose).
 
 ### Fixed
 

--- a/charts/piraeus/crds/piraeus.linbit.com_linstorcontrollers_crd.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstorcontrollers_crd.yaml
@@ -1013,6 +1013,16 @@ spec:
                   needs to contain a truststore `truststore.jks`, which will be used
                   to authenticate clients.
                 type: string
+              logLevel:
+                description: LogLevel sets the log level for deployed components.
+                enum:
+                - error
+                - warn
+                - info
+                - debug
+                - trace
+                nullable: true
+                type: string
               luksSecret:
                 description: Name of the secret containing the master passphrase for
                   LUKS devices as `MASTER_PASSPHRASE`

--- a/charts/piraeus/crds/piraeus.linbit.com_linstorcsidrivers_crd.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstorcsidrivers_crd.yaml
@@ -967,6 +967,16 @@ spec:
               linstorPluginImage:
                 description: Image that contains the linstor-csi driver plugin
                 type: string
+              logLevel:
+                description: LogLevel sets the log level for deployed components.
+                enum:
+                - error
+                - warn
+                - info
+                - debug
+                - trace
+                nullable: true
+                type: string
               nodeAffinity:
                 description: Affinity for scheduling the CSI node pods
                 nullable: true

--- a/charts/piraeus/crds/piraeus.linbit.com_linstorsatellitesets_crd.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstorsatellitesets_crd.yaml
@@ -1036,6 +1036,16 @@ spec:
                   matching the client key (PEM format, without password) If set, HTTPS
                   is used for connecting and authenticating with linstor'
                 type: string
+              logLevel:
+                description: LogLevel sets the log level for deployed components.
+                enum:
+                - error
+                - warn
+                - info
+                - debug
+                - trace
+                nullable: true
+                type: string
               monitoringImage:
                 description: MonitoringImage is the image used to export monitoring
                   information from DRBD and Linstor.

--- a/charts/piraeus/templates/operator-controller.yaml
+++ b/charts/piraeus/templates/operator-controller.yaml
@@ -33,6 +33,9 @@ spec:
   {{- if .Values.operator.controller.additionalProperties }}
   additionalProperties: {{ .Values.operator.controller.additionalProperties | toJson }}
   {{- end }}
+  {{- if .Values.operator.controller.logLevel }}
+  logLevel: {{ .Values.operator.controller.logLevel | quote }}
+  {{- end }}
 ---
 {{- if not .Values.operator.controller.luksSecret }}
 apiVersion: v1

--- a/charts/piraeus/templates/operator-csi-driver.yaml
+++ b/charts/piraeus/templates/operator-csi-driver.yaml
@@ -29,4 +29,7 @@ spec:
   enableTopology: {{ .Values.csi.enableTopology }}
   resources: {{ .Values.csi.resources | toJson }}
   kubeletPath: {{ .Values.csi.kubeletPath | quote }}
+  {{- if .Values.csi.logLevel }}
+  logLevel: {{ .Values.csi.logLevel | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/piraeus/templates/operator-satelliteset.yaml
+++ b/charts/piraeus/templates/operator-satelliteset.yaml
@@ -27,4 +27,7 @@ spec:
   {{- if .Values.operator.satelliteSet.additionalEnv }}
   additionalEnv: {{ .Values.operator.satelliteSet.additionalEnv | toJson }}
   {{- end }}
+  {{- if .Values.operator.satelliteSet.logLevel }}
+  logLevel: {{ .Values.operator.satelliteSet.logLevel | quote }}
+  {{- end }}
 {{- end }}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/LINBIT/golinstor v0.37.1
+	github.com/LINBIT/golinstor v0.39.0
 	github.com/coreos/prometheus-operator v0.41.1
 	github.com/linbit/k8s-await-election v0.2.3
 	github.com/operator-framework/operator-sdk v0.19.4

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
-github.com/LINBIT/golinstor v0.37.1 h1:Xv+jh6EQNYtCYF+xDkuvmpsvOYU9PEmy0yl3p2NbHew=
-github.com/LINBIT/golinstor v0.37.1/go.mod h1:HOOiFf97Y3Mi0LeLsTKtqhVddkrx5sY2LOEQ7I1E6jQ=
+github.com/LINBIT/golinstor v0.39.0 h1:coDeBklMkETBdpsB0u2dFMZSqoQnjot5rCWA5AdP8w8=
+github.com/LINBIT/golinstor v0.39.0/go.mod h1:GspbEuOx6efhdqvnBm9SUA4NPsMfdmEm8utSMfmb8eI=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
@@ -1039,11 +1039,13 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
-github.com/smartystreets/assertions v1.0.1 h1:voD4ITNjPL5jjBfgR/r8fPIIBrliWrWHeiJApdr3r4w=
 github.com/smartystreets/assertions v1.0.1/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=
+github.com/smartystreets/assertions v1.2.0 h1:42S6lae5dvLc7BrLu/0ugRtcFVjoJNMC/N3yZFZkDFs=
+github.com/smartystreets/assertions v1.2.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/smartystreets/goconvey v1.7.2 h1:9RBaZCeXEQ3UselpuwUQHltGVXvdwm6cv1hgR6gDIPg=
+github.com/smartystreets/goconvey v1.7.2/go.mod h1:Vw0tHAZW6lzCRk3xgdin6fKYcG+G3Pg9vgXWeJpQFMM=
 github.com/soheilhy/cmux v0.1.3/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
@@ -1181,7 +1183,6 @@ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/crypto v0.0.0-20190228161510-8dd112bcdc25/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190320223903-b7391e95e576/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/pkg/apis/piraeus/shared/linstor_types.go
+++ b/pkg/apis/piraeus/shared/linstor_types.go
@@ -354,3 +354,31 @@ const (
 	// ModuleInjectionDepsOnly means we only inject already present modules on the host for LINSTOR layers
 	ModuleInjectionDepsOnly = "DepsOnly"
 )
+
+type LogLevel string
+
+const (
+	LogLevelTrace = "trace"
+	LogLevelDebug = "debug"
+	LogLevelInfo  = "info"
+	LogLevelWarn  = "warn"
+	LogLevelError = "error"
+)
+
+func (l LogLevel) ToLinstor() lapi.LogLevel {
+	switch l {
+	case LogLevelTrace:
+		return lapi.TRACE
+	case LogLevelDebug:
+		return lapi.DEBUG
+	case LogLevelInfo:
+		return lapi.INFO
+	case LogLevelWarn:
+		return lapi.WARN
+	case LogLevelError:
+		return lapi.ERROR
+	default:
+		// Keep LINSTOR default
+		return ""
+	}
+}

--- a/pkg/apis/piraeus/v1/linstorcontroller_types.go
+++ b/pkg/apis/piraeus/v1/linstorcontroller_types.go
@@ -107,6 +107,12 @@ type LinstorControllerSpec struct {
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName"`
 
+	// LogLevel sets the log level for deployed components.
+	// +nullable
+	// +optional
+	// +kubebuilder:validation:Enum=error;warn;info;debug;trace
+	LogLevel shared.LogLevel `json:"logLevel,omitempty"`
+
 	shared.LinstorClientConfig `json:",inline"`
 }
 

--- a/pkg/apis/piraeus/v1/linstorcsidriver_types.go
+++ b/pkg/apis/piraeus/v1/linstorcsidriver_types.go
@@ -117,6 +117,12 @@ type LinstorCSIDriverSpec struct {
 	// +optional
 	KubeletPath string `json:"kubeletPath"`
 
+	// LogLevel sets the log level for deployed components.
+	// +nullable
+	// +optional
+	// +kubebuilder:validation:Enum=error;warn;info;debug;trace
+	LogLevel shared.LogLevel `json:"logLevel,omitempty"`
+
 	shared.LinstorClientConfig `json:",inline"`
 }
 

--- a/pkg/apis/piraeus/v1/linstorsatelliteset_types.go
+++ b/pkg/apis/piraeus/v1/linstorsatelliteset_types.go
@@ -106,6 +106,12 @@ type LinstorSatelliteSetSpec struct {
 	// +nullable
 	MonitoringImage string `json:"monitoringImage"`
 
+	// LogLevel sets the log level for deployed components.
+	// +nullable
+	// +optional
+	// +kubebuilder:validation:Enum=error;warn;info;debug;trace
+	LogLevel shared.LogLevel `json:"logLevel,omitempty"`
+
 	shared.LinstorClientConfig `json:",inline"`
 }
 

--- a/pkg/controller/linstorcontroller/linstorcontroller_controller_test.go
+++ b/pkg/controller/linstorcontroller/linstorcontroller_controller_test.go
@@ -36,21 +36,10 @@ func TestNewConfigMapForPCS(t *testing.T) {
 					Namespace: "default-ns",
 				},
 				Data: map[string]string{
-					"linstor.toml": `[config]
-
-[debug]
-
-[log]
-
-[db]
+					"linstor.toml": `[db]
   connection_url = "etcd://etcd.svc:5000/"
-  [db.etcd]
 
-[http]
-
-[https]
-
-[ldap]
+[logging]
 `,
 					"linstor-client.conf": `[global]
 controllers = http://test.default-ns.svc:3370
@@ -78,22 +67,11 @@ controllers = http://test.default-ns.svc:3370
 					Namespace: "default-ns",
 				},
 				Data: map[string]string{
-					"linstor.toml": `[config]
-
-[debug]
-
-[log]
-
-[db]
+					"linstor.toml": `[db]
   connection_url = "etcd://secure.etcd.svc:443/"
   ca_certificate = "/etc/linstor/certs/ca.pem"
-  [db.etcd]
 
-[http]
-
-[https]
-
-[ldap]
+[logging]
 `,
 					"linstor-client.conf": `[global]
 controllers = http://test.default-ns.svc:3370
@@ -122,24 +100,13 @@ controllers = http://test.default-ns.svc:3370
 					Namespace: "default-ns",
 				},
 				Data: map[string]string{
-					"linstor.toml": `[config]
-
-[debug]
-
-[log]
-
-[db]
+					"linstor.toml": `[db]
   connection_url = "etcd://secure.etcd.svc:443/"
   ca_certificate = "/etc/linstor/certs/ca.pem"
   client_certificate = "/etc/linstor/certs/client.cert"
   client_key_pkcs8_pem = "/etc/linstor/certs/client.key"
-  [db.etcd]
 
-[http]
-
-[https]
-
-[ldap]
+[logging]
 `,
 					"linstor-client.conf": `[global]
 controllers = http://test.default-ns.svc:3370
@@ -149,7 +116,7 @@ controllers = http://test.default-ns.svc:3370
 			},
 		},
 		{
-			name: "with-https-auth",
+			name: "with-https-auth-and-log-level",
 			spec: &piraeusv1.LinstorController{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
@@ -162,6 +129,7 @@ controllers = http://test.default-ns.svc:3370
 					LinstorClientConfig: shared.LinstorClientConfig{
 						LinstorHttpsClientSecret: "secret",
 					},
+					LogLevel: shared.LogLevelTrace,
 				},
 			},
 			expected: &corev1.ConfigMap{
@@ -170,26 +138,18 @@ controllers = http://test.default-ns.svc:3370
 					Namespace: "default-ns",
 				},
 				Data: map[string]string{
-					"linstor.toml": `[config]
-
-[debug]
-
-[log]
-
-[db]
-  connection_url = "etcd://etcd.svc:5000/"
-  [db.etcd]
-
-[http]
-
-[https]
+					"linstor.toml": `[https]
   enabled = true
   keystore = "/etc/linstor/https/keystore.jks"
   keystore_password = "linstor"
   truststore = "/etc/linstor/https/truststore.jks"
   truststore_password = "linstor"
 
-[ldap]
+[db]
+  connection_url = "etcd://etcd.svc:5000/"
+
+[logging]
+  linstor_level = "TRACE"
 `,
 					"linstor-client.conf": `[global]
 controllers = https://test.default-ns.svc:3371


### PR DESCRIPTION
Due to the way the operator reconciles resources, it was not possible to set
the log level for components while the operator was running. With this commit
the CRDs have a new "logLevel" field, which can be used to set a blanket log
level for the component.

If no value is given, it defaults to INFO. This was already the default for
LINSTOR Controller and Satellite. Linstor CSI was previously on DEBUG level,
which was often too verbose, running into storage issues after long uptimes.

Signed-off-by: Moritz "WanzenBug" Wanzenböck <moritz.wanzenboeck@linbit.com>