### PR TITLE
Options to set amount of worker threads for CSI-controller

### DIFF
--- a/charts/piraeus/crds/piraeus.linbit.com_linstorcsidrivers_crd.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstorcsidrivers_crd.yaml
@@ -917,6 +917,11 @@ spec:
               csiAttacherImage:
                 description: Name of the CSI external attacher image. See https://kubernetes-csi.github.io/docs/external-attacher.html
                 type: string
+              csiAttacherWorkerThreads:
+                description: Number of simultaneously running operations for attaching
+                  and detaching volumes
+                format: int32
+                type: integer
               csiControllerServiceAccountName:
                 description: Name of the service account used by the CSI controller
                   pods
@@ -933,12 +938,27 @@ spec:
               csiProvisionerImage:
                 description: Name of the CSI external provisioner image. See https://kubernetes-csi.github.io/docs/external-provisioner.html
                 type: string
+              csiProvisionerWorkerThreads:
+                description: Number of simultaneously running operations for creating
+                  and deleting volumes
+                format: int32
+                type: integer
               csiResizerImage:
                 description: Name of the CSI external resizer image. See https://kubernetes-csi.github.io/docs/external-resizer.html
                 type: string
+              csiResizerWorkerThreads:
+                description: Number of simultaneously running operations for resizing
+                  volumes
+                format: int32
+                type: integer
               csiSnapshotterImage:
                 description: Name of the CSI external snapshotter image. See https://kubernetes-csi.github.io/docs/external-snapshotter.html
                 type: string
+              csiSnapshotterWorkerThreads:
+                description: Number of simultaneously running operations for creating
+                  and deleting snapshots
+                format: int32
+                type: integer
               enableTopology:
                 description: Enable CSI topology feature to control volume accessibility
                   on cluster nodes

--- a/charts/piraeus/templates/operator-csi-driver.yaml
+++ b/charts/piraeus/templates/operator-csi-driver.yaml
@@ -16,6 +16,10 @@ spec:
   csiProvisionerImage: {{ .Values.csi.csiProvisionerImage | quote }}
   csiResizerImage: {{ .Values.csi.csiResizerImage | quote }}
   csiSnapshotterImage: {{ .Values.csi.csiSnapshotterImage | quote }}
+  csiAttacherWorkerThreads: {{ .Values.csi.csiAttacherWorkerThreads }}
+  csiProvisionerWorkerThreads: {{ .Values.csi.csiProvisionerWorkerThreads }}
+  csiSnapshotterWorkerThreads: {{ .Values.csi.csiSnapshotterWorkerThreads }}
+  csiResizerWorkerThreads: {{ .Values.csi.csiResizerWorkerThreads }}
   linstorHttpsClientSecret: {{ .Values.linstorHttpsClientSecret | quote }}
   priorityClassName: {{ .Values.priorityClassName | default "" | quote }}
   controllerReplicas: {{ .Values.csi.controllerReplicas }}

--- a/charts/piraeus/values.cn.yaml
+++ b/charts/piraeus/values.cn.yaml
@@ -31,6 +31,10 @@ csi:
   csiProvisionerImage: daocloud.io/piraeus/csi-provisioner:v3.0.0
   csiSnapshotterImage: daocloud.io/piraeus/csi-snapshotter:v4.2.1
   csiResizerImage: daocloud.io/piraeus/csi-resizer:v1.3.0
+  csiAttacherWorkerThreads: 10
+  csiProvisionerWorkerThreads: 10
+  csiSnapshotterWorkerThreads: 10
+  csiResizerWorkerThreads: 10
   controllerReplicas: 1
   nodeAffinity: {}
   nodeTolerations: []

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -31,6 +31,10 @@ csi:
   csiProvisionerImage: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
   csiSnapshotterImage: k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.1
   csiResizerImage: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
