### PR TITLE
Fix controller's service monitor when using TLS

### DIFF
--- a/pkg/controller/linstorcontroller/linstorcontroller_controller.go
+++ b/pkg/controller/linstorcontroller/linstorcontroller_controller.go
@@ -239,7 +239,7 @@ func (r *ReconcileLinstorController) reconcileSpec(ctx context.Context, controll
 
 		serviceMonitor.Spec.Endpoints[0].Path = "/metrics"
 
-		if !controllerResource.Spec.SslConfig.IsPlain() {
+		if controllerResource.Spec.LinstorHttpsControllerSecret != "" {
 			serviceMonitor.Spec.Endpoints[0].Scheme = "https"
 			serviceMonitor.Spec.Endpoints[0].TLSConfig = &monitoringv1.TLSConfig{
 				SafeTLSConfig: monitoringv1.SafeTLSConfig{


### PR DESCRIPTION
The presence of `HttpsControllerSecret`, not `SslConfig`, is what enables the controller's HTTPS port and client secret.

https://github.com/piraeusdatastore/piraeus-operator/blob/master/pkg/controller/linstorcontroller/linstorcontroller_controller.go#L658

https://github.com/piraeusdatastore/piraeus-operator/blob/master/pkg/controller/linstorcontroller/linstorcontroller_controller.go#L787 

Prior to this fix, a controller with HTTPS secrets configured but _not_ SslConfig would generate a ServiceMonitor that would erroneously attempt to scrape over HTTP.

https://github.com/piraeusdatastore/piraeus-operator/blob/master/pkg/controller/linstorcontroller/linstorcontroller_controller.go#L242