### PR TITLE
chart: fix ugprading from old CRDs

### DIFF
--- a/charts/piraeus/templates/operator-controller.yaml
+++ b/charts/piraeus/templates/operator-controller.yaml
@@ -38,8 +38,6 @@ spec:
   {{- end }}
   {{- if .Values.operator.controller.httpBindAddress }}
   httpBindAddress: {{ .Values.operator.controller.httpBindAddress | quote }}
-  {{- else if (include "controller.sslSecretName" .) }}
-  httpBindAddress: "127.0.0.1"
   {{- end }}
   {{- if .Values.operator.controller.httpsBindAddress }}
   httpsBindAddress: {{ .Values.operator.controller.httpsBindAddress | quote }}


### PR DESCRIPTION
Using `httpBindAddress` caused validation to fail if upgrading from older
releases with TLS configured. Since LINSTOR already redirects from HTTP
to HTTPS in all cases, the default http address does not need to be
reconfigured when TLS is used.