### PR TITLE
satellite: change default monitoring address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Can set the variable `mountDrbdResourceDirectoriesFromHost` in the Helm chart to create hostPath Volumes for DRBD and LINSTOR configuration directories for the satellite set.
 
+### Changed
+
+- Change default bind address for satellite monitoring to use IPv6 anylocal `[::]`. This will still to work on IPv4
+  only systems with IPv6 disabled via sysctl.
+
 ## [v1.10.0-rc.1] - 2022-09-21
 
 ### Fixed

--- a/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
+++ b/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
@@ -1222,7 +1222,7 @@ func newSatelliteConfigMap(satelliteSet *piraeusv1.LinstorSatelliteSet) (*corev1
 func newMonitoringConfigMap(set *piraeusv1.LinstorSatelliteSet) *corev1.ConfigMap {
 	bindAddress := set.Spec.MonitoringBindAddress
 	if bindAddress == "" {
-		bindAddress = "0.0.0.0"
+		bindAddress = "[::]"
 	}
 	return &corev1.ConfigMap{
 		ObjectMeta: getObjectMeta(set, "%s-node-monitoring"),


### PR DESCRIPTION
The default monitoring address should also work in dualstack or IPV6-only clusters. Luckily, this can easily be achieved by using the special "[::]" IPv6 bind address, which binds to any IPv4 _and_ IPv6 address. It also works if IPv6 is completely disabled via sysctls.