### PR TITLE
reduce load on satellites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stork updated to support Kubernetes v1.22+.
 - Satellites no longer have a readiness probe defined. This caused issues in the satellites by repeatedly opening
   unexpected connections, especially when using SSL.
+- Only query node devices if a storage pool needs to be created.
+- Use cached storage pool response to avoid causing excessive load on LINSTOR satellites.
 
 ### Breaking
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/LINBIT/golinstor v0.39.0
+	github.com/LINBIT/golinstor v0.41.0
 	github.com/coreos/prometheus-operator v0.41.1
 	github.com/linbit/k8s-await-election v0.2.3
 	github.com/operator-framework/operator-sdk v0.19.4

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
-github.com/LINBIT/golinstor v0.39.0 h1:coDeBklMkETBdpsB0u2dFMZSqoQnjot5rCWA5AdP8w8=
-github.com/LINBIT/golinstor v0.39.0/go.mod h1:GspbEuOx6efhdqvnBm9SUA4NPsMfdmEm8utSMfmb8eI=
+github.com/LINBIT/golinstor v0.41.0 h1:04LC/NkzfRGcdyrrAtNOvosIyTZefjo5a4bop93uDNk=
+github.com/LINBIT/golinstor v0.41.0/go.mod h1:GspbEuOx6efhdqvnBm9SUA4NPsMfdmEm8utSMfmb8eI=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=

--- a/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
+++ b/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
@@ -530,7 +530,16 @@ func (r *ReconcileLinstorSatelliteSet) reconcileAutomaticDeviceSetup(ctx context
 		"Op":        "reconcileAutomaticDeviceSetup",
 	})
 
-	logger.Debug("check for re-used device paths")
+	logger.Debug("get existing storage pools on node")
+
+	cached := true
+
+	existingPools, err := linstorClient.Nodes.GetStoragePools(ctx, pod.Spec.NodeName, &lapi.ListOpts{Cached: &cached})
+	if err != nil {
+		return fmt.Errorf("failed to list existing storage pools: %w", err)
+	}
+
+	logger.Debug("check for re-used device paths or existing storage pools")
 
 	devsToConfigure := sets.NewString()
 
@@ -539,10 +548,21 @@ func (r *ReconcileLinstorSatelliteSet) reconcileAutomaticDeviceSetup(ctx context
 			return fmt.Errorf("a device referenced in the storage pools is referenced twice")
 		}
 
+		if findStoragePool(existingPools, poolConfig.GetName()) != nil {
+			// Pool already configured
+			continue
+		}
+
 		devsToConfigure.Insert(poolConfig.GetDevicePaths()...)
 	}
 
 	logger.Debug("no device re-used")
+
+	if devsToConfigure.Len() == 0 {
+		logger.Debug("no device to configure")
+
+		return nil
+	}
 
 	logger.Debug("fetch available devices for node")
 
@@ -624,7 +644,9 @@ func (r *ReconcileLinstorSatelliteSet) reconcileStoragePoolsOnNode(ctx context.C
 	})
 	log.Debug("reconcile storage pools: started")
 
-	currentPools, err := linstorClient.Nodes.GetStoragePools(ctx, pod.Spec.NodeName)
+	cached := true
+
+	currentPools, err := linstorClient.Nodes.GetStoragePools(ctx, pod.Spec.NodeName, &lapi.ListOpts{Cached: &cached})
 	if err != nil {
 		return fmt.Errorf("failed to fetch storage pools: %w", err)
 	}
@@ -790,7 +812,8 @@ func (r *ReconcileLinstorSatelliteSet) reconcileLinstorStatus(ctx context.Contex
 			}
 		}
 
-		pools, err := linstorClient.Nodes.GetStoragePools(ctx, pod.Spec.NodeName)
+		cached := true
+		pools, err := linstorClient.Nodes.GetStoragePools(ctx, pod.Spec.NodeName, &lapi.ListOpts{Cached: &cached})
 		if err != nil {
 			log.Warnf("failed to get storage pools for node %s: %v", pod.Spec.NodeName, err)
 		}
@@ -1393,6 +1416,16 @@ func (r *ReconcileLinstorSatelliteSet) removeDanglingSatellites(ctx context.Cont
 			if err != nil {
 				return fmt.Errorf("failed to delete node '%s': %w", node.Name, err)
 			}
+		}
+	}
+
+	return nil
+}
+
+func findStoragePool(pools []lapi.StoragePool, name string) *lapi.StoragePool {
+	for i := range pools {
+		if pools[i].StoragePoolName == name {
+			return &pools[i]
 		}
 	}
 

--- a/pkg/linstor/client/client.go
+++ b/pkg/linstor/client/client.go
@@ -286,12 +286,13 @@ func filterNodes(resources []lapi.ResourceWithVolumes, nodeName string) []lapi.R
 func (c *HighLevelClient) GetAllStorageNodes(ctx context.Context) ([]StorageNode, error) {
 	storageNodes := make([]StorageNode, 0)
 
-	// TODO: Expand LINSTOR API for an all nodes plus storage pools view?
 	nodes, err := c.Nodes.GetAll(ctx)
 	if err != nil {
 		return storageNodes, fmt.Errorf("unable to get cluster nodes: %v", err)
 	}
-	pools, err := c.Nodes.GetStoragePoolView(ctx)
+
+	cached := true
+	pools, err := c.Nodes.GetStoragePoolView(ctx, &lapi.ListOpts{Cached: &cached})
 	if err != nil {
 		return storageNodes, fmt.Errorf("unable to get cluster storage pools: %v", err)
 	}


### PR DESCRIPTION
* Use cached storage pool information to avoid triggering a rescan of pools.
* Ensure device scan is only executed if storage pools have to be configured.