### PR TITLE
chart: add toleration for control plane

### DIFF
--- a/charts/piraeus/charts/etcd/values.yaml
+++ b/charts/piraeus/charts/etcd/values.yaml
@@ -64,8 +64,11 @@ memoryMode: false
 nodeSelector: {}
 tolerations:
   - key: node-role.kubernetes.io/master
-    operator: "Exists"
-    effect: "NoSchedule"
+    operator: Exists
+    effect: NoSchedule
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule
 affinity: {}
 podsecuritycontext: {}
 extraEnv: []

--- a/charts/piraeus/values.cn.yaml
+++ b/charts/piraeus/values.cn.yaml
@@ -71,8 +71,11 @@ operator:
     affinity: {}
     tolerations:
       - key: node-role.kubernetes.io/master
-        operator: "Exists"
-        effect: "NoSchedule"
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
     resources: {}
     replicas: 1
     additionalEnv: []

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -71,8 +71,11 @@ operator:
     affinity: {}
     tolerations:
       - key: node-role.kubernetes.io/master
-        operator: "Exists"
-        effect: "NoSchedule"
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
     resources: {}
     replicas: 1
     additionalEnv: []

--- a/charts/pv-hostpath/values.yaml
+++ b/charts/pv-hostpath/values.yaml
@@ -6,8 +6,11 @@ gid: 1000
 chownerImage: quay.io/centos/centos:8
 tolerations:
   - key: node-role.kubernetes.io/master
-    operator: "Exists"
-    effect: "NoSchedule"
+    operator: Exists
+    effect: NoSchedule
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule
 pspRole: ""
 selinux: false
 nodes: []

--- a/deploy/piraeus/charts/etcd/templates/statefulset.yaml
+++ b/deploy/piraeus/charts/etcd/templates/statefulset.yaml
@@ -41,6 +41,9 @@ spec:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
           operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000

--- a/deploy/piraeus/templates/operator-controller.yaml
+++ b/deploy/piraeus/templates/operator-controller.yaml
@@ -18,6 +18,6 @@ spec:
   imagePullPolicy: "IfNotPresent"
   linstorHttpsControllerSecret: ""
   linstorHttpsClientSecret: ""
-  tolerations: [{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"}]
+  tolerations: [{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane","operator":"Exists"}]
   resources: {}
   replicas: 1

--- a/doc/helm-values.adoc
+++ b/doc/helm-values.adoc
@@ -253,9 +253,12 @@ Description:: Resource requests and limits to apply to the etcd containers. See 
 Default::
 [source]
 ----
+- key: node-role.kubernetes.io/control-plane
+  operator: Exists
+  effect: NoSchedule
 - key: node-role.kubernetes.io/master
-  operator: "Exists"
-  effect: "NoSchedule"
+  operator: Exists
+  effect: NoSchedule
 ----
 Valid values:: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[tolerations]
 Description:: Set the tolerations for etcd. Defaults to allow scheduling on master nodes.

--- a/doc/scheduling.md
+++ b/doc/scheduling.md
@@ -37,9 +37,12 @@ To allow pods to be placed on master nodes, you need add [tolerations]:
 
 ```yaml
 tolerations:
+- key: node-role.kubernetes.io/control-plane # New value since Kubernetes 1.24
+  operator: Exists
+  effect: NoSchedule
 - key: node-role.kubernetes.io/master
-  operator: "Exists"
-  effect: "NoSchedule"
+  operator: Exists
+  effect: NoSchedule
 ```
 
 This toleration allows pods to be scheduled on master nodes.


### PR DESCRIPTION
In Kubernetes 1.24, the master roles is renamed to control-plane, and all
node taints are renamed. To keep existing behaviour, include tolerations
for both taints.