### PR TITLE
Introduce option to disable monitoring resources management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrades involving k8s databases no long require manually confirming a backup exists using
   `--set IHaveBackedUpAllMyLinstorResources=true`.
+- HA Controller and CSI components now wait for the LINSTOR API to be initialized using InitContainers.
+- Option to disable creating monitoring resources (Services and ServiceMonitors)
 
 ## [v1.8.0] - 2022-03-15
 

--- a/charts/piraeus/templates/operator-deployment.yaml
+++ b/charts/piraeus/templates/operator-deployment.yaml
@@ -39,7 +39,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
-              value: "piraeus-operator"
+              value: {{ template "operator.fullname" . }}-operator
           readinessProbe:
             httpGet:
               port: 8081

--- a/charts/piraeus/templates/operator-deployment.yaml
+++ b/charts/piraeus/templates/operator-deployment.yaml
@@ -26,6 +26,12 @@ spec:
         - name: piraeus-operator
           image: {{ .Values.operator.image }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy | quote }}
+          {{- with .Values.operator.args }}
+          args:
+          {{- range $k, $v := . }}
+            - "--{{ kebabcase $k }}={{ $v }}"
+          {{- end }}
+          {{- end }}
           volumeMounts:
             - name: backup-dir
               mountPath: /run/linstor-backups

--- a/charts/piraeus/templates/operator-serviceaccount.yaml
+++ b/charts/piraeus/templates/operator-serviceaccount.yaml
@@ -105,6 +105,7 @@ rules:
       - create
       - update
       - patch
+      - delete
   # Potential watches from the CSI controller
   - apiGroups:
       - ""

--- a/charts/piraeus/values.cn.yaml
+++ b/charts/piraeus/values.cn.yaml
@@ -59,6 +59,9 @@ operator:
   tolerations: []
   resources: {}
   podsecuritycontext: {}
+  args:
+    createBackups: true
+    createMonitoring: true
   controller:
     enabled: true
     controllerImage: daocloud.io/piraeus/piraeus-server:v1.18.1

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -59,6 +59,9 @@ operator:
   tolerations: []
   resources: {}
   podsecuritycontext: {}
+  args:
+    createBackups: true
+    createMonitoring: true
   controller:
     enabled: true
     controllerImage: quay.io/piraeusdatastore/piraeus-server:v1.18.1

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -32,12 +32,14 @@ import (
 	"github.com/piraeusdatastore/piraeus-operator/pkg/apis"
 	"github.com/piraeusdatastore/piraeus-operator/pkg/controller"
 	"github.com/piraeusdatastore/piraeus-operator/pkg/controller/linstorcontroller"
+	"github.com/piraeusdatastore/piraeus-operator/pkg/controller/linstorsatelliteset"
 	kubeSpec "github.com/piraeusdatastore/piraeus-operator/pkg/k8s/spec"
 )
 
 var (
-	scheme   = runtime.NewScheme()
-	setupLog = ctrl.Log.WithName("setup")
+	scheme           = runtime.NewScheme()
+	setupLog         = ctrl.Log.WithName("setup")
+	createMonitoring = true
 )
 
 func init() {
@@ -57,6 +59,8 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&linstorcontroller.CreateBackups, "create-backups", linstorcontroller.CreateBackups,
 		"create backups of linstor resources if k8s database is used")
+	flag.BoolVar(&createMonitoring, "create-monitoring", createMonitoring,
+		"automatically create monitoring resources in the cluster")
 
 	opts := zap.Options{
 		Development: true,
@@ -64,6 +68,9 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 
 	flag.Parse()
+
+	linstorcontroller.CreateMonitoring = createMonitoring
+	linstorsatelliteset.CreateMonitoring = createMonitoring
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
@@ -98,7 +105,6 @@ func main() {
 	}
 
 	setupLog.Info("starting manager")
-
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)

--- a/deploy/piraeus/templates/operator-deployment.yaml
+++ b/deploy/piraeus/templates/operator-deployment.yaml
@@ -26,6 +26,9 @@ spec:
         - name: piraeus-operator
           image: quay.io/piraeusdatastore/piraeus-operator:latest
           imagePullPolicy: "IfNotPresent"
+          args:
+            - "--create-backups=true"
+            - "--create-monitoring=true"
           volumeMounts:
             - name: backup-dir
               mountPath: /run/linstor-backups

--- a/deploy/piraeus/templates/operator-deployment.yaml
+++ b/deploy/piraeus/templates/operator-deployment.yaml
@@ -39,7 +39,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
-              value: "piraeus-operator"
+              value: piraeus-op-operator
           readinessProbe:
             httpGet:
               port: 8081

--- a/deploy/piraeus/templates/operator-serviceaccount.yaml
+++ b/deploy/piraeus/templates/operator-serviceaccount.yaml
@@ -221,6 +221,7 @@ rules:
       - create
       - update
       - patch
+      - delete
   # Potential watches from the CSI controller
   - apiGroups:
       - ""


### PR DESCRIPTION
Current implementation of serviceMonitors is not flexible.

It has few potential problems:
- Quite often monitoring systems require setting of additional labels for `ServiceMonitors` and run them in different namespaces (exactly our case)
- Using `ServiceMonitor` makes not much sense for piraeus-operator and linstor-node daemonset, `PodMonitor` works as well but does not require any additional `Service` for this
- operator-sdk v0.19 has [hardcoded label](https://github.com/operator-framework/operator-sdk/blob/125d0dfcc71fef4f9d7e2a42b1354cb79ffdee03/pkg/metrics/metrics.go#L112) `name` which must be set for both `Service` and `Pod`, otherwise it will not work, but your operator can be running with the different set of labels, especially when you follow [Recommended Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) guide of Kubernetes
- All thesee fancy api are not supported since operator-sdk v1.0.0

Given all of the above, I have decided not to try to solving all the problems, but do that on another level. Namely to provide user an oportunity to define his own monitoring resources.

This PR introduces new option `--create-monitoring=<bool>`, which is enabled by default. Later it also can be considered to move monitroing configuration into Helm chart and deprecate the option.