### PR TITLE
Fix conflicting names

### DIFF
--- a/pkg/controller/linstorcontroller/linstorcontroller_controller.go
+++ b/pkg/controller/linstorcontroller/linstorcontroller_controller.go
@@ -176,6 +176,13 @@ func (r *ReconcileLinstorController) reconcileSpec(ctx context.Context, controll
 		return fmt.Errorf("failed to add finalizer: %w", err)
 	}
 
+	log.Debug("reconcile legacy config map name")
+
+	err = reconcileutil.DeleteIfOwned(ctx, r.client, &corev1.ConfigMap{ObjectMeta: getObjectMeta(controllerResource, "%s-config")}, controllerResource)
+	if err != nil {
+		return fmt.Errorf("failed to delete legacy config map: %w", err)
+	}
+
 	log.Debug("reconcile LINSTOR Service")
 
 	ctrlService := newServiceForResource(controllerResource)

--- a/pkg/controller/linstorcontroller/linstorcontroller_controller.go
+++ b/pkg/controller/linstorcontroller/linstorcontroller_controller.go
@@ -720,7 +720,7 @@ func newDeploymentForResource(controllerResource *piraeusv1.LinstorController) *
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: controllerResource.Name + "-config",
+						Name: controllerResource.Name + "-controller-config",
 					},
 				},
 			},
@@ -1000,7 +1000,7 @@ func NewConfigMapForResource(controllerResource *piraeusv1.LinstorController) (*
 	}
 
 	cm := &corev1.ConfigMap{
-		ObjectMeta: getObjectMeta(controllerResource, "%s-config"),
+		ObjectMeta: getObjectMeta(controllerResource, "%s-controller-config"),
 		Data: map[string]string{
 			kubeSpec.LinstorControllerConfigFile: controllerConfigBuilder.String(),
 			kubeSpec.LinstorClientConfigFile:     clientConfigFile,

--- a/pkg/controller/linstorcontroller/linstorcontroller_controller_test.go
+++ b/pkg/controller/linstorcontroller/linstorcontroller_controller_test.go
@@ -32,7 +32,7 @@ func TestNewConfigMapForPCS(t *testing.T) {
 			},
 			expected: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-config",
+					Name:      "test-controller-config",
 					Namespace: "default-ns",
 				},
 				Data: map[string]string{
@@ -63,7 +63,7 @@ controllers = http://test.default-ns.svc:3370
 			},
 			expected: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-config",
+					Name:      "test-controller-config",
 					Namespace: "default-ns",
 				},
 				Data: map[string]string{
@@ -96,7 +96,7 @@ controllers = http://test.default-ns.svc:3370
 			},
 			expected: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-config",
+					Name:      "test-controller-config",
 					Namespace: "default-ns",
 				},
 				Data: map[string]string{
@@ -134,7 +134,7 @@ controllers = http://test.default-ns.svc:3370
 			},
 			expected: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-config",
