### PR TITLE
let components wait for LINSTOR API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- HA Controller and CSI components now wait for the LINSTOR API to be initialized using InitContainers.
+
 ## [v1.8.0-rc.1] - 2022-02-24
 
 ### Added

--- a/charts/piraeus/templates/ha-controller-deployment.yaml
+++ b/charts/piraeus/templates/ha-controller-deployment.yaml
@@ -15,9 +15,22 @@ spec:
         app.kubernetes.io/name: {{ template "operator.fullname" . }}-ha-controller
     spec:
       serviceAccountName: ha-controller
+      initContainers:
+        - name: wait-for-api
+          image: {{ .Values.haController.image }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy | quote }}
+          command:
+            - /linstor-wait-until
+            - api-online
+          env:
+{{ include "linstor-env" . | indent 12 }}
+{{- if .Values.haController.resources }}
+          resources:
+{{ toYaml .Values.haController.resources | indent 12 }}
+{{- end}}
       containers:
         - name: controller
-          image: {{ .Values.haController.image}}
+          image: {{ .Values.haController.image }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy | quote }}
           args:
             - --leader-election=true

--- a/deploy/piraeus/templates/ha-controller-deployment.yaml
+++ b/deploy/piraeus/templates/ha-controller-deployment.yaml
@@ -16,6 +16,16 @@ spec:
         app.kubernetes.io/name: piraeus-op-ha-controller
     spec:
       serviceAccountName: ha-controller
+      initContainers:
+        - name: wait-for-api
+          image: quay.io/piraeusdatastore/piraeus-ha-controller:v0.3.0
+          imagePullPolicy: "IfNotPresent"
+          command:
+            - /linstor-wait-until
+            - api-online
+          env:
+            - name: LS_CONTROLLERS
+              value: http://piraeus-op-cs.default.svc:3370
       containers:
         - name: controller
           image: quay.io/piraeusdatastore/piraeus-ha-controller:v0.3.0

--- a/doc/helm-values.adoc
+++ b/doc/helm-values.adoc
@@ -168,7 +168,7 @@ Valid values:: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and
 Description:: Tolerations to pass to the csi node pods.
 
 === `csi.pluginImage`
-Default:: `quay.io/piraeusdatastore/piraeus-csi:v0.13.0`
+Default:: `quay.io/piraeusdatastore/piraeus-csi:v0.18.0`
 Valid values:: image ref
 Description:: Image to use for LINSTOR CSI plugin containers (both node and controller). https://github.com/piraeusdatastore/linstor-csi[Project page]
 


### PR DESCRIPTION
The HA Controller and CSI Driver can only run if the LINSTOR api is available.
To prevent an initial round of crashed containers, we add init containers with
the only purpose of waiting for the LINSTOR API to be available.

The used linstor-wait-until binary is included in the docker images itself, so
we don't need to add yet another image that needs to be configured.