### PR TITLE
added healthz containerPort to linstor-csi-plugin containers

### DIFF
--- a/pkg/controller/linstorcsidriver/linstorcsidriver_controller.go
+++ b/pkg/controller/linstorcsidriver/linstorcsidriver_controller.go
@@ -693,6 +693,13 @@ func newCSINodeDaemonSet(csiResource *piraeusv1.LinstorCSIDriver) *appsv1.Daemon
 		Name:            "linstor-csi-plugin",
 		Image:           csiResource.Spec.LinstorPluginImage,
 		ImagePullPolicy: csiResource.Spec.ImagePullPolicy,
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "healthz",
+				ContainerPort: int32(DefaultHealthPort),
+				Protocol:      corev1.ProtocolTCP,
+			},
+		},
 		Args: []string{
 			"--csi-endpoint=unix://$(CSI_ENDPOINT)",
 			"--node=$(KUBE_NODE_NAME)",
@@ -916,6 +923,13 @@ func newCSIControllerDeployment(csiResource *piraeusv1.LinstorCSIDriver) *appsv1
 		Name:            "linstor-csi-plugin",
 		Image:           csiResource.Spec.LinstorPluginImage,
 		ImagePullPolicy: csiResource.Spec.ImagePullPolicy,
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "healthz",
+				ContainerPort: int32(DefaultHealthPort),
+				Protocol:      corev1.ProtocolTCP,
+			},
+		},
 		Args: []string{
 			"--csi-endpoint=unix://$(ADDRESS)",
 			"--node=$(KUBE_NODE_NAME)",


### PR DESCRIPTION
Linkerd requires the health probe ports to be defined in the container spec. I.e.

```yaml
ports:
- containerPort: 9808
  name: healthz
  protocol: TCP
```

This PR applies the changes to the `linstor-csi-plugin` health probes to allow the csi daemonset (nodes) and csi deployment (controller) to be meshed. 

#304 