### PR TITLE
satellites: only restore evicted sat. on ready nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Restoring satellites after eviction only happens if the node is ready.
+
 ## [v1.9.1] - 2022-07-27
 
 ### Fixed

--- a/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
+++ b/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
@@ -557,7 +557,15 @@ func (r *ReconcileLinstorSatelliteSet) reconcileSingleNodeRegistration(ctx conte
 		return fmt.Errorf("failed to reconcile satellite: %w", err)
 	}
 
-	if mdutil.SliceContains(lNode.Flags, linstor.FlagEvicted) {
+	nodeReady := false
+
+	for _, cond := range k8sNode.Status.Conditions {
+		if cond.Type == corev1.NodeReady {
+			nodeReady = cond.Status == corev1.ConditionTrue
+		}
+	}
+
+	if nodeReady && mdutil.SliceContains(lNode.Flags, linstor.FlagEvicted) {
 		// The pod exists, so there is no reason not to restore it.
 		err := linstorClient.Nodes.Restore(ctx, lNode.Name, lapi.NodeRestore{})
 		if err != nil {


### PR DESCRIPTION
We automatically restore evicted satellites if the pod is running. Since the status of a pod is responsibility of the kubelet, i.e. the actual node, an offline node will still show running pods.

In order to prevent restoring satellites that are still offline, we check the node ready condition in addition to the pod status. This way we can be reasonably sure that the satellite is actually reachable.
