### PR TITLE
drbd-injection: make source directory configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   names for LINSTOR volumes.
 - Allow setting the log level of LINSTOR components via CRs. Other components are left using their default log level.
   The new default log level is INFO (was DEBUG previously, which was often too verbose).
+- Override the kernel source directory used when compiling DRBD (defaults to /usr/src). See
+  [`operator.satelliteSet.kernelModuleInjectionAdditionalSourceDirectory`](./doc/helm-values.adoc#operatorsatellitesetkernelmoduleinjectionadditionalsourcedirectory)
 - etcd-chart: add option to set priorityClassName.
 
 ### Fixed

--- a/charts/piraeus/crds/piraeus.linbit.com_linstorsatellitesets_crd.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstorsatellitesets_crd.yaml
@@ -987,6 +987,13 @@ spec:
               imagePullPolicy:
                 description: Pull policy applied to all pods started from this controller
                 type: string
+              kernelModuleInjectionAdditionalSourceDirectory:
+                description: kernelModuleInjectionAdditionalSourceDirectory is the
+                  directory containing the kernel sources and config on the host.
+                  It will be mounted read-only when the injection mode is Compile.
+                  If unset, defaults to /usr/src. To disable the mount, specify "none".
+                nullable: true
+                type: string
               kernelModuleInjectionImage:
                 description: kernelModuleInjectionImage is the image (location + tag)
                   for the LINSTOR/DRBD kernel module injector

--- a/charts/piraeus/templates/operator-satelliteset.yaml
+++ b/charts/piraeus/templates/operator-satelliteset.yaml
@@ -20,6 +20,9 @@ spec:
   kernelModuleInjectionMode: {{ .Values.operator.satelliteSet.kernelModuleInjectionMode | quote }}
   kernelModuleInjectionImage: {{ .Values.operator.satelliteSet.kernelModuleInjectionImage | quote }}
   kernelModuleInjectionResources: {{ .Values.operator.satelliteSet.kernelModuleInjectionResources | toJson }}
+  {{- if .Values.operator.satelliteSet.kernelModuleInjectionAdditionalSourceDirectory }}
+  kernelModuleInjectionAdditionalSourceDirectory: {{ .Values.operator.satelliteSet.kernelModuleInjectionAdditionalSourceDirectory | quote }}
+  {{- end }}
   {{- if .Values.operator.satelliteSet.storagePools }}
   storagePools:
 {{ toYaml .Values.operator.satelliteSet.storagePools | indent 4 }}

--- a/charts/piraeus/values.cn.yaml
+++ b/charts/piraeus/values.cn.yaml
@@ -83,6 +83,7 @@ operator:
     monitoringImage: daocloud.io/piraeus/drbd-reactor:v0.4.4
     kernelModuleInjectionImage: daocloud.io/piraeus/drbd9-bionic:v9.1.4
     kernelModuleInjectionMode: Compile
+    kernelModuleInjectionAdditionalSourceDirectory: ""
     kernelModuleInjectionResources: {}
     additionalEnv: []
 haController:

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -83,6 +83,7 @@ operator:
     monitoringImage: quay.io/piraeusdatastore/drbd-reactor:v0.4.4
     kernelModuleInjectionImage: quay.io/piraeusdatastore/drbd9-bionic:v9.1.4
     kernelModuleInjectionMode: Compile
+    kernelModuleInjectionAdditionalSourceDirectory: ""
     kernelModuleInjectionResources: {}
     additionalEnv: []
 haController:

--- a/doc/helm-values.adoc
+++ b/doc/helm-values.adoc
@@ -185,6 +185,11 @@ Valid values:: string
 Description:: Path to the working directory of kubelet. Some distributions require changing this path for CSI to work.
 See link:distributions.md[here] for more information
 
+=== `csi.logLevel`
+Default:: `""`
+Valid values:: `error`, `warn`, `info`, `debug`, `trace`
+Description:: Set the log level of the LINSTOR CSI driver. If not set defaults to `info`.
+
 == ETCD
 
 === `etcd.image.repository`
@@ -240,6 +245,10 @@ Default:: `{}`
 Valid values:: A valid pod-level https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[security-context]
 Description:: Override for the default security context passed to the etcd pods. See <<_global_setsecuritycontext>>
 
+=== `etcd.priorityClassName`
+Default: `""`
+Valid values:: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass[priority class] name
+Description:: Name of the priority class with which the Etcd pods should be scheduled.
 
 == Piraeus Controller
 
@@ -327,6 +336,11 @@ Default:: `{}`
 Valid values:: A map with string keys and values
 Description:: A map of properties to set on the Linstor Controller, equivalent to
 calling `linstor controller set-property <key> <value>`
+
+=== `operator.controller.logLevel`
+Default:: `""`
+Valid values:: `error`, `warn`, `info`, `debug`, `trace`
+Description:: Set the log level of the LINSTOR Controller. If not set defaults to `info`.
 
 == Piraeus Satellites
 
@@ -427,6 +441,10 @@ Default:: `[]`
 Valid values:: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/[EnvVar list]
 Description:: A list of additional environment variables to pass to the Linstor satellite containers.
 
+=== `operator.satelliteSet.logLevel`
+Default:: `""`
+Valid values:: `error`, `warn`, `info`, `debug`, `trace`
+Description:: Set the log level of the LINSTOR Satellite. If not set defaults to `info`.
 
 == PSP
 

--- a/doc/helm-values.adoc
+++ b/doc/helm-values.adoc
@@ -382,6 +382,13 @@ Description:: Resource requests and limits to apply to the kernel module injecti
 
 Note: When using `kernelModuleInjectionMode: Compile`, at least 500MiB of memory is required.
 
+=== `operator.satelliteSet.kernelModuleInjectionAdditionalSourceDirectory`
+Default:: `""`, implying /usr/src.
+Valid values:: Existing (absolute) filesystem path or "none".
+Description:: Path to the directory holding the kernel source, required when compiling DRBD. If not set, it defaults
+to `/usr/src`, which is the kernel source path on most distributions. In some cases, you might need to disable this by
+using `"none"` as the directory (more generally: any non-absolute path will result in _no_ mount).
+
 === `operator.satelliteSet.monitoringImage`
 Default:: `quay.io/piraeusdatastore/drbd-reactor:v0.3.0`
 Valid values:: iamge ref

--- a/doc/host-setup.md
+++ b/doc/host-setup.md
@@ -49,6 +49,15 @@ You can set the image by passing `--set operator.satelliteSet.kernelModuleInject
 [InitContainer]: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 [#137]: https://github.com/piraeusdatastore/piraeus-operator/issues/137
 
+### Flatcar Container Linux
+
+Flatcar Container Linux requires building DRBD from source. Piraeus by default bind mounts `/usr/src` into the injection
+container, as that is required on most distributions. This will fail on Flatcar Container Linux, as that directory
+does not exist there, and can't easily be created (`/usr` is always read-only).
+
+For this case, you can disable mounting of `/usr/src` by passing
+`--set operator.satelliteSet.kernelModuleInjectionAdditionalSourceDirectory=none` to Helm.
+
 ### Injector image for compiling without headers on host
 
 Installing the kernel headers is not always feasible on the host. A prime example is Fedora CoreOS (FCOS), which uses

--- a/pkg/apis/piraeus/v1/linstorsatelliteset_types.go
+++ b/pkg/apis/piraeus/v1/linstorsatelliteset_types.go
@@ -18,9 +18,10 @@ limitations under the License.
 package v1
 
 import (
-	"github.com/piraeusdatastore/piraeus-operator/pkg/apis/piraeus/shared"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/piraeusdatastore/piraeus-operator/pkg/apis/piraeus/shared"
 )
 
 // LinstorSatelliteSetSpec defines the desired state of a LinstorSatelliteSet.
@@ -76,6 +77,13 @@ type LinstorSatelliteSetSpec struct {
 	// +kubebuilder:validation:Enum=None;Compile;ShippedModules;DepsOnly
 	// +optional
 	KernelModuleInjectionMode shared.KernelModuleInjectionMode `json:"kernelModuleInjectionMode"`
+
+	// kernelModuleInjectionAdditionalSourceDirectory is the directory containing the kernel sources and config on the
+	// host. It will be mounted read-only when the injection mode is Compile. If unset, defaults to /usr/src. To
+	// disable the mount, specify "none".
+	// +optional
+	// +nullable
+	KernelModuleInjectionAdditionalSourceDirectory string `json:"kernelModuleInjectionAdditionalSourceDirectory,omitempty"`
 
 	// Resource requirements for the kernel module builder/injector container
 	// +optional


### PR DESCRIPTION
Some distributions don't use /usr/src to store kernel sources. Notably,
Flatcar Container Linux does not have that directory (and it can't easily be
created, either).
    
This commit adds a new value to the satellite CRD:
    
  kernelModuleInjectionAdditionalSourceDirectory
    
If set, the injection container will be started with the directory bound
from the host (read-only). If not set, /usr/src will be bound to keep
existing behaviour. If the given value is not an absolute path, no directory
from the host will be bound (except for /lib/modules, which is required in
all cases).
    
As a small improvement, we also don't try to mount this directory if
DRBD should not be compiled.