### PR TITLE
Introduce kernelModuleInjectionExtraVolumeMounts option

### DIFF
--- a/charts/piraeus/crds/piraeus.linbit.com_linstorsatellitesets.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstorsatellitesets.yaml
@@ -2489,6 +2489,47 @@ spec:
                   If unset, defaults to /usr/src. To disable the mount, specify "none".
                 nullable: true
                 type: string
+              kernelModuleInjectionExtraVolumeMounts:
+                description: KernelModuleInjectionExtraVolumeMounts are additional
+                  volumes mounts for the kernel module builder/injector container.
+                items:
+                  description: VolumeMount describes a mounting of a Volume within
+                    a container.
+                  properties:
+                    mountPath:
+                      description: Path within the container at which the volume should
+                        be mounted.  Must not contain ':'.
+                      type: string
+                    mountPropagation:
+                      description: mountPropagation determines how mounts are propagated
+                        from the host to container and the other way around. When
+                        not set, MountPropagationNone is used. This field is beta
+                        in 1.10.
+                      type: string
+                    name:
+                      description: This must match the Name of a Volume.
+                      type: string
+                    readOnly:
+                      description: Mounted read-only if true, read-write otherwise
+                        (false or unspecified). Defaults to false.
+                      type: boolean
+                    subPath:
+                      description: Path within the volume from which the container's
+                        volume should be mounted. Defaults to "" (volume's root).
+                      type: string
+                    subPathExpr:
+                      description: Expanded path within the volume from which the
+                        container's volume should be mounted. Behaves similarly to
+                        SubPath but environment variable references $(VAR_NAME) are
+                        expanded using the container's environment. Defaults to ""
+                        (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                      type: string
+                  required:
+                  - mountPath
+                  - name
+                  type: object
+                nullable: true
+                type: array
               kernelModuleInjectionImage:
                 description: kernelModuleInjectionImage is the image (location + tag)
                   for the LINSTOR/DRBD kernel module injector

--- a/charts/piraeus/templates/operator-satelliteset.yaml
+++ b/charts/piraeus/templates/operator-satelliteset.yaml
@@ -36,6 +36,9 @@ spec:
   {{- if .Values.operator.satelliteSet.kernelModuleInjectionAdditionalSourceDirectory }}
   kernelModuleInjectionAdditionalSourceDirectory: {{ .Values.operator.satelliteSet.kernelModuleInjectionAdditionalSourceDirectory | quote }}
   {{- end }}
+  {{- if .Values.operator.satelliteSet.kernelModuleInjectionExtraVolumeMounts }}
+  kernelModuleInjectionExtraVolumeMounts: {{ .Values.operator.satelliteSet.kernelModuleInjectionExtraVolumeMounts | toJson }}
+  {{- end }}
   {{- if .Values.operator.satelliteSet.storagePools }}
   storagePools:
 {{ toYaml .Values.operator.satelliteSet.storagePools | indent 4 }}

--- a/charts/piraeus/values.cn.yaml
+++ b/charts/piraeus/values.cn.yaml
@@ -113,6 +113,7 @@ operator:
     kernelModuleInjectionMode: Compile
     kernelModuleInjectionAdditionalSourceDirectory: ""
     kernelModuleInjectionResources: {}
+    kernelModuleInjectionExtraVolumeMounts: []
     additionalEnv: []
     sidecars: []
     extraVolumes: []

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -113,6 +113,7 @@ operator:
     kernelModuleInjectionMode: Compile
     kernelModuleInjectionAdditionalSourceDirectory: ""
     kernelModuleInjectionResources: {}
+    kernelModuleInjectionExtraVolumeMounts: []
     additionalEnv: []
     sidecars: []
     extraVolumes: []

--- a/pkg/apis/piraeus/v1/linstorsatelliteset_types.go
+++ b/pkg/apis/piraeus/v1/linstorsatelliteset_types.go
@@ -85,6 +85,11 @@ type LinstorSatelliteSetSpec struct {
 	// +nullable
 	KernelModuleInjectionAdditionalSourceDirectory string `json:"kernelModuleInjectionAdditionalSourceDirectory,omitempty"`
 
+	// KernelModuleInjectionExtraVolumeMounts are additional volumes mounts for the kernel module builder/injector container.
+	// +optional
+	// +nullable
+	KernelModuleInjectionExtraVolumeMounts []corev1.VolumeMount `json:"kernelModuleInjectionExtraVolumeMounts"`
+
 	// Resource requirements for the kernel module builder/injector container
 	// +optional
 	// +nullable

--- a/pkg/apis/piraeus/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/piraeus/v1/zz_generated.deepcopy.go
@@ -423,6 +423,13 @@ func (in *LinstorSatelliteSetSpec) DeepCopyInto(out *LinstorSatelliteSetSpec) {
 		**out = **in
 	}
 	in.Resources.DeepCopyInto(&out.Resources)
+	if in.KernelModuleInjectionExtraVolumeMounts != nil {
+		in, out := &in.KernelModuleInjectionExtraVolumeMounts, &out.KernelModuleInjectionExtraVolumeMounts
+		*out = make([]corev1.VolumeMount, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	in.KernelModuleInjectionResources.DeepCopyInto(&out.KernelModuleInjectionResources)
 	if in.Affinity != nil {
 		in, out := &in.Affinity, &out.Affinity

--- a/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
+++ b/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
@@ -1200,6 +1200,15 @@ func daemonSetWithDRBDKernelModuleInjection(ds *apps.DaemonSet, satelliteSet *pi
 		},
 	)
 
+	volumeMounts := satelliteSet.Spec.KernelModuleInjectionExtraVolumeMounts
+	volumeMounts = append(volumeMounts, corev1.VolumeMount{
+		// VolumumeSource for this directory is already present on the base
+		// daemonset.
+		Name:      kubeSpec.ModulesDirName,
+		MountPath: kubeSpec.ModulesDir,
+	},
+	)
+
 	ds.Spec.Template.Spec.InitContainers = []corev1.Container{
 		{
 			Name:            "kernel-module-injector",
@@ -1207,15 +1216,8 @@ func daemonSetWithDRBDKernelModuleInjection(ds *apps.DaemonSet, satelliteSet *pi
 			ImagePullPolicy: satelliteSet.Spec.ImagePullPolicy,
 			SecurityContext: &corev1.SecurityContext{Privileged: &kubeSpec.Privileged},
 			Env:             env,
-			VolumeMounts: []corev1.VolumeMount{
-				// VolumumeSource for this directory is already present on the base
-				// daemonset.
-				{
-					Name:      kubeSpec.ModulesDirName,
-					MountPath: kubeSpec.ModulesDir,
-				},
-			},
-			Resources: satelliteSet.Spec.KernelModuleInjectionResources,
+			VolumeMounts:    volumeMounts,
+			Resources:       satelliteSet.Spec.KernelModuleInjectionResources,
 		},
 	}
 


### PR DESCRIPTION
Allows to specify extra volumeMounts for kernel-module-injector `kernelModuleInjectionExtraVolumeMounts`.

Fixes https://github.com/piraeusdatastore/piraeus-operator/issues/315