### PR TITLE
Add k8s resources used by the operator

### DIFF
--- a/pkg/resources/cluster/controller/controller-cluster-role-binding.yaml
+++ b/pkg/resources/cluster/controller/controller-cluster-role-binding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linstor-controller
+  labels:
+    app.kubernetes.io/component: linstor-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: linstor-controller
+subjects:
+  - kind: ServiceAccount
+    name: linstor-controller

--- a/pkg/resources/cluster/controller/controller-cluster-role.yaml
+++ b/pkg/resources/cluster/controller/controller-cluster-role.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: linstor-controller
+  labels:
+    app.kubernetes.io/component: linstor-controller
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+      - delete
+  - apiGroups:
+      - internal.linstor.linbit.com
+    resources:
+      - "*"
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+      - delete

--- a/pkg/resources/cluster/controller/controller-config.yaml
+++ b/pkg/resources/cluster/controller/controller-config.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: linstor-controller-config
+  labels:
+    app.kubernetes.io/component: linstor-controller
+data:
+  linstor.toml: |
+    [db]
+      connection_url = "k8s"

--- a/pkg/resources/cluster/controller/controller-deployment.yaml
+++ b/pkg/resources/cluster/controller/controller-deployment.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: linstor-controller
+  labels:
+    app.kubernetes.io/component: linstor-controller
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: linstor-controller
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: linstor-controller
+      labels:
+        app.kubernetes.io/component: linstor-controller
+    spec:
+      containers:
+        - name: linstor-controller
+          image: linstor-controller
+          args:
+            - startController
+          env:
+            - name: JAVA_OPTS
+              value: '-Djdk.tls.acknowledgeCloseNotify=true'
+            - name: MASTER_PASSPHRASE
+              valueFrom:
+                secretKeyRef:
+                  name: linstor-controller-passphrase
+                  key: MASTER_PASSPHRASE
+                  optional: true
+          ports:
+            - name: api
+              containerPort: 3370
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              port: api
+          startupProbe:
+            httpGet:
+              port: api
+            failureThreshold: 30
+            periodSeconds: 10
+          securityContext:
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /var/log/linstor-controller
+              name: var-log-linstor-controller
+            - mountPath: /etc/linstor
+              name: etc-linstor
+              readOnly: true
+            - mountPath: /tmp
+              name: tmp
+      enableServiceLinks: false
+      serviceAccountName: linstor-controller
+      volumes:
+        - name: etc-linstor
+          configMap:
+            name: linstor-controller-config
+        - name: var-log-linstor-controller
+          emptyDir: { }
+        - name: tmp
+          emptyDir: { }
+      tolerations:
+        - key: "node.kubernetes.io/unreachable"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 30
+        - key: "node.kubernetes.io/not-ready"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 30

--- a/pkg/resources/cluster/controller/controller-service-account.yaml
+++ b/pkg/resources/cluster/controller/controller-service-account.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: linstor-controller
+  labels:
+    app.kubernetes.io/component: linstor-controller

--- a/pkg/resources/cluster/controller/controller-service.yaml
+++ b/pkg/resources/cluster/controller/controller-service.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: linstor-controller
+  labels:
+    app.kubernetes.io/component: linstor-controller
+spec:
+  selector:
+    app.kubernetes.io/component: linstor-controller
+  ipFamilyPolicy: PreferDualStack
+  ports:
+    - port: 3370
+      name: api

--- a/pkg/resources/cluster/controller/kustomization.yaml
+++ b/pkg/resources/cluster/controller/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - controller-deployment.yaml
+  - controller-config.yaml
+  - controller-service.yaml
+  - controller-service-account.yaml
+  - controller-cluster-role.yaml
+  - controller-cluster-role-binding.yaml

--- a/pkg/resources/cluster/csi/csi-controller-deployment.yaml
+++ b/pkg/resources/cluster/csi/csi-controller-deployment.yaml
@@ -1,0 +1,191 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: csi-controller
+  labels:
+    app.kubernetes.io/component: csi-controller
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: csi-controller
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: linstor-csi
+      labels:
+        app.kubernetes.io/component: csi-controller
+    spec:
+      enableServiceLinks: false
+      serviceAccountName: csi-controller
+      initContainers:
+        - name: linstor-wait-api-online
+          image: linstor-csi
+          command:
+            - /linstor-wait-until
+            - api-online
+          env:
+            - name: LS_CONTROLLERS
+              value: 'http://linstor-controller:3370'
+          securityContext:
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      containers:
+        - name: linstor-csi
+          image: linstor-csi
+          args:
+            - --csi-endpoint=unix://$(ADDRESS)
+            - --linstor-endpoint=$(LS_CONTROLLERS)
+            - --property-namespace=Aux/topology
+            - --label-by-storage-pool=false
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: LS_CONTROLLERS
+              value: 'http://linstor-controller:3370'
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          ports:
+            - name: healthz
+              containerPort: 9808
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          securityContext:
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+        - name: csi-attacher
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.5.0
+          args:
+            - '--v=5'
+            - '--csi-address=$(ADDRESS)'
+            - '--timeout=1m'
+            - '--leader-election=true'
+            - '--leader-election-namespace=$(NAMESPACE)'
+            - '--worker-threads=10'
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          securityContext:
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+        - name: csi-livenessprobe
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.7.0
+          args:
+            - '--csi-address=$(ADDRESS)'
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          securityContext:
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+        - name: csi-provisioner
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.2.1
+          args:
+            - '--csi-address=$(ADDRESS)'
+            - '--timeout=1m'
+            - '--default-fstype=ext4'
+            - '--feature-gates=Topology=true'
+            - '--leader-election=true'
+            - '--leader-election-namespace=$(NAMESPACE)'
+            - '--enable-capacity'
+            - '--extra-create-metadata'
+            - '--capacity-ownerref-level=2'
+            - '--worker-threads=10'
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          securityContext:
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+        - name: csi-snapshotter
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1
+          args:
+            - '--timeout=1m'
+            - '--csi-address=$(ADDRESS)'
+            - '--leader-election=true'
+            - '--leader-election-namespace=$(NAMESPACE)'
+            - '--worker-threads=10'
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          securityContext:
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+        - name: csi-resizer
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.5.0
+          args:
+            - '--v=5'
+            - '--csi-address=$(ADDRESS)'
+            - '--timeout=1m'
+            - '--handle-volume-inuse-error=false'
+            - '--leader-election=true'
+            - '--leader-election-namespace=$(NAMESPACE)'
+            - '--workers=10'
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          securityContext:
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: socket-dir
+          emptyDir: {}

--- a/pkg/resources/cluster/csi/csi-controller-service-account.yaml
+++ b/pkg/resources/cluster/csi/csi-controller-service-account.yaml
@@ -1,0 +1,134 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-controller
+  labels:
+    app.kubernetes.io/component: csi-controller
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-controller
+rules:
+# csi attacher rules
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumes" ]
+    verbs: [ "get", "list", "watch", "patch" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "csinodes" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "volumeattachments" ]
+    verbs: [ "get", "list", "watch", "patch" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "volumeattachments/status" ]
+    verbs: [ "patch" ]
+# csi-resizer rules
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumes" ]
+    verbs: [ "get", "list", "watch", "patch" ]
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumeclaims" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "pods" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumeclaims/status" ]
+    verbs: [ "patch" ]
+  - apiGroups: [ "" ]
+    resources: [ "events" ]
+    verbs: [ "list", "watch", "create", "update", "patch" ]
+# csi-provisioner rules
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumes" ]
+    verbs: [ "get", "list", "watch", "create", "delete" ]
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumeclaims" ]
+    verbs: [ "get", "list", "watch", "update" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "storageclasses" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "events" ]
+    verbs: [ "list", "watch", "create", "update", "patch" ]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources: [ "volumesnapshots" ]
+    verbs: [ "get", "list" ]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources: [ "volumesnapshotcontents" ]
+    verbs: [ "get", "list" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "csinodes" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "nodes" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "volumeattachments" ]
+    verbs: [ "get", "list", "watch" ]
+# csi-snapshotter rules
+  - apiGroups: [ "" ]
+    resources: [ "events" ]
+    verbs: [ "list", "watch", "create", "update", "patch" ]
+  - apiGroups: [ "" ]
+    resources: [ "secrets" ]
+    verbs: [ "get", "list" ]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources: [ "volumesnapshotclasses" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources: [ "volumesnapshotcontents" ]
+    verbs: [ "get", "list", "watch", "update", "patch" ]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources: [ "volumesnapshotcontents/status" ]
+    verbs: [ "update", "patch" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-controller
+  labels:
+    app.kubernetes.io/component: csi-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: csi-controller
+subjects:
+  - kind: ServiceAccount
+    name: csi-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: csi-controller
+  labels:
+    app.kubernetes.io/component: csi-controller
+rules:
+  - apiGroups: [ "coordination.k8s.io" ]
+    resources: [ "leases" ]
+    verbs: [ "get", "watch", "list", "delete", "update", "create" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "csistoragecapacities" ]
+    verbs: [ "get", "list", "watch", "create", "update", "patch", "delete" ]
+  - apiGroups: [ "" ]
+    resources: [ "pods" ]
+    verbs: [ "get" ]
+  - apiGroups: [ "apps" ]
+    resources: [ "replicasets" ]
+    verbs: [ "get" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: csi-controller
+  labels:
+    app.kubernetes.io/component: csi-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: csi-controller
+subjects:
+  - kind: ServiceAccount
+    name: csi-controller

--- a/pkg/resources/cluster/csi/csi-driver.yaml
+++ b/pkg/resources/cluster/csi/csi-driver.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: linstor.csi.linbit.com
+spec:
+  attachRequired: true
+  fsGroupPolicy: ReadWriteOnceWithFSType
+  podInfoOnMount: true
+  volumeLifecycleModes:
+    - Persistent
+  storageCapacity: true
+  requiresRepublish: false

--- a/pkg/resources/cluster/csi/csi-node-daemon-set.yaml
+++ b/pkg/resources/cluster/csi/csi-node-daemon-set.yaml
@@ -1,0 +1,136 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: csi-node
+  labels:
+    app.kubernetes.io/component: csi-node
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: csi-node
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: linstor-csi
+      labels:
+        app.kubernetes.io/component: csi-node
+    spec:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      serviceAccountName: csi-node
+      initContainers:
+        - name: linstor-wait-node-online
+          image: linstor-csi
+          command:
+            - /linstor-wait-until
+            - satellite-online
+            - $(KUBE_NODE_NAME)
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: LS_CONTROLLERS
+              value: 'http://linstor-controller:3370'
+      containers:
+        - name: linstor-csi
+          image: linstor-csi
+          args:
+            - --csi-endpoint=unix://$(CSI_ENDPOINT)
+            - --node=$(KUBE_NODE_NAME)
+            - --linstor-endpoint=$(LS_CONTROLLERS)
+            - --property-namespace=Aux/topology
+            - --label-by-storage-pool=false
+          securityContext:
+            readOnlyRootFilesystem: true
+            privileged: true
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - SYS_ADMIN
+          env:
+            - name: CSI_ENDPOINT
+              value: /var/lib/kubelet/plugins/linstor.csi.linbit.com/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: LS_CONTROLLERS
+              value: 'http://linstor-controller:3370'
+          ports:
+            - containerPort: 9808
+              name: healthz
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: publish-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: Bidirectional
+            - name: device-dir
+              mountPath: /dev
+        - name: csi-node-driver-registrar
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+          args:
+            - '--v=5'
+            - '--csi-address=/csi/csi.sock'
+            - '--kubelet-registration-path=/var/lib/kubelet/plugins/linstor.csi.linbit.com/csi.sock'
+            - '--health-port=9809'
+          securityContext:
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - containerPort: 9809
+              name: healthz
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+        - name: csi-livenessprobe
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.7.0
+          securityContext:
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+          args:
+            - '--csi-address=/csi/csi.sock'
+      volumes:
+        - name: device-dir
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: publish-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/linstor.csi.linbit.com
+            type: DirectoryOrCreate

--- a/pkg/resources/cluster/csi/csi-node-service-account.yaml
+++ b/pkg/resources/cluster/csi/csi-node-service-account.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-node
+  labels:
+    app.kubernetes.io/component: csi-node

--- a/pkg/resources/cluster/csi/kustomization.yaml
+++ b/pkg/resources/cluster/csi/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - csi-node-daemon-set.yaml
+  - csi-node-service-account.yaml
+  - csi-driver.yaml
+  - csi-controller-deployment.yaml
+  - csi-controller-service-account.yaml

--- a/pkg/resources/cluster/resources.go
+++ b/pkg/resources/cluster/resources.go
@@ -1,0 +1,6 @@
+package cluster
+
+import "embed"
+
+//go:embed satellite-common controller csi satellite
+var Resources embed.FS

--- a/pkg/resources/cluster/satellite-common/kustomization.yaml
+++ b/pkg/resources/cluster/satellite-common/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - network-policy.yaml
+  - service-account.yaml

--- a/pkg/resources/cluster/satellite-common/network-policy.yaml
+++ b/pkg/resources/cluster/satellite-common/network-policy.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: satellite
+  labels:
+    app.kubernetes.io/component: linstor-satellite
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: linstor-satellite
+  policyTypes:
+  - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: linstor-controller
+      ports:
+        - protocol: TCP
+          port: 3366
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: linstor-satellite
+      ports:
+        - protocol: TCP
+          port: 7000
+          endPort: 9000
+    - from:
+        - namespaceSelector:
+            matchLabels: {}
+      ports:
+        - protocol: TCP
+          port: prometheus

--- a/pkg/resources/cluster/satellite-common/service-account.yaml
+++ b/pkg/resources/cluster/satellite-common/service-account.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: satellite
+  labels:
+    app.kubernetes.io/component: linstor-satellite

--- a/pkg/resources/cluster/satellite/kustomization.yaml
+++ b/pkg/resources/cluster/satellite/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - linstor-satellite.yaml

--- a/pkg/resources/cluster/satellite/linstor-satellite.yaml
+++ b/pkg/resources/cluster/satellite/linstor-satellite.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: piraeus.io/v1
+kind: LinstorSatellite
+metadata:
+  name: satellite
+spec:
+  clusterRef:
+    name: CLUSTER
+  patches: []
+  storagePools: []
+  properties:
+    - name: Aux/topology/linbit.com/hostname
+      valueFrom:
+        nodeFieldRef: metadata.name
+    - name: Aux/topology/kubernetes.io/hostname
+      valueFrom:
+        nodeFieldRef: metadata.labels['kubernetes.io/hostname']
+    - name: Aux/topology/topology.kubernetes.io/region
+      optional: true
+      valueFrom:
+        nodeFieldRef: metadata.labels['topology.kubernetes.io/region']
+    - name: Aux/topology/topology.kubernetes.io/zone
+      optional: true
+      valueFrom:
+        nodeFieldRef: metadata.labels['topology.kubernetes.io/zone']

--- a/pkg/resources/loader.go
+++ b/pkg/resources/loader.go
@@ -1,0 +1,67 @@
+package resources
+
+import (
+	"embed"
+	"io/fs"
+
+	"sigs.k8s.io/kustomize/api/krusty"
+	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+	"sigs.k8s.io/yaml"
+)
+
+type Kustomizer struct {
+	fsys       filesys.FileSystem
+	kustomizer *krusty.Kustomizer
+}
+
+func NewKustomizer(base *embed.FS, options *krusty.Options) (*Kustomizer, error) {
+	fsys := filesys.MakeFsInMemory()
+
+	err := fs.WalkDir(base, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			err := fsys.Mkdir(path)
+			if err != nil {
+				return err
+			}
+		} else {
+			content, err := base.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			err = fsys.WriteFile(path, content)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &Kustomizer{
+		fsys:       fsys,
+		kustomizer: krusty.MakeKustomizer(options),
+	}, nil
+}
+
+func (k *Kustomizer) Kustomize(kustomization *types.Kustomization) (resmap.ResMap, error) {
+	rawK, err := yaml.Marshal(kustomization)
+	if err != nil {
+		return nil, err
+	}
+
+	err = k.fsys.WriteFile("/kustomization.yaml", rawK)
+	if err != nil {
+		return nil, err
+	}
+
+	return k.kustomizer.Run(k.fsys, "/")
+}

--- a/pkg/resources/loader_test.go
+++ b/pkg/resources/loader_test.go
@@ -1,0 +1,82 @@
+package resources_test
+
+import (
+	"embed"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/kustomize/api/krusty"
+	"sigs.k8s.io/kustomize/api/types"
+
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/resources"
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/resources/test"
+)
+
+func TestNewKustomizer(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name      string
+		fs        *embed.FS
+		kustomize *types.Kustomization
+		expected  string
+	}{
+		{
+			name:      "empty",
+			fs:        &test.EmptyResources,
+			kustomize: &types.Kustomization{Resources: []string{"empty"}},
+		},
+		{
+			name:      "basic",
+			fs:        &test.BasicResources,
+			kustomize: &types.Kustomization{Resources: []string{"basic"}},
+			expected: `apiVersion: v1
+kind: Namespace
+metadata:
+  name: example
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-sa
+  namespace: example
+`,
+		},
+		{
+			name: "basic-patch",
+			fs:   &test.BasicResources,
+			kustomize: &types.Kustomization{
+				Resources:  []string{"basic"},
+				NamePrefix: "patch-",
+				Namespace:  "patched",
+			},
+			expected: `apiVersion: v1
+kind: Namespace
+metadata:
+  name: patched
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: patch-example-sa
+  namespace: patched
+`,
+		},
+	}
+
+	for i := range testcases {
+		tcase := &testcases[i]
+		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			kstmzr, err := resources.NewKustomizer(tcase.fs, krusty.MakeDefaultOptions())
+			assert.NoError(t, err)
+
+			resmap, err := kstmzr.Kustomize(tcase.kustomize)
+			assert.NoError(t, err)
+			actual, err := resmap.AsYaml()
+			assert.NoError(t, err)
+			assert.Equal(t, tcase.expected, string(actual))
+		})
+	}
+}

--- a/pkg/resources/satellite/pod/kustomization.yaml
+++ b/pkg/resources/satellite/pod/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - node-pod.yaml
+  - node-config.yaml

--- a/pkg/resources/satellite/pod/node-config.yaml
+++ b/pkg/resources/satellite/pod/node-config.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: satellite-config
+  labels:
+    app.kubernetes.io/component: linstor-satellite
+data:
+  linstor_satellite.toml: ""
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: reactor-config
+  labels:
+    app.kubernetes.io/component: linstor-satellite
+data:
+  prometheus.toml: |
+    [[prometheus]]
+    enums = true
+    address = "[::]:9942"

--- a/pkg/resources/satellite/pod/node-pod.yaml
+++ b/pkg/resources/satellite/pod/node-pod.yaml
@@ -1,0 +1,139 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: satellite
+  annotations:
+    kubectl.kubernetes.io/default-container: linstor-satellite
+  labels:
+    app.kubernetes.io/component: linstor-satellite
+spec:
+  automountServiceAccountToken: false
+  enableServiceLinks: false
+  serviceAccountName: satellite
+  initContainers:
+    - name: drbd-module-loader
+      image: drbd-module-loader
+      securityContext:
+        # NB: We don't use RO root here, as SELinux likes to complain
+        # if we try to insert a module from a emptyDir volume.
+        capabilities:
+          drop:
+            - ALL
+          add:
+            - SYS_MODULE
+      volumeMounts:
+        - mountPath: /usr/lib/modules
+          name: usr-lib-modules
+          readOnly: true
+        - mountPath: /usr/src
+          name: usr-src
+          readOnly: true
+  containers:
+    - name: linstor-satellite
+      image: linstor-satellite
+      args:
+        - startSatellite
+      securityContext:
+        readOnlyRootFilesystem: true
+        privileged: true
+        capabilities:
+          drop:
+            - ALL
+          add:
+            - NET_ADMIN
+            - SYS_ADMIN
+      volumeMounts:
+        - mountPath: /etc/linstor
+          name: satellite-config
+          readOnly: true
+        - mountPath: /dev
+          name: dev
+        - mountPath: /var/log/linstor-satellite
+          name: var-log-linstor-satellite
+        - mountPath: /var/lib/drbd
+          name: var-lib-drbd
+        - mountPath: /var/lib/linstor.d
+          name: var-lib-linstor-d
+        - mountPath: /etc/lvm/archive
+          name: etc-lvm-archive
+        - mountPath: /etc/lvm/backup
+          name: etc-lvm-backup
+        - mountPath: /run
+          name: run
+        - mountPath: tmp
+          name: tmp
+        - mountPath: /run/lock
+          name: run-lock
+    - name: drbd-reactor
+      image: drbd-reactor
+      ports:
+        - name: prometheus
+          containerPort: 9942
+          protocol: TCP
+      securityContext:
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+      volumeMounts:
+        - mountPath: /etc/drbd-reactor.d
+          name: reactor-config
+          readOnly: true
+  volumes:
+    - name: usr-lib-modules
+      hostPath:
+        path: /usr/lib/modules
+        type: Directory
+    - name: usr-src
+      hostPath:
+        path: /usr/src
+        type: Directory
+    - name: dev
+      hostPath:
+        path: /dev
+        type: Directory
+    - name: etc-lvm-archive
+      hostPath:
+        path: /etc/lvm/archive
+        type: DirectoryOrCreate
+    - name: etc-lvm-backup
+      hostPath:
+        path: /etc/lvm/backup
+        type: DirectoryOrCreate
+    - name: var-lib-linstor-d
+      hostPath:
+        path: /var/lib/linstor.d
+        type: DirectoryOrCreate
+    - name: var-lib-drbd
+      hostPath:
+        path: /var/lib/drbd
+        type: DirectoryOrCreate
+    - name: satellite-config
+      configMap:
+        name: satellite-config
+        defaultMode: 0440
+    - name: reactor-config
+      configMap:
+        name: reactor-config
+        defaultMode: 0440
+    - name: var-log-linstor-satellite
+      emptyDir: { }
+    - name: tmp
+      emptyDir: { }
+    - name: run-lock
+      emptyDir: { }
+    - name: run
+      emptyDir: { }
+  restartPolicy: Always
+  tolerations:
+    - key: node.kubernetes.io/not-ready
+      effect: NoExecute
+    - key: node.kubernetes.io/unreachable
+      effect: NoExecute
+    - key: node.kubernetes.io/disk-pressure
+      effect: NoSchedule
+    - key: node.kubernetes.io/memory-pressure
+      effect: NoSchedule
+    - key: node.kubernetes.io/unschedulable
+      effect: NoSchedule

--- a/pkg/resources/satellite/resources.go
+++ b/pkg/resources/satellite/resources.go
@@ -1,0 +1,6 @@
+package satellite
+
+import "embed"
+
+//go:embed pod
+var Resources embed.FS

--- a/pkg/resources/test/basic/kustomization.yaml
+++ b/pkg/resources/test/basic/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml

--- a/pkg/resources/test/basic/namespace.yaml
+++ b/pkg/resources/test/basic/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example

--- a/pkg/resources/test/basic/serviceaccount.yaml
+++ b/pkg/resources/test/basic/serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-sa
+  namespace: example

--- a/pkg/resources/test/empty/kustomization.yaml
+++ b/pkg/resources/test/empty/kustomization.yaml
@@ -1,0 +1,3 @@
+---
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1

--- a/pkg/resources/test/resources.go
+++ b/pkg/resources/test/resources.go
@@ -1,0 +1,11 @@
+package test
+
+import "embed"
+
+var (
+	//go:embed empty
+	EmptyResources embed.FS
+
+	//go:embed basic
+	BasicResources embed.FS
+)


### PR DESCRIPTION
Add the initial definitions for the resources controlled by the operator. There are two kinds of resources: cluster-wide and per-node resources.

Cluster-wide resources include:
* LINSTOR Controller Deployment
* LINSTOR CSI Driver Deployment + DaemonSet

Per-node resources include:
* Satellite Pod + Configuration

In addition to the raw resources, also include a small wrapper around the default kustomize packages, making it easy to create a "Kustomization" from embeded resources and a Kustomization struct.

Signed-off-by: Moritz "WanzenBug" Wanzenböck <moritz.wanzenboeck@linbit.com>