### PR TITLE
controller: avoid error loop when scaling deployment

### DIFF
--- a/pkg/controller/linstorcontroller/linstorcontroller_backup.go
+++ b/pkg/controller/linstorcontroller/linstorcontroller_backup.go
@@ -399,6 +399,11 @@ func stopDeployment(ctx context.Context, clientset kubernetes.Interface, control
 		Spec: autoscalingv1.ScaleSpec{Replicas: 0},
 	}, metav1.UpdateOptions{})
 	if err != nil {
+		if errors.IsNotFound(err) {
+			// No deployment, nothing to stop
+			return nil
+		}
+
 		return fmt.Errorf("failed to update controller scale: %w", err)
 	}
 


### PR DESCRIPTION
We might run into situations where we need to create a backup of LINSTOR DB
resources while no LINSTOR Controller deployment is active. For example,
this may happen when a user temporarily uninstalls the CR, or similar.

While our code to determine the image version deals with this gracefully,
we forgot about this possibility when scaling the deployment. If we
can't find the deployment to patch, that already implies that there
is nothing for us to stop, so we can continue without erroring out.

See https://github.com/piraeusdatastore/piraeus-operator/pull/246#issuecomment-1055467169