### PR TITLE
satellite: remove useless readiness probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * CSI Resizer v1.4.0
   * Stork v2.8.2
 - Stork updated to support Kubernetes v1.22+.
+- Satellites no longer have a readiness probe defined. This caused issues in the satellites by repeatedly opening
+  unexpected connections, especially when using SSL.
 
 ### Breaking
 

--- a/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
+++ b/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
@@ -918,17 +918,6 @@ func newSatelliteDaemonSet(satelliteSet *piraeusv1.LinstorSatelliteSet, satellit
 									MountPropagation: &kubeSpec.MountPropagationBidirectional,
 								},
 							},
-							ReadinessProbe: &corev1.Probe{
-								Handler: corev1.Handler{
-									TCPSocket: &corev1.TCPSocketAction{
-										Port: intstr.FromInt(int(satelliteSet.Spec.SslConfig.Port())),
-									},
-								},
-								TimeoutSeconds:      5,
-								PeriodSeconds:       10,
-								FailureThreshold:    10,
-								InitialDelaySeconds: 10,
-							},
 							Resources: satelliteSet.Spec.Resources,
 						},
 					},


### PR DESCRIPTION
The readiness probe was implemented as a connection check on the satellites's
comm-port. This turned out to cause issues, as the satellite only expects a
single connection (from the controller). The most visible issues occured
when using SSL, as the readiness probe would not complete the TLS handshake,
generating repeated error reports.

Since the open comm-port doesn't actually tell us all that much about
the satellites readiness, other than that it completed start-up, we don't
lose very much by just removing it.

Note that a solution querying the Controller API was considered, but discarded,
as it would almost certainly propagate any Controller errors to the
readiness state, causing satellites to be recreated when they actually work
fine.

Closes #181