### PR TITLE
satellite: continue if controller unreachable

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -83,6 +83,7 @@ linters:
     - dupl
     - goerr113
     - exhaustivestruct
+    - exhaustruct
     - gomoddirectives
     - golint
     - maligned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Satellite operator now reports basic satellite status even if controller is not reachable
+
 ## [v1.8.2] - 2022-05-24
 
 ### Added


### PR DESCRIPTION
We should always set a satellite status. While implementing a check
for controller reachability, we unintentionally broke that behaviour again.
This meant that status updates would fail, which in turn meant that we would
run into ever longer back-off loops in the reconcile loops, making eventual
recovery very slow.

This commit omits the reachability check during status collection in favor
of having shorter timeouts on the linstor requests.

Rather old-school PR... I think I've worked on a variation of this problem for almost 2 years now :grinning: 