+					Name:      "test-controller-config",
 					Namespace: "default-ns",
 				},
 				Data: map[string]string{

--- a/pkg/controller/linstorcsidriver/linstorcsidriver_controller.go
+++ b/pkg/controller/linstorcsidriver/linstorcsidriver_controller.go
@@ -1039,7 +1039,7 @@ func getObjectMeta(controllerResource *piraeusv1.LinstorCSIDriver, nameFmt, comp
 		Name:      fmt.Sprintf(nameFmt, controllerResource.Name),
 		Namespace: controllerResource.Namespace,
 		Labels: map[string]string{
-			"app.kubernetes.io/name":       kubeSpec.ControllerRole,
+			"app.kubernetes.io/name":       kubeSpec.CSIDriverRole,
 			"app.kubernetes.io/instance":   controllerResource.Name,
 			"app.kubernetes.io/managed-by": kubeSpec.Name,
 			"app.kubernetes.io/component":  component,

--- a/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
+++ b/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
@@ -1079,7 +1079,7 @@ func newSatelliteConfigMap(satelliteSet *piraeusv1.LinstorSatelliteSet) (*corev1
 	}
 
 	cm := &corev1.ConfigMap{
-		ObjectMeta: getObjectMeta(satelliteSet, "%s-config"),
+		ObjectMeta: getObjectMeta(satelliteSet, "%s-node-config"),
 		Data: map[string]string{
 			kubeSpec.LinstorSatelliteConfigFile: tomlConfigBuilder.String(),
 			kubeSpec.LinstorClientConfigFile:    clientConfigFile,
@@ -1091,7 +1091,7 @@ func newSatelliteConfigMap(satelliteSet *piraeusv1.LinstorSatelliteSet) (*corev1
 
 func newMonitoringConfigMap(set *piraeusv1.LinstorSatelliteSet) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
-		ObjectMeta: getObjectMeta(set, "%s-monitoring"),
+		ObjectMeta: getObjectMeta(set, "%s-node-monitoring"),
 		Data: map[string]string{
 			"prometheus.toml": fmt.Sprintf(`
 [[prometheus]]
@@ -1241,7 +1241,7 @@ func daemonSetWithHttpsConfiguration(ds *apps.DaemonSet, satelliteSet *piraeusv1
 }
 
 func newMonitoringService(set *piraeusv1.LinstorSatelliteSet) *corev1.Service {
-	meta := getObjectMeta(set, "%s-monitoring")
+	meta := getObjectMeta(set, "%s-node-monitoring")
 
 	return &corev1.Service{
 		ObjectMeta: meta,

--- a/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
+++ b/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
@@ -190,6 +190,13 @@ func (r *ReconcileLinstorSatelliteSet) reconcileSpec(ctx context.Context, satell
 		return []error{fmt.Errorf("failed to add finalizer to resource: %w", err)}
 	}
 
+	log.Debug("reconcile legacy config map name")
+
+	err = reconcileutil.DeleteIfOwned(ctx, r.client, &corev1.ConfigMap{ObjectMeta: getObjectMeta(satelliteSet, "%s-config")}, satelliteSet)
+	if err != nil {
+		return []error{fmt.Errorf("failed to delete legacy config map: %w", err)}
+	}
+
 	log.Debug("reconcile satellite configmap")
 
 	// Create the satellite configuration
@@ -238,6 +245,13 @@ func (r *ReconcileLinstorSatelliteSet) reconcileMonitoring(ctx context.Context, 
 		return nil, nil
 	}
 
+	log.Debug("reconcile legacy monitoring config map name")
+
+	err := reconcileutil.DeleteIfOwned(ctx, r.client, &corev1.ConfigMap{ObjectMeta: getObjectMeta(satelliteSet, "%s-monitoring")}, satelliteSet)
+	if err != nil {
+		return nil, fmt.Errorf("failed to delete legacy monitoring config map: %w", err)
+	}
+
 	log.Debug("reconcile drbd-reactor configmap")
 
 	drbdReactorCM := newMonitoringConfigMap(satelliteSet)
@@ -248,6 +262,13 @@ func (r *ReconcileLinstorSatelliteSet) reconcileMonitoring(ctx context.Context, 
 	}
 
 	log.WithField("changed", drbdReactorCMChanged).Debug("reconcile drbd-reactor configmap: done")
+
+	log.Debug("reconcile legacy monitoring service name")
+
+	err = reconcileutil.DeleteIfOwned(ctx, r.client, &corev1.Service{ObjectMeta: getObjectMeta(satelliteSet, "%s-monitoring")}, satelliteSet)
+	if err != nil {
+		return nil, fmt.Errorf("failed to delete legacy monitoring service: %w", err)
+	}
 
 	log.Debug("reconciling monitoring service definition")
 

--- a/pkg/k8s/spec/piraeus.go
+++ b/pkg/k8s/spec/piraeus.go
@@ -29,6 +29,9 @@ const (
 	// NodeRole is the role for the node set
 	NodeRole = "piraeus-node"
 
+	// CSIDriverRole is the role for the CSI Workloads
+	CSIDriverRole = "piraeus-csi"
+
 	// CSIControllerRole is the role for the CSI Controller Workloads
 	CSIControllerRole = "csi-controller"
 


### PR DESCRIPTION
LinstorSattelliteSet and LinstorController are having conflicting entity names.

Eg. if you install linstorController with name `linstor` and linstorSatelliteSet with name `linstor` operator will be failed to upgrade ownerRefference field for `linstor-config` configmap.

This PR fixes this behavior by adding additional suffix for such resources.