### PR TITLE
Remove backup nagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Upgrades involving k8s databases no long require manually confirming a backup exists using
+  `--set IHaveBackedUpAllMyLinstorResources=true`.
+
 ## [v1.8.0] - 2022-03-15
 
 ### Added

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,12 @@ etcd was deployed using `etcd.persistentVolume.enabled=true`
 During the upgrade process, provisioning of volumes and attach/detach operations might not work. Existing
 volumes and volumes already in use by a pod will continue to work without interruption.
 
+# Upgrades when using the `k8s` database
+
+If you are using the `k8s` database _and_ you also upgrade from **before Operator 1.8.0** you **need to perform a manual
+backup** of the database. The required steps are included in the
+[k8s-backend guide](./doc/k8s-backend.md#manually-creating-a-backup-of-linstor-internal-resources).
+
 # Upgrade from v1.7 to v1.8
 
 If you need to set the number of worker threads, or you need to set the log level of LINSTOR components, please update

--- a/charts/piraeus/templates/legacy-check.yaml
+++ b/charts/piraeus/templates/legacy-check.yaml
@@ -16,7 +16,3 @@ Update check to make sure no legacy settings are used
 {{- if .Values.operator.satelliteSet.kernelModImage -}}
   {{ fail "Detected use of legacy key 'operator.satelliteSet.kernelModImage'. Use 'operator.satelliteSet.kernelModuleInjectionImage' instead" }}
 {{- end -}}
-
-{{- if and .Release.IsUpgrade (eq .Values.operator.controller.dbConnectionURL "k8s") (not .Values.IHaveBackedUpAllMyLinstorResources) }}
-  {{ fail "Detected upgrade involving the 'k8s' backend. This is currently in the very early stages, so expect issues. Check out ./doc/k8s-backend.md to learn how to create a backup before upgrading." }}
-{{- end -}}

--- a/charts/piraeus/values.cn.yaml
+++ b/charts/piraeus/values.cn.yaml
@@ -1,4 +1,3 @@
-IHaveBackedUpAllMyLinstorResources: false
 global:
   imagePullPolicy: IfNotPresent # empty pull policy means k8s default is used ("always" if tag == ":latest", "ifnotpresent" else)
   setSecurityContext: true # Force non-privileged containers to run as non-root users

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -1,4 +1,3 @@
-IHaveBackedUpAllMyLinstorResources: false
 global:
   imagePullPolicy: IfNotPresent # empty pull policy means k8s default is used ("always" if tag == ":latest", "ifnotpresent" else)
   setSecurityContext: true # Force non-privileged containers to run as non-root users

--- a/doc/k8s-backend.md
+++ b/doc/k8s-backend.md
@@ -23,14 +23,13 @@ Then apply it using:
 $ helm install piraeus-op ./charts/piraeus --values k8s-backend.yaml
 ```
 
-However, since this feature is quite new, there might be situations in which LINSTOR fails to upgrade resources,
-leaving the LINSTOR cluster in an unusable state. For this reason, we strongly recommend doing a manual backup
-of all LINSTOR resources before upgrading the cluster.
+Since operator version v1.8.0, the operator will create a snapshot of all LINSTOR internal resources
+before changing the controller image. The backup is available as a secret named `linstor-backup-<hash>`.
 
-Beginning with operator version v1.8.0, the operator will create a snapshot of all LINSTOR internal resources
-before changing the controller image. The backup is available as a secret named `linstor-backup-<hash>`. To copy
-the backup to your local machine, you can use the following command:
+**Upgrades from before 1.8.0** will skip the above backup step, so you should always do a manual backup (described
+below) in this case.
 
+To copy the backup to your local machine, you can use the following command:
 ```
 kubectl get secret linstor-backup-<hash> -o 'go-template={{index .data ".binaryData.backup.tar.gz" | base64decode}}' > linstor-backup.tar.gz
 ```
@@ -45,9 +44,6 @@ that the backup is safe and the operator can proceed:
 kubectl cp <piraeus-operator-pod>:/run/linstor-backups/linstor-backup-<some-hash>.tar.gz <destination-path>
 kubectl create secret linstor-backup-<same-hash>
 ```
-
-We will remove the `IHaveBackedUpAllMyLinstorResources=true` switch in a release after 1.8.0. Upgrades from before
-1.8.0 will skip the above backup step, so you should always do a manual backup (described below) in this case.
 
 ## Manually creating a backup of LINSTOR internal resources
 
@@ -65,8 +61,7 @@ We will remove the `IHaveBackedUpAllMyLinstorResources=true` switch in a release
    ```
    $ kubectl get crds | grep -o ".*.internal.linstor.linbit.com" | xargs -i{} sh -c "kubectl get {} -oyaml > {}.yaml"
    ```
-4. Run the chart upgrade using `--set IHaveBackedUpAllMyLinstorResources=true` to acknowledge you have executed the
-   above steps.
+4. Run the chart upgrade.
 
 ## Restore a backup after a failed upgrade
 


### PR DESCRIPTION
Operator 1.8.0 already creates a backup, so explicit confirmation by the
user is no longer needed. Instead, add some warnings in the documentation
for users upgrading from before 1.8.0.
