### PR TITLE
cleanup Chart.lock

### DIFF
--- a/charts/piraeus/Chart.lock
+++ b/charts/piraeus/Chart.lock
@@ -1,9 +1,6 @@
 dependencies:
 - name: etcd
   repository: ""
-  version: 0.7.4
-- name: csi-snapshotter
-  repository: ""
-  version: 1.0.0
+  version: 0.7.5
 digest: sha256:cf21a04c22738a1cf06166ce1515f9ffe0558483c043e4432d19fbcd15307682
 generated: "2020-06-17T11:17:16.759913497+02:00"


### PR DESCRIPTION
This fix issue with installing piraeus operator via [flux2](https://github.com/fluxcd/flux2)

It looks like this:
```
flux get all -A --status-selector ready=false
# flux-system	helmchart/piraeus-piraeus-op	False	dependency build error: failed to add local dependency 'csi-snapshotter': can't get a valid version for constraint '1.0.0'	        	False
```