### PR TITLE
Added doc: host setup - disable lvmetad

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v4.2.0
     hooks:
       - id: trailing-whitespace
         exclude: 'deploy/piraeus/'
@@ -13,11 +13,11 @@ repos:
           - --multi
       - id: check-added-large-files
   - repo: https://github.com/Bahjat/pre-commit-golang
-    rev: master
+    rev: a4be1d0f860565649a450a8d480e541844c14a07
     hooks:
       - id: gofumpt
   - repo: https://github.com/dnephin/pre-commit-golang
-    rev: master
+    rev: v0.5.0
     hooks:
       - id: golangci-lint
         args:

--- a/doc/host-setup.md
+++ b/doc/host-setup.md
@@ -155,7 +155,7 @@ CentOS 7 and Ubuntu 18.04 by default use `lvmetad`,  a metadata caching daemon f
 
 Note: Newer distributions no longer include with `lvmetad`, no changes necessary.
 
-Follow below steps to disable lvmetad completely: 
+Follow below steps to disable lvmetad completely:
 ```bash
 $ systemctl stop lvm2-lvmetad.socket lvm2-lvmetad.service
 

--- a/doc/host-setup.md
+++ b/doc/host-setup.md
@@ -147,7 +147,7 @@ Checking the current value again will reveal that the helper is now disabled
 disabled
 ```
 
-## Disable Lvmetad in CentOS 7 and Ubuntu 18.04
+## Disable Lvmetad on CentOS 7 and Ubuntu 18.04
 
 Reference: https://access.redhat.com/solutions/2053483
 

--- a/doc/host-setup.md
+++ b/doc/host-setup.md
@@ -149,13 +149,14 @@ disabled
 
 ## Disable Lvmetad on CentOS 7 and Ubuntu 18.04
 
-Reference: https://access.redhat.com/solutions/2053483
+Reference: <https://access.redhat.com/solutions/2053483>
 
 CentOS 7 and Ubuntu 18.04 by default use `lvmetad`,  a metadata caching daemon for LVM. The daemon improves performance of LVM commands by avoiding rescanning the disks on every execution. `piraeus-ns-node` pods run LVM commands inside a container without access to lvmetad. Since that means  `lvmetad` would get out of sync, it is recommended to disable `lvmetad` in CentOS 7 and Ubuntu 18.04 Bionic.
 
 Note: Newer distributions no longer include with `lvmetad`, no changes necessary.
 
 Follow below steps to disable lvmetad completely:
+
 ```bash
 $ systemctl stop lvm2-lvmetad.socket lvm2-lvmetad.service
 
@@ -168,7 +169,9 @@ $ sed -i 's/use_lvmetad = 1/use_lvmetad = 0/' /etc/lvm/lvm.conf
 $ cat /etc/lvm/lvm.conf | grep use_lvmetad
 use_lvmetad = 0
 ```
+
 If the root partition already uses LVM, you also need to update the initial ram-disk:
+
 ```bash
 # CentOS 7
 $ cp -vf /boot/initramfs-$(uname -r).img /boot/initramfs-$(uname -r).img.$(date +%m-%d-%H%M%S).bak
@@ -179,4 +182,3 @@ $ cp -vf /boot/initrd.img-$(uname -r) /boot/initd.img.$(uname -r).$(date +%m-%d-
 $ update-initramfs -c -k $(uname -r)
 $ update-grub
 ```
-

--- a/doc/host-setup.md
+++ b/doc/host-setup.md
@@ -151,11 +151,9 @@ disabled
 
 Reference: https://access.redhat.com/solutions/2053483
 
-CentOS 7 and Ubuntu 18.04 by default use **lvmetad**,  a metadata caching daemon for LVM. The daemon receives notifications from udev rules. Through these notifications, lvmetad has an up-to-date and consistent image of the volume groups available in the system. lvmetad improves performance of LVM commands by saving them from scanning the disks in every execution. 
+CentOS 7 and Ubuntu 18.04 by default use `lvmetad`,  a metadata caching daemon for LVM. The daemon improves performance of LVM commands by avoiding rescanning the disks on every execution. `piraeus-ns-node` pods run LVM commands inside a container without access to lvmetad. Since that means  `lvmetad` would get out of sync, it is recommended to disable `lvmetad` in CentOS 7 and Ubuntu 18.04 Bionic.
 
-`piraeus-ns-node` pod runs lvm commands inside a container without using any lvmetad or udev. And it does not communicate to lvmetad daemon in the operation system. Therefore, users must run `pvscan --cache` in the OS each time to view LVM changes after a Piraeus volume operation. 
-
-In CentOS 8 and in Ubuntu 20.04 (focal), lvmetad is deprecated because lvm2 has removed it since version 2.03. **Therefore, it is also recommended to disable lvmetad in CentOS 7 and Ubuntu 18.04 binoic**. 
+Note: Newer distributions no longer include with `lvmetad`, no changes necessary.
 
 Follow below steps to disable lvmetad completely: 
 ```bash

--- a/doc/host-setup.md
+++ b/doc/host-setup.md
@@ -168,7 +168,7 @@ $ sed -i 's/use_lvmetad = 1/use_lvmetad = 0/' /etc/lvm/lvm.conf
 $ cat /etc/lvm/lvm.conf | grep use_lvmetad
 use_lvmetad = 0
 ```
-If lvm is used for root, initial RAM has to be updated:
+If the root partition already uses LVM, you also need to update the initial ram-disk:
 ```bash
 # CentOS 7
 $ cp -vf /boot/initramfs-$(uname -r).img /boot/initramfs-$(uname -r).img.$(date +%m-%d-%H%M%S).bak

--- a/doc/host-setup.md
+++ b/doc/host-setup.md
@@ -146,3 +146,39 @@ Checking the current value again will reveal that the helper is now disabled
 # cat /sys/module/drbd/parameters/usermode_helper
 disabled
 ```
+
+## Disable Lvmetad in CentOS 7 and Ubuntu 18.04
+
+Reference: https://access.redhat.com/solutions/2053483
+
+CentOS 7 and Ubuntu 18.04 by default use **lvmetad**,  a metadata caching daemon for LVM. The daemon receives notifications from udev rules. Through these notifications, lvmetad has an up-to-date and consistent image of the volume groups available in the system. lvmetad improves performance of LVM commands by saving them from scanning the disks in every execution. 
+
+`piraeus-ns-node` pod runs lvm commands inside a container without using any lvmetad or udev. And it does not communicate to lvmetad daemon in the operation system. Therefore, users must run `pvscan --cache` in the OS each time to view LVM changes after a Piraeus volume operation. 
+
+In CentOS 8 and in Ubuntu 20.04 (focal), lvmetad is deprecated because lvm2 has removed it since version 2.03. **Therefore, it is also recommended to disable lvmetad in CentOS 7 and Ubuntu 18.04 binoic**. 
+
+Follow below steps to disable lvmetad completely: 
+```bash
+$ systemctl stop lvm2-lvmetad.socket lvm2-lvmetad.service
+
+$ systemctl disable lvm2-lvmetad.service
+
+$ systemctl mask lvm2-lvmetad.socket
+
+$ sed -i 's/use_lvmetad = 1/use_lvmetad = 0/' /etc/lvm/lvm.conf
+
+$ cat /etc/lvm/lvm.conf | grep use_lvmetad
+use_lvmetad = 0
+```
+If lvm is used for root, initial RAM has to be updated:
+```bash
+# CentOS 7
+$ cp -vf /boot/initramfs-$(uname -r).img /boot/initramfs-$(uname -r).img.$(date +%m-%d-%H%M%S).bak
+$ dracut -f -v
+
+# Ubuntu 18.04
+$ cp -vf /boot/initrd.img-$(uname -r) /boot/initd.img.$(uname -r).$(date +%m-%d-%H%M%S).bak
+$ update-initramfs -c -k $(uname -r)
+$ update-grub
+```
+


### PR DESCRIPTION
This doc update provides instruction to fix the issue where in centos 7 and ubuntu bionic, one must run `pvscan --cache` before `vgdispaly, lvdisplay, lvs` to see Piraeus volume LVs