### PR TITLE
helm: prevent naive passphrase deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - HA Controller and CSI components now wait for the LINSTOR API to be initialized using InitContainers.
 
+### Changed
+
+- Protect LINSTOR passphrase from accidental deletion by using a finalizer.
+
 ## [v1.8.0-rc.1] - 2022-02-24
 
 ### Added

--- a/charts/piraeus/templates/operator-controller-passphrase.yaml
+++ b/charts/piraeus/templates/operator-controller-passphrase.yaml
@@ -5,6 +5,8 @@ kind: Secret
 metadata:
   name: {{ template "operator.fullname" . }}-passphrase
   namespace: {{ .Release.Namespace }}
+  finalizers:
+    - piraeus.linbit.com/protect-master-passphrase
   annotations:
     helm.sh/resource-policy: keep
     helm.sh/hook: pre-install

--- a/deploy/piraeus/templates/operator-controller-passphrase.yaml
+++ b/deploy/piraeus/templates/operator-controller-passphrase.yaml
@@ -5,6 +5,8 @@ kind: Secret
 metadata:
   name: piraeus-op-passphrase
   namespace: default
+  finalizers:
+    - piraeus.linbit.com/protect-master-passphrase
   annotations:
     helm.sh/resource-policy: keep
     helm.sh/hook: pre-install

--- a/doc/k8s-backend.md
+++ b/doc/k8s-backend.md
@@ -97,3 +97,17 @@ We will remove the `IHaveBackedUpAllMyLinstorResources=true` switch in a release
    ```
    $ helm upgrade piraeus-op charts/piraeus --set operator.controller.controllerImage=... --set operator.satelliteSet.satelliteImage=...
    ```
+
+## Delete the database
+
+If you are using the `k8s` database backend, you may want to remove the associated resources after removing Piraeus.
+Otherwise, you may run LINSTOR with outdated information if you decide to install it again. To create a local backup
+and then delete the database resources, run:
+
+```
+kubectl get crds | grep -o ".*.internal.linstor.linbit.com" | xargs kubectl get crds -oyaml > crds.yaml
+kubectl get crds | grep -o ".*.internal.linstor.linbit.com" | xargs -i{} sh -c "kubectl get {} -oyaml > {}.yaml"
+# Check the the resources are properly backed up now!
+# Then delete the LINSTOR database:
+kubectl get crds | grep -o ".*.internal.linstor.linbit.com" | xargs --no-run-if-empty kubectl delete crds
+```


### PR DESCRIPTION
A user might try to redeploy Piraeus, by using "helm uninstall" and deleting
the whole namespace. This will delete the passphrase secret, but if the user
then tries to redeploy, LINSTOR will not start. That is because the generated
passphrase will be different on redeploy, and LINSTOR compares the passphrase
with whatever is stored in its database. The database is not necessarily
deleted (for example: K8s backend requires manual deletion).

To prevent a user from accidentally deleting the passphrase, we add a finalizer
that is only removed by manual intervention by the user.

See discussion in #273 