### PR TITLE
reconfigure net-interface if transport changed

### DIFF
--- a/pkg/linstor/client/client.go
+++ b/pkg/linstor/client/client.go
@@ -238,7 +238,10 @@ func (c *HighLevelClient) ensureWantedInterface(ctx context.Context, node lapi.N
 			continue
 		}
 
-		if nodeIf.Address == wanted.Address && nodeIf.SatelliteEncryptionType == wanted.SatelliteEncryptionType && nodeIf.SatellitePort == wanted.SatellitePort {
+		// LINSTOR is sadly inconsistent with using "Plain" vs "PLAIN" in encryption types. Fixing it in linstor-common
+		// (which is used to generate the constants in golinstor) was deemed too much effort, so we do the next best
+		// thing: just ignore casing while comparing.
+		if nodeIf.Address == wanted.Address && strings.ToUpper(nodeIf.SatelliteEncryptionType) == strings.ToUpper(wanted.SatelliteEncryptionType) && nodeIf.SatellitePort == wanted.SatellitePort {
 			return nil
 		}
 

--- a/pkg/linstor/client/client.go
+++ b/pkg/linstor/client/client.go
@@ -238,7 +238,7 @@ func (c *HighLevelClient) ensureWantedInterface(ctx context.Context, node lapi.N
 			continue
 		}
 
-		if nodeIf.Address == wanted.Address {
+		if nodeIf.Address == wanted.Address && nodeIf.SatelliteEncryptionType == wanted.SatelliteEncryptionType && nodeIf.SatellitePort == wanted.SatellitePort {
 			return nil
 		}
 


### PR DESCRIPTION
If a user adds the SSL certificates to an existing cluster the existing
connection needs to be reconfigured to use the SSL type and port. A naive
check for the satellites address is no longer enough.