### PR TITLE
satellite: support setting VG name on LVM thinpool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Creating LVM thinpools no longer limits the ability to choose a VolumeGroup name.
+
 ## [v1.10.0] - 2022-10-18
 
 ### Added

--- a/doc/storage.md
+++ b/doc/storage.md
@@ -108,8 +108,7 @@ Note that a LVM configuration for Piraeus will result in volume snapshot creatio
 
 #### `lvmThinPools` configuration
 * `name` name of the LINSTOR storage pool. Required
-* `volumeGroup` VG to use for the thin pool. If you want to use `devicePaths`, you must set this to `""`.
-  This is required because LINSTOR does not allow configuration of the VG name when preparing devices.
+* `volumeGroup` VG to use for the thin pool.
 * `thinVolume` name of the thinpool. Required
 * `devicePaths` devices to configure for this pool. Must be empty and >= 1GiB to be recognized. Optional
 * `raidLevel` LVM raid level. Optional

--- a/pkg/apis/piraeus/shared/linstor_types.go
+++ b/pkg/apis/piraeus/shared/linstor_types.go
@@ -234,7 +234,7 @@ func (in *StoragePoolLVM) ToPhysicalStorageCreate() lapi.PhysicalStorageCreate {
 }
 
 func (in *StoragePoolLVMThin) CreatedVolumeGroup() string {
-	if len(in.DevicePaths) != 0 {
+	if in.VolumeGroup == "" {
 		return fmt.Sprintf("linstor_%s", in.ThinVolume)
 	}
 
@@ -263,7 +263,7 @@ func (in *StoragePoolLVMThin) ToLinstorStoragePool() lapi.StoragePool {
 func (in *StoragePoolLVMThin) ToPhysicalStorageCreate() lapi.PhysicalStorageCreate {
 	return lapi.PhysicalStorageCreate{
 		DevicePaths:  in.DevicePaths,
-		PoolName:     in.ThinVolume,
+		PoolName:     fmt.Sprintf("%s/%s", in.CreatedVolumeGroup(), in.ThinVolume),
 		ProviderKind: lapi.LVM_THIN,
 		RaidLevel:    in.RaidLevel,
 		WithStoragePool: lapi.PhysicalStorageStoragePoolCreate{

--- a/pkg/apis/piraeus/shared/linstor_types_test.go
+++ b/pkg/apis/piraeus/shared/linstor_types_test.go
@@ -122,7 +122,7 @@ func TestToPhysicalStorageCreate(t *testing.T) {
 				ThinVolume:  "test0ThinPool",
 			},
 			lapi.PhysicalStorageCreate{
-				PoolName:     "test0ThinPool",
+				PoolName:     "test0VolumeGroup/test0ThinPool",
 				ProviderKind: lapi.LVM_THIN,
 				RaidLevel:    "raid(-1)",
 				WithStoragePool: lapi.PhysicalStorageStoragePoolCreate{

--- a/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
+++ b/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
@@ -385,23 +385,6 @@ func (r *ReconcileLinstorSatelliteSet) reconcileResource(ctx context.Context, sa
 
 	logger.Debugf("finished upgrade/fill: #2 -> Set default automatic storage setup type: changed=%t", changed)
 
-	logger.Debug("performing upgrade/full: #3 -> Set default VG name for LVMTHIN pools with device spec")
-
-	// linstor will automatically create a VG named "linstor_$THINNAME" when creating LVMTHIN pools.
-	for _, pool := range satelliteSet.Spec.StoragePools.LVMThinPools {
-		if len(pool.DevicePaths) == 0 {
-			continue
-		}
-
-		if pool.VolumeGroup == "" || pool.VolumeGroup == pool.CreatedVolumeGroup() {
-			continue
-		}
-
-		return fmt.Errorf("lvmThinPools: `devicePaths` is set, but `volumeGroup` is not empty and does not match expected `linstor_$THINVOLUME` value: '%s'", pool.VolumeGroup)
-	}
-
-	logger.Debugf("performing upgrade/full: #3 -> Set default VG name for LVMTHIN pools with device spec: changed=%t", changed)
-
 	logger.Debug("finished all upgrades/fills")
 
 	if changed {


### PR DESCRIPTION
LINSTOR 1.20.0 allows us to specify the VG name when creating lvmthin storage pools with the physical-storage API. So we can relax our checks a bit and optionally add the custom VG name to the creation request.