### PR TITLE
fix lastAppliedAnnotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Query single satellite devices to receive errors when the satellite is offline instead of assuming
   devices are already configured.
 
+### Fixed
+
+- `last-applied-configuration `annotation was never updated, so updating of some fields was not performed correctly.
+
 ## [v1.8.2] - 2022-05-24
 
 ### Added


### PR DESCRIPTION
It seems the last applied annotation is never updated for existing objects.
This PR adds it to generate three way merge patch.

Some logic borrowed here:
https://github.com/kubernetes/kubectl/blob/b5fe0f6e9c65ea95a2118746b7e04822255d76c2/pkg/util/apply.go#L67-L117

fixes https://github.com/piraeusdatastore/piraeus-operator/issues/321