### PR TITLE
Autogenerate SSL certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow setting the number of parallel requests created by the CSI sidecars. This limits the load on the LINSTOR
   backend, which could easily overload when creating many volumes at once.
 - Unify certificates format for SSL enabled installation, no more java tooling required.
+- Automatic certificates generation using Helm or Cert-manager
 
 ### Changed
 

--- a/charts/piraeus/templates/operator-controller-passphrase.yaml
+++ b/charts/piraeus/templates/operator-controller-passphrase.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.operator.controller.enabled (not .Values.operator.controller.luksSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "operator.fullname" . }}-passphrase
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/resource-policy: keep
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: before-hook-creation
+immutable: true
+data:
+  {{- /* We have to be careful not to override the original secret value, otherwise encrypted data could be lost forever */}}
+  {{- $secret := lookup "v1" "Secret" .Release.Namespace (printf "%s-passphrase" ( include "operator.fullname" . )) }}
+  {{- if $secret }}
+  MASTER_PASSPHRASE: {{ $secret.data.MASTER_PASSPHRASE | quote }}
+  {{- else }}
+  MASTER_PASSPHRASE: {{ .Values.operator.controller.masterPassphrase | default (randAlphaNum 40) | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/piraeus/templates/operator-controller.yaml
+++ b/charts/piraeus/templates/operator-controller.yaml
@@ -13,14 +13,14 @@ spec:
 {{- else }}
   luksSecret: {{ template "operator.fullname" . }}-passphrase
 {{- end}}
-  sslSecret: {{ .Values.operator.controller.sslSecret }}
+  sslSecret: {{ include "controller.sslSecretName" . | quote }}
   dbCertSecret: {{ .Values.operator.controller.dbCertSecret | default "" }}
   dbUseClientCert: {{ .Values.operator.controller.dbUseClientCert }}
   drbdRepoCred: {{ .Values.drbdRepoCred | quote }}
   controllerImage: {{ .Values.operator.controller.controllerImage }}
   imagePullPolicy: {{ .Values.global.imagePullPolicy | quote }}
-  linstorHttpsControllerSecret: {{ .Values.linstorHttpsControllerSecret | quote }}
-  linstorHttpsClientSecret: {{ .Values.linstorHttpsClientSecret | quote }}
+  linstorHttpsControllerSecret: {{ include "controller.httpsSecretName" . | quote }}
+  linstorHttpsClientSecret: {{ include "client.httpsSecretName" . | quote }}
 {{- if .Values.operator.controller.affinity }}
   affinity: {{ .Values.operator.controller.affinity | toJson }}
 {{- end }}
@@ -45,6 +45,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/resource-policy: keep
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: before-hook-creation
 data:
 {{- /* We have to be careful not to override the original secret value, otherwise encrypted data could be lost forever */}}
 {{- $secret := lookup "v1" "Secret" .Release.Namespace (printf "%s-passphrase" ( include "operator.fullname" . )) }}

--- a/charts/piraeus/templates/operator-controller.yaml
+++ b/charts/piraeus/templates/operator-controller.yaml
@@ -36,24 +36,4 @@ spec:
   {{- if .Values.operator.controller.logLevel }}
   logLevel: {{ .Values.operator.controller.logLevel | quote }}
   {{- end }}
-{{- if not .Values.operator.controller.luksSecret }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ template "operator.fullname" . }}-passphrase
-  namespace: {{ .Release.Namespace }}
-  annotations:
-    helm.sh/resource-policy: keep
-    helm.sh/hook: pre-install
-    helm.sh/hook-delete-policy: before-hook-creation
-data:
-{{- /* We have to be careful not to override the original secret value, otherwise encrypted data could be lost forever */}}
-{{- $secret := lookup "v1" "Secret" .Release.Namespace (printf "%s-passphrase" ( include "operator.fullname" . )) }}
-{{- if $secret }}
-  MASTER_PASSPHRASE: {{ $secret.data.MASTER_PASSPHRASE | quote }}
-{{- else }}
-  MASTER_PASSPHRASE: {{ .Values.operator.controller.masterPassphrase | default (randAlphaNum 40) | b64enc | quote }}
-{{- end }}
-{{- end }}
 {{- end }}

--- a/charts/piraeus/templates/operator-controller.yaml
+++ b/charts/piraeus/templates/operator-controller.yaml
@@ -36,8 +36,8 @@ spec:
   {{- if .Values.operator.controller.logLevel }}
   logLevel: {{ .Values.operator.controller.logLevel | quote }}
   {{- end }}
----
 {{- if not .Values.operator.controller.luksSecret }}
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/piraeus/templates/operator-csi-driver.yaml
+++ b/charts/piraeus/templates/operator-csi-driver.yaml
@@ -28,7 +28,7 @@ spec:
 {{- if ne (int .Values.csi.csiResizerWorkerThreads) 10 }}
   csiResizerWorkerThreads: {{ .Values.csi.csiResizerWorkerThreads }}
 {{- end }}
-  linstorHttpsClientSecret: {{ .Values.linstorHttpsClientSecret | quote }}
+  linstorHttpsClientSecret: {{ include "client.httpsSecretName" . | quote }}
   priorityClassName: {{ .Values.priorityClassName | default "" | quote }}
   controllerReplicas: {{ .Values.csi.controllerReplicas }}
   controllerEndpoint: {{ template "controller.endpoint" . }}

--- a/charts/piraeus/templates/operator-https-secret.yaml
+++ b/charts/piraeus/templates/operator-https-secret.yaml
@@ -1,0 +1,88 @@
+{{- $fullName := include "operator.fullname" . -}}
+{{- $cn := printf "%s-cs" $fullName -}}
+{{- $altName1 := printf "%s.%s" $cn .Release.Namespace }}
+{{- $altName2 := printf "%s.%s.svc" $cn .Release.Namespace }}
+{{- if (eq .Values.linstorHttpsMethod "helm") }}
+{{- $ca := genCA (printf "%s-ca" $fullName) 3650 -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "controller.httpsSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/resource-policy": "keep"
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+type: kubernetes.io/tls
+data:
+  {{- with genSignedCert $cn (list "::1" "127.0.0.1") (list $cn $altName1 $altName2 "localhost") 3650 $ca }}
+  tls.crt: {{ b64enc .Cert }}
+  tls.key: {{ b64enc .Key }}
+  ca.crt: {{ b64enc $ca.Cert }}
+  {{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "client.httpsSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/resource-policy": "keep"
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+type: kubernetes.io/tls
+data:
+  {{- with genSignedCert (printf "%s-client" $fullName) nil nil 3650 $ca }}
+  tls.crt: {{ b64enc .Cert }}
+  tls.key: {{ b64enc .Key }}
+  ca.crt: {{ b64enc $ca.Cert }}
+  {{- end }}
+{{- else if (eq .Values.linstorHttpsMethod "cert-manager") }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ template "controller.httpsSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: {{ template "controller.httpsSecretName" . }}
+  commonName: {{ $cn }}
+  ipAddresses:
+  - "::1"
+  - "127.0.0.1"
+  dnsNames:
+  - {{ $cn }}
+  - {{ $altName1 }}
+  - {{ $altName2 }}
+  - localhost
+  duration: 87600h # 3650d
+  usages:
+  - "signing"
+  - "key encipherment"
+  - "server auth"
+  issuerRef:
+    name: {{ $fullName }}-ca-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ template "client.httpsSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: {{ template "client.httpsSecretName" . }}
+  commonName: {{ $cn }}-client
+  duration: 87600h # 3650d
+  usages:
+  - "signing"
+  - "key encipherment"
+  - "client auth"
+  issuerRef:
+    name: {{ $fullName }}-ca-issuer
+    kind: Issuer
+    group: cert-manager.io
+{{- else if (not (eq (.Values.linstorHttpsMethod | default "manual") "manual"))  }}
+{{- fail ".Values.linstorHttpsMethod is not set to <manual|helm|cert-manager>" }}
+{{- end }}

--- a/charts/piraeus/templates/operator-issuer.yaml
+++ b/charts/piraeus/templates/operator-issuer.yaml
@@ -1,0 +1,39 @@
+{{- $fullName := include "operator.fullname" . -}}
+{{- if or (eq .Values.linstorHttpsMethod "cert-manager") (eq .Values.linstorSslMethod "cert-manager") }}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ $fullName }}-selfsigning-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ $fullName }}-ca-secret
+  namespace: {{ .Release.Namespace }}
+spec:
+  commonName: {{ $fullName }}-ca
+  secretName: {{ $fullName }}-ca-secret
+  duration: 87600h # 3650d
+  renewBefore: 8760h # 365d
+  usages:
+  - "signing"
+  - "key encipherment"
+  - "cert sign"
+  isCA: true
+  issuerRef:
+    name: "{{ $fullName }}-selfsigning-issuer"
+    kind: Issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ $fullName }}-ca-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  ca:
+    secretName: {{ $fullName }}-ca-secret
+{{- end }}

--- a/charts/piraeus/templates/operator-satelliteset.yaml
+++ b/charts/piraeus/templates/operator-satelliteset.yaml
@@ -6,11 +6,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   priorityClassName: {{ .Values.priorityClassName | default "" | quote }}
-  sslSecret: {{ .Values.operator.satelliteSet.sslSecret }}
+  sslSecret: {{ include "satelliteSet.sslSecretName" . | quote }}
   drbdRepoCred: {{ .Values.drbdRepoCred | quote }}
   imagePullPolicy: {{ .Values.global.imagePullPolicy | quote }}
   satelliteImage: {{ .Values.operator.satelliteSet.satelliteImage }}
-  linstorHttpsClientSecret: {{ .Values.linstorHttpsClientSecret | quote }}
+  linstorHttpsClientSecret: {{ include "client.httpsSecretName" . | quote }}
   controllerEndpoint: {{ template "controller.endpoint" . }}
   automaticStorageType: {{ .Values.operator.satelliteSet.automaticStorageType | default "None" | quote }}
   affinity: {{ .Values.operator.satelliteSet.affinity | toJson }}

--- a/charts/piraeus/templates/operator-ssl-secret.yaml
+++ b/charts/piraeus/templates/operator-ssl-secret.yaml
@@ -1,0 +1,90 @@
+{{- $fullName := include "operator.fullname" . -}}
+{{- $cn := printf "%s-cs" $fullName -}}
+{{- $altName1 := printf "%s.%s" $cn .Release.Namespace }}
+{{- $altName2 := printf "%s.%s.svc" $cn .Release.Namespace }}
+{{- if (eq .Values.linstorSslMethod "helm") }}
+{{- $ca := genCA (printf "%s-ca" $fullName) 3650 -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "controller.sslSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/resource-policy": "keep"
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+type: kubernetes.io/tls
+data:
+  {{- with genSignedCert $cn (list "::1" "127.0.0.1") (list $cn $altName1 $altName2 "localhost") 3650 $ca }}
+  tls.crt: {{ b64enc .Cert }}
+  tls.key: {{ b64enc .Key }}
+  ca.crt: {{ b64enc $ca.Cert }}
+  {{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "satelliteSet.sslSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/resource-policy": "keep"
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+type: kubernetes.io/tls
+data:
+  {{- with genSignedCert (printf "%s-client" $fullName) nil nil 3650 $ca }}
+  tls.crt: {{ b64enc .Cert }}
+  tls.key: {{ b64enc .Key }}
+  ca.crt: {{ b64enc $ca.Cert }}
+  {{- end }}
+{{- else if (eq .Values.linstorSslMethod "cert-manager") }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ template "controller.sslSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: {{ template "controller.sslSecretName" . }}
+  commonName: {{ $cn }}-client
+  duration: 87600h # 3650d
+  ipAddresses:
+  - "::1"
+  - "127.0.0.1"
+  dnsNames:
+  - {{ $cn }}
+  - {{ $altName1 }}
+  - {{ $altName2 }}
+  - localhost
+  usages:
+  - "signing"
+  - "key encipherment"
+  - "client auth"
+  - "server auth"
+  issuerRef:
+    name: {{ $fullName }}-ca-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ template "satelliteSet.sslSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: {{ template "satelliteSet.sslSecretName" . }}
+  commonName: {{ $cn }}-client
+  duration: 87600h # 3650d
+  usages:
+  - "signing"
+  - "key encipherment"
+  - "client auth"
+  - "server auth"
+  issuerRef:
+    name: {{ $fullName }}-ca-issuer
+    kind: Issuer
+    group: cert-manager.io
+{{- else if (not (eq (.Values.linstorSslMethod | default "manual") "manual")) }}
+{{- fail ".Values.linstorSslMethod is not set to <manual|helm|cert-manager>" }}
+{{- end }}

--- a/charts/piraeus/values.cn.yaml
+++ b/charts/piraeus/values.cn.yaml
@@ -45,6 +45,8 @@ csi:
   kubeletPath: /var/lib/kubelet
 priorityClassName: ""
 drbdRepoCred: "" # <- Specify the kubernetes secret name here
+linstorSslMethod: "manual" # <- If set to 'helm' or 'cert-manager' the certificates will be generated automatically
+linstorHttpsMethod: "manual"  # <- If set to 'helm' or 'cert-manager' the certificates will be generated automatically
 linstorHttpsControllerSecret: "" # <- name of secret containing linstor server certificates+key. See docs/security.md
 linstorHttpsClientSecret: "" # <- name of secret containing linstor client certificates+key. See docs/security.md
 controllerEndpoint: "" # <- override to the generated controller endpoint. use if controller is not deployed via operator

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -45,6 +45,8 @@ csi:
   kubeletPath: /var/lib/kubelet
 priorityClassName: ""
 drbdRepoCred: "" # <- Specify the kubernetes secret name here
+linstorSslMethod: "manual" # <- If set to 'helm' or 'cert-manager' the certificates will be generated automatically
+linstorHttpsMethod: "manual"  # <- If set to 'helm' or 'cert-manager' the certificates will be generated automatically
 linstorHttpsControllerSecret: "" # <- name of secret containing linstor server certificates+key. See docs/security.md
 linstorHttpsClientSecret: "" # <- name of secret containing linstor client certificates+key. See docs/security.md
 controllerEndpoint: "" # <- override to the generated controller endpoint. use if controller is not deployed via operator

--- a/deploy/piraeus/templates/operator-controller-passphrase.yaml
+++ b/deploy/piraeus/templates/operator-controller-passphrase.yaml
@@ -1,0 +1,14 @@
+---
+# Source: piraeus/templates/operator-controller-passphrase.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: piraeus-op-passphrase
+  namespace: default
+  annotations:
+    helm.sh/resource-policy: keep
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: before-hook-creation
+immutable: true
+data:
+  MASTER_PASSPHRASE: "Y2hhbmdlbWVwbGVhc2U="

--- a/deploy/piraeus/templates/operator-controller.yaml
+++ b/deploy/piraeus/templates/operator-controller.yaml
@@ -7,28 +7,7 @@ metadata:
   namespace: default
   annotations:
     helm.sh/resource-policy: keep
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: before-hook-creation
 data:
   MASTER_PASSPHRASE: "Y2hhbmdlbWVwbGVhc2U="
----
-# Source: piraeus/templates/operator-controller.yaml
-apiVersion: piraeus.linbit.com/v1
-kind: LinstorController
-metadata:
-  name: piraeus-op-cs
-  namespace: default
-spec:
-  priorityClassName: ""
-  # TODO: switch to k8s db by default
-  dbConnectionURL:  etcd://piraeus-op-etcd:2379
-  luksSecret: piraeus-op-passphrase
-  sslSecret: 
-  dbCertSecret: 
-  dbUseClientCert: false
-  drbdRepoCred: ""
-  controllerImage: quay.io/piraeusdatastore/piraeus-server:v1.17.0
-  imagePullPolicy: "IfNotPresent"
-  linstorHttpsControllerSecret: ""
-  linstorHttpsClientSecret: ""
-  tolerations: [{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"}]
-  resources: {}
-  replicas: 1

--- a/deploy/piraeus/templates/operator-controller.yaml
+++ b/deploy/piraeus/templates/operator-controller.yaml
@@ -1,13 +1,23 @@
 ---
 # Source: piraeus/templates/operator-controller.yaml
-apiVersion: v1
-kind: Secret
+apiVersion: piraeus.linbit.com/v1
+kind: LinstorController
 metadata:
-  name: piraeus-op-passphrase
+  name: piraeus-op-cs
   namespace: default
-  annotations:
-    helm.sh/resource-policy: keep
-    helm.sh/hook: pre-install
-    helm.sh/hook-delete-policy: before-hook-creation
-data:
-  MASTER_PASSPHRASE: "Y2hhbmdlbWVwbGVhc2U="
+spec:
+  priorityClassName: ""
+  # TODO: switch to k8s db by default
+  dbConnectionURL:  etcd://piraeus-op-etcd:2379
+  luksSecret: piraeus-op-passphrase
+  sslSecret: ""
+  dbCertSecret: 
+  dbUseClientCert: false
+  drbdRepoCred: ""
+  controllerImage: quay.io/piraeusdatastore/piraeus-server:v1.17.0
+  imagePullPolicy: "IfNotPresent"
+  linstorHttpsControllerSecret: ""
+  linstorHttpsClientSecret: ""
+  tolerations: [{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"}]
+  resources: {}
+  replicas: 1

--- a/deploy/piraeus/templates/operator-satelliteset.yaml
+++ b/deploy/piraeus/templates/operator-satelliteset.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
 spec:
   priorityClassName: ""
-  sslSecret: 
+  sslSecret: ""
   drbdRepoCred: ""
   imagePullPolicy: "IfNotPresent"
   satelliteImage: quay.io/piraeusdatastore/piraeus-server:v1.17.0

--- a/doc/security.md
+++ b/doc/security.md
@@ -28,7 +28,27 @@ If this option is active, the secret specified in the above section must contain
 ## Configuring secure communication between LINSTOR components
 
 The default communication between LINSTOR components is not secured by TLS. If this is needed for your setup,
-follow these steps:
+choose one of three methods:
+
+**Generate certificates using cert-manager**
+
+Requires [cert-manager](https://cert-manager.io/docs/)) installed in your cluster
+
+* Pass the following option to `helm install`.
+```
+--set linstorSslMethod=cert-manager
+```
+All required certificates will be issued automatically using cert-manager custom resources.
+
+**Generate certificates using Helm**
+
+* Pass the following option to `helm install`.
+```
+--set linstorSslMethod=helm
+```
+All required certificates will be generated automatically using Helm during initial installation.
+
+**Generate and import certificates manually**
 
 * Create private key and self-signed certificate for your certificate authority:
 
@@ -48,12 +68,12 @@ follow these steps:
   openssl x509 -req -in control.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out control.crt -days 5000 -sha256
   openssl x509 -req -in node.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out node.crt -days 5000 -sha256
   ```
-* Create kubernetes secrets that can be passed to the controller and node pods
+* Create kubernetes secrets that can be passed to the controller and node pods:
   ```
   kubectl create secret generic control-secret --type=kubernetes.io/tls --from-file=ca.crt=ca.crt --from-file=tls.crt=control.crt --from-file=tls.key=control.key
   kubectl create secret generic node-secret --type=kubernetes.io/tls --from-file=ca.crt=ca.crt --from-file=tls.crt=node.crt --from-file=tls.key=node.key
   ```
-* Pass the names of the created secrets to `helm install`
+* Pass the names of the created secrets to `helm install`:
   ```
   --set operator.satelliteSet.sslSecret=node-secret --set operator.controller.sslSecret=control-secret
   ```
@@ -67,6 +87,28 @@ needs access to:
 * A private key
 * A certificate based on the key
 * A trusted certificate, used to verify that other components are trustworthy
+
+Choose one of three methods:
+
+**Generate certificates using cert-manager**
+
+Requires [cert-manager](https://cert-manager.io/docs/)) installed in your cluster
+
+* Pass the following option to `helm install`.
+```
+--set linstorHttpsMethod=cert-manager
+```
+All required certificates will be issued automatically using cert-manager custom resources.
+
+**Generate certificates using Helm**
+
+* Pass the following option to `helm install`.
+```
+--set linstorHttpsMethod=helm
+```
+All required certificates will be issued automatically using Helm during initial installation.
+
+**Generate and import certificates manually**
 
 The next sections will guide you through creating all required components.
 

--- a/doc/security.md
+++ b/doc/security.md
@@ -162,3 +162,7 @@ On install, add the following arguments to the helm command:
 ```
 --set operator.controller.luksSecret=linstor-pass
 ```
+
+| :warning: WARNING                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| If you ever delete or change the passphrase secret, the LINSTOR Controller can no longer start with a failure message like `Automatic injection of passphrase failed`. You can force the Controller to start by setting the `luksSecret` value in the `LinstorController` resource to `""`. This will _not_ give you access to encrypted items such as remotes, but it will allow the Controller to start. If you need to recover encrypted values, you need to restore the original secret. |


### PR DESCRIPTION
This PR adds two new methods to automate SSL certificates generation for both communications: 

```
--set linstorSslMethod=helm --set linstorHttpsMethod=helm
```

```
--set linstorSslMethod=cert-manager --set linstorHttpsMethod=cert-manager
```

by default `manual` mode enabled, so it shouldn't brake oportunity to import your own certificates:

requires https://github.com/piraeusdatastore/piraeus-operator/pull/262 to be merged first