+  csiAttacherWorkerThreads: 10
+  csiProvisionerWorkerThreads: 10
+  csiSnapshotterWorkerThreads: 10
+  csiResizerWorkerThreads: 10
   controllerReplicas: 1
   nodeAffinity: {}
   nodeTolerations: []

--- a/deploy/piraeus/templates/operator-csi-driver.yaml
+++ b/deploy/piraeus/templates/operator-csi-driver.yaml
@@ -17,6 +17,10 @@ spec:
   csiProvisionerImage: "k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0"
   csiResizerImage: "k8s.gcr.io/sig-storage/csi-resizer:v1.3.0"
   csiSnapshotterImage: "k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.1"
+  csiAttacherWorkerThreads: 10
+  csiProvisionerWorkerThreads: 10
+  csiSnapshotterWorkerThreads: 10
+  csiResizerWorkerThreads: 10
   linstorHttpsClientSecret: ""
   priorityClassName: ""
   controllerReplicas: 1

--- a/pkg/apis/piraeus/v1/linstorcsidriver_types.go
+++ b/pkg/apis/piraeus/v1/linstorcsidriver_types.go
@@ -29,6 +29,9 @@ type LinstorCSIDriverSpec struct {
 	// See https://kubernetes-csi.github.io/docs/external-attacher.html
 	// +optional
 	CSIAttacherImage string `json:"csiAttacherImage"`
+	// Number of simultaneously running operations for attaching and detaching volumes
+	// +optional
+	CSIAttacherWorkerThreads int32 `json:"csiAttacherWorkerThreads"`
 	// Name of the CSI liveness probe image.
 	// See https://kubernetes-csi.github.io/docs/livenessprobe.html
 	// +optional
@@ -41,14 +44,23 @@ type LinstorCSIDriverSpec struct {
 	// See https://kubernetes-csi.github.io/docs/external-provisioner.html
 	// +optional
 	CSIProvisionerImage string `json:"csiProvisionerImage"`
+	// Number of simultaneously running operations for creating and deleting volumes
+	// +optional
+	CSIProvisionerWorkerThreads int32 `json:"csiProvisionerWorkerThreads"`
 	// Name of the CSI external snapshotter image.
 	// See https://kubernetes-csi.github.io/docs/external-snapshotter.html
 	// +optional
 	CSISnapshotterImage string `json:"csiSnapshotterImage"`
+	// Number of simultaneously running operations for creating and deleting snapshots
+	// +optional
+	CSISnapshotterWorkerThreads int32 `json:"csiSnapshotterWorkerThreads"`
 	// Name of the CSI external resizer image.
 	// See https://kubernetes-csi.github.io/docs/external-resizer.html
 	// +optional
 	CSIResizerImage string `json:"csiResizerImage"`
+	// Number of simultaneously running operations for resizing volumes
+	// +optional
+	CSIResizerWorkerThreads int32 `json:"csiResizerWorkerThreads"`
 
 	// Name of a secret with authentication details for the `LinstorPluginImage` registry
 	ImagePullSecret string `json:"imagePullSecret"`

--- a/pkg/controller/linstorcsidriver/linstorcsidriver_controller.go
+++ b/pkg/controller/linstorcsidriver/linstorcsidriver_controller.go
@@ -271,6 +271,38 @@ func (r *ReconcileLinstorCSIDriver) reconcileResource(ctx context.Context, csiRe
 
 	logger.Debugf("finished upgrade/fill: #4 -> Set kubelet path to: changed=%t", changed)
 
+	logger.Debug("performing upgrade/fill: #5 -> Set default worker threads for CSI controller")
+
+	if csiResource.Spec.CSIAttacherWorkerThreads == 0 {
+		csiResource.Spec.CSIAttacherWorkerThreads = 10
+		changed = true
+
+		logger.Infof("set csi attacher worker threads to '%d'", csiResource.Spec.CSIAttacherWorkerThreads)
+	}
+
+	if csiResource.Spec.CSIProvisionerWorkerThreads == 0 {
+		csiResource.Spec.CSIProvisionerWorkerThreads = 10
+		changed = true
+
+		logger.Infof("set csi attacher worker threads to '%d'", csiResource.Spec.CSIProvisionerWorkerThreads)
+	}
+
+	if csiResource.Spec.CSISnapshotterWorkerThreads == 0 {
+		csiResource.Spec.CSISnapshotterWorkerThreads = 10
+		changed = true
+
+		logger.Infof("set csi attacher worker threads to '%d'", csiResource.Spec.CSISnapshotterWorkerThreads)
+	}
+
+	if csiResource.Spec.CSIResizerWorkerThreads == 0 {
+		csiResource.Spec.CSIResizerWorkerThreads = 10
+		changed = true
+
+		logger.Infof("set csi attacher worker threads to '%d'", csiResource.Spec.CSIResizerWorkerThreads)
+	}
+
+	logger.Debugf("finished upgrade/fill: #5 -> Set default worker threads for CSI controller: changed=%t", changed)
+
 	logger.Debug("finished all upgrades/fills")
 	if changed {
 		logger.Info("save updated spec")
@@ -817,6 +849,7 @@ func newCSIControllerDeployment(csiResource *piraeusv1.LinstorCSIDriver) *appsv1
 			"--enable-capacity",
 			"--extra-create-metadata",
 			"--capacity-ownerref-level=2",
+			fmt.Sprintf("--worker-threads=%d", csiResource.Spec.CSIProvisionerWorkerThreads),
 		},
 		Env: []corev1.EnvVar{socketAddress, podNamespace, podName},
 		VolumeMounts: []corev1.VolumeMount{{
@@ -835,6 +868,7 @@ func newCSIControllerDeployment(csiResource *piraeusv1.LinstorCSIDriver) *appsv1
 			"--timeout=1m",
 			"--leader-election=true",
 			"--leader-election-namespace=$(NAMESPACE)",
+			fmt.Sprintf("--workers=%d", csiResource.Spec.CSIAttacherWorkerThreads),
 		},
 		Env: []corev1.EnvVar{socketAddress, podNamespace},
 		VolumeMounts: []corev1.VolumeMount{{
@@ -852,6 +886,7 @@ func newCSIControllerDeployment(csiResource *piraeusv1.LinstorCSIDriver) *appsv1
 			"--csi-address=$(ADDRESS)",
 			"--leader-election=true",
 			"--leader-election-namespace=$(NAMESPACE)",
+			fmt.Sprintf("--worker-threads=%d", csiResource.Spec.CSISnapshotterWorkerThreads),
 		},
 		Env: []corev1.EnvVar{socketAddress, podNamespace},
 		VolumeMounts: []corev1.VolumeMount{{
@@ -872,6 +907,7 @@ func newCSIControllerDeployment(csiResource *piraeusv1.LinstorCSIDriver) *appsv1
 			"--handle-volume-inuse-error=false",
 			"--leader-election=true",
 			"--leader-election-namespace=$(NAMESPACE)",
+			fmt.Sprintf("--worker-threads=%d", csiResource.Spec.CSIResizerWorkerThreads),
 		},
 		Env: []corev1.EnvVar{socketAddress, podNamespace},
 		VolumeMounts: []corev1.VolumeMount{{


### PR DESCRIPTION
[external-provisioner](https://github.com/kubernetes-csi/external-provisioner) has 100 worker threads set by default. It seems linstor-server is not capable to handle such a load.

I faced many fancy bugs while testing pvc creating in concurrency:
- https://github.com/LINBIT/linstor-server/issues/268
- https://github.com/LINBIT/linstor-server/issues/269
- https://github.com/LINBIT/linstor-server/issues/270
- https://github.com/LINBIT/linstor-server/issues/271
- https://github.com/LINBIT/linstor-server/issues/272

Setting `--worker-threads=10` solves this problem to me.
But I suppose there are might be users with more or less powerful servers, so I made this parameter configurable