### PR TITLE
Add various utility functions

### DIFF
--- a/api/v1/patch.go
+++ b/api/v1/patch.go
@@ -1,0 +1,95 @@
+package v1
+
+import (
+	"fmt"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/kustomize/api/hasher"
+	kustresource "sigs.k8s.io/kustomize/api/resource"
+	"sigs.k8s.io/yaml"
+)
+
+// Patch represent either a Strategic Merge Patch or a JSON patch and its targets.
+type Patch struct {
+	// Patch is the content of a patch.
+	//+kubebuilder:validation:MinLength=1
+	//+kubebuilder:validation:Required
+	Patch string `json:"patch,omitempty" yaml:"patch,omitempty"`
+
+	// Target points to the resources that the patch is applied to
+	Target *Selector `json:"target,omitempty" yaml:"target,omitempty"`
+
+	// Options is a list of options for the patch
+	// +kubebuilder:validation:Optional
+	Options map[string]bool `json:"options,omitempty" yaml:"options,omitempty"`
+}
+
+// Selector specifies a set of resources.
+// Any resource that matches all of the conditions is included in this set.
+type Selector struct {
+	Group   string `json:"group,omitempty" yaml:"group,omitempty"`
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
+	Kind    string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	// Name of the resource.
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	// Namespace the resource belongs to, if it can belong to a namespace.
+	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+
+	// AnnotationSelector is a string that follows the label selection expression
+	// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+	// It matches against the resource annotations.
+	AnnotationSelector string `json:"annotationSelector,omitempty" yaml:"annotationSelector,omitempty"`
+
+	// LabelSelector is a string that follows the label selection expression
+	// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+	// It matches against the resource labels.
+	LabelSelector string `json:"labelSelector,omitempty" yaml:"labelSelector,omitempty"`
+}
+
+func (p *Patch) validate(path *field.Path) field.ErrorList {
+	var result field.ErrorList
+
+	_, smErr := strategicMergePatchFromBytes([]byte(p.Patch))
+	_, jsErr := jsonPatchFromBytes([]byte(p.Patch))
+	if smErr != nil && jsErr != nil {
+		result = append(result, field.Invalid(path.Child("patch"), p.Patch, fmt.Sprintf("Failed to parse patch as either Strategic Merge Patch (%s) or JSON Patch (%s)", smErr, jsErr)))
+	}
+
+	return result
+}
+
+func strategicMergePatchFromBytes(in []byte) (*kustresource.Resource, error) {
+	factory := kustresource.NewFactory(&hasher.Hasher{})
+	ress, err := factory.SliceFromBytes(in)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(ress) != 1 {
+		return nil, fmt.Errorf("expected strategic merge patch to contain exactly 1 resource, got %d", len(ress))
+	}
+
+	return ress[0], nil
+}
+
+// jsonPatchFromBytes loads a Json 6902 patch from a bytes input.
+// Taken from sigs.k8s.io/kustomize/api@v0.12.1/internal/builtins/PatchTransformer.go
+func jsonPatchFromBytes(in []byte) (jsonpatch.Patch, error) {
+	ops := string(in)
+	if ops == "" {
+		return nil, fmt.Errorf("empty json patch operations")
+	}
+
+	if ops[0] != '[' {
+		jsonOps, err := yaml.YAMLToJSON(in)
+		if err != nil {
+			return nil, err
+		}
+		ops = string(jsonOps)
+	}
+
+	return jsonpatch.DecodePatch([]byte(ops))
+}

--- a/api/v1/properties.go
+++ b/api/v1/properties.go
@@ -1,0 +1,80 @@
+package v1
+
+import (
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+type LinstorControllerProperty struct {
+	// Name of the property to set.
+	//+kubebuilder:validation:MinLength=1
+	//+kubebuilder:validation:Required
+	Name string `json:"name"`
+
+	// Value to set the property to.
+	Value string `json:"value,omitempty"`
+}
+
+type LinstorNodeProperty struct {
+	// Name of the property to set.
+	//+kubebuilder:validation:MinLength=1
+	//+kubebuilder:validation:Required
+	Name string `json:"name"`
+
+	// Value to set the property to.
+	//+kubebuilder:validation:Optional
+	Value string `json:"value,omitempty"`
+
+	// ValueFrom sets the value from an existing resource.
+	//+kubebuilder:validation:Optional
+	ValueFrom *LinstorNodePropertyValueFrom `json:"valueFrom,omitempty"`
+
+	// Optional values are only set if they have a non-empty value
+	//+kubebuilder:validation:Optional
+	Optional bool `json:"optional,omitempty"`
+}
+
+type LinstorNodePropertyValueFrom struct {
+	// Select a field of the node. Supports `metadata.name`, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`.
+	//+kubebuilder:validation:MinLength=1
+	//+kubebuilder:validation:Required
+	NodeFieldRef string `json:"nodeFieldRef,omitempty"`
+}
+
+func ValidateNodeProperties(props []LinstorNodeProperty, path *field.Path) field.ErrorList {
+	var result field.ErrorList
+
+	allNames := sets.NewString()
+
+	for i := range props {
+		p := &props[i]
+		if allNames.Has(p.Name) {
+			result = append(result, field.Duplicate(path.Child(strconv.Itoa(i), "name"), p.Name))
+		}
+
+		valSet := p.Value != ""
+		fromSet := p.ValueFrom != nil
+		if valSet == fromSet {
+			result = append(result, field.Invalid(path.Child(strconv.Itoa(i)), p, "Expected exactly one of 'value' and 'valueFrom' to be set"))
+		}
+	}
+
+	return result
+}
+
+func ValidateControllerProperties(props []LinstorControllerProperty, path *field.Path) field.ErrorList {
+	var result field.ErrorList
+
+	allNames := sets.NewString()
+
+	for i := range props {
+		p := &props[i]
+		if allNames.Has(p.Name) {
+			result = append(result, field.Duplicate(path.Child(strconv.Itoa(i), "name"), p.Name))
+		}
+	}
+
+	return result
+}

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,15 @@ go 1.18
 
 require (
 	github.com/LINBIT/golinstor v0.45.0
+	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/piraeusdatastore/piraeus-operator v1.10.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0
+	golang.org/x/exp v0.0.0-20221006183845-316c7553db56
 	gopkg.in/ini.v1 v1.67.0
 	k8s.io/api v0.25.0
 	k8s.io/apimachinery v0.25.0
+	k8s.io/client-go v0.25.0
 	sigs.k8s.io/controller-runtime v0.12.3
 	sigs.k8s.io/kustomize/api v0.12.1
 	sigs.k8s.io/kustomize/kyaml v0.13.9
@@ -20,7 +23,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/donovanhide/eventsource v0.0.0-20210830082556-c59027999da0 // indirect
 	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
-	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
@@ -62,7 +64,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.25.0 // indirect
-	k8s.io/client-go v0.25.0 // indirect
 	k8s.io/klog/v2 v2.80.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect
 	k8s.io/utils v0.0.0-20220823124924-e9cbc92d1a73 // indirect

--- a/go.sum
+++ b/go.sum
@@ -271,6 +271,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20221006183845-316c7553db56 h1:BrYbdKcCNjLyrN6aKqXy4hPw9qGI8IATkj4EWv9Q+kQ=
+golang.org/x/exp v0.0.0-20221006183845-316c7553db56/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/utils/anyerror.go
+++ b/pkg/utils/anyerror.go
@@ -1,0 +1,12 @@
+package utils
+
+// AnyError returns an error if any given error is not nil.
+func AnyError(errs ...error) error {
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/utils/fieldpath/doc.go
+++ b/pkg/utils/fieldpath/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package fieldpath supplies methods for extracting fields from objects
+// given a path to a field.
+package fieldpath

--- a/pkg/utils/fieldpath/fieldpath.go
+++ b/pkg/utils/fieldpath/fieldpath.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fieldpath
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// FormatMap formats map[string]string to a string.
+func FormatMap(m map[string]string) (fmtStr string) {
+	// output with keys in sorted order to provide stable output
+	keys := sets.NewString()
+	for key := range m {
+		keys.Insert(key)
+	}
+	for _, key := range keys.List() {
+		fmtStr += fmt.Sprintf("%v=%q\n", key, m[key])
+	}
+	fmtStr = strings.TrimSuffix(fmtStr, "\n")
+
+	return
+}
+
+// ExtractFieldPathAsString extracts the field from the given object
+// and returns it as a string.  The object must be a pointer to an
+// API type.
+func ExtractFieldPathAsString(obj interface{}, fieldPath string) (string, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return "", err
+	}
+
+	if path, subscript, ok := SplitMaybeSubscriptedPath(fieldPath); ok {
+		switch path {
+		case "metadata.annotations":
+			if errs := validation.IsQualifiedName(strings.ToLower(subscript)); len(errs) != 0 {
+				return "", fmt.Errorf("invalid key subscript in %s: %s", fieldPath, strings.Join(errs, ";"))
+			}
+			return accessor.GetAnnotations()[subscript], nil
+		case "metadata.labels":
+			if errs := validation.IsQualifiedName(subscript); len(errs) != 0 {
+				return "", fmt.Errorf("invalid key subscript in %s: %s", fieldPath, strings.Join(errs, ";"))
+			}
+			return accessor.GetLabels()[subscript], nil
+		default:
+			return "", fmt.Errorf("fieldPath %q does not support subscript", fieldPath)
+		}
+	}
+
+	switch fieldPath {
+	case "metadata.annotations":
+		return FormatMap(accessor.GetAnnotations()), nil
+	case "metadata.labels":
+		return FormatMap(accessor.GetLabels()), nil
+	case "metadata.name":
+		return accessor.GetName(), nil
+	case "metadata.namespace":
+		return accessor.GetNamespace(), nil
+	case "metadata.uid":
+		return string(accessor.GetUID()), nil
+	}
+
+	return "", fmt.Errorf("unsupported fieldPath: %v", fieldPath)
+}
+
+// SplitMaybeSubscriptedPath checks whether the specified fieldPath is
+// subscripted, and
+//   - if yes, this function splits the fieldPath into path and subscript, and
+//     returns (path, subscript, true).
+//   - if no, this function returns (fieldPath, "", false).
+//
+// Example inputs and outputs:
+//
+//	"metadata.annotations['myKey']" --> ("metadata.annotations", "myKey", true)
+//	"metadata.annotations['a[b]c']" --> ("metadata.annotations", "a[b]c", true)
+//	"metadata.labels['']"           --> ("metadata.labels", "", true)
+//	"metadata.labels"               --> ("metadata.labels", "", false)
+func SplitMaybeSubscriptedPath(fieldPath string) (string, string, bool) {
+	if !strings.HasSuffix(fieldPath, "']") {
+		return fieldPath, "", false
+	}
+	s := strings.TrimSuffix(fieldPath, "']")
+	parts := strings.SplitN(s, "['", 2)
+	if len(parts) < 2 {
+		return fieldPath, "", false
+	}
+	if len(parts[0]) == 0 {
+		return fieldPath, "", false
+	}
+	return parts[0], parts[1], true
+}

--- a/pkg/utils/fieldpath/fieldpath_test.go
+++ b/pkg/utils/fieldpath/fieldpath_test.go
@@ -1,0 +1,270 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fieldpath
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestExtractFieldPathAsString(t *testing.T) {
+	cases := []struct {
+		name                    string
+		fieldPath               string
+		obj                     interface{}
+		expectedValue           string
+		expectedMessageFragment string
+	}{
+		{
+			name:                    "not an API object",
+			fieldPath:               "metadata.name",
+			obj:                     "",
+			expectedMessageFragment: "object does not implement the Object interfaces",
+		},
+		{
+			name:      "ok - namespace",
+			fieldPath: "metadata.namespace",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "object-namespace",
+				},
+			},
+			expectedValue: "object-namespace",
+		},
+		{
+			name:      "ok - name",
+			fieldPath: "metadata.name",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "object-name",
+				},
+			},
+			expectedValue: "object-name",
+		},
+		{
+			name:      "ok - labels",
+			fieldPath: "metadata.labels",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"key": "value"},
+				},
+			},
+			expectedValue: "key=\"value\"",
+		},
+		{
+			name:      "ok - labels bslash n",
+			fieldPath: "metadata.labels",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"key": "value\n"},
+				},
+			},
+			expectedValue: "key=\"value\\n\"",
+		},
+		{
+			name:      "ok - annotations",
+			fieldPath: "metadata.annotations",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"builder": "john-doe"},
+				},
+			},
+			expectedValue: "builder=\"john-doe\"",
+		},
+		{
+			name:      "ok - annotation",
+			fieldPath: "metadata.annotations['spec.pod.beta.kubernetes.io/statefulset-index']",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"spec.pod.beta.kubernetes.io/statefulset-index": "1"},
+				},
+			},
+			expectedValue: "1",
+		},
+		{
+			name:      "ok - annotation",
+			fieldPath: "metadata.annotations['Www.k8s.io/test']",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"Www.k8s.io/test": "1"},
+				},
+			},
+			expectedValue: "1",
+		},
+		{
+			name:      "ok - uid",
+			fieldPath: "metadata.uid",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: "b70b3269-858e-12a8-9cf2-1232a194038a",
+				},
+			},
+			expectedValue: "b70b3269-858e-12a8-9cf2-1232a194038a",
+		},
+		{
+			name:      "ok - label",
+			fieldPath: "metadata.labels['something']",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"something": "label value",
+					},
+				},
+			},
+			expectedValue: "label value",
+		},
+		{
+			name:      "invalid expression",
+			fieldPath: "metadata.whoops",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "object-namespace",
+				},
+			},
+			expectedMessageFragment: "unsupported fieldPath",
+		},
+		{
+			name:      "invalid annotation key",
+			fieldPath: "metadata.annotations['invalid~key']",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"foo": "bar"},
+				},
+			},
+			expectedMessageFragment: "invalid key subscript in metadata.annotations",
+		},
+		{
+			name:      "invalid label key",
+			fieldPath: "metadata.labels['Www.k8s.io/test']",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"foo": "bar"},
+				},
+			},
+			expectedMessageFragment: "invalid key subscript in metadata.labels",
+		},
+		{
+			name:                    "invalid subscript",
+			fieldPath:               "metadata.notexisting['something']",
+			obj:                     &v1.Pod{},
+			expectedMessageFragment: "fieldPath \"metadata.notexisting['something']\" does not support subscript",
+		},
+	}
+
+	for _, tc := range cases {
+		actual, err := ExtractFieldPathAsString(tc.obj, tc.fieldPath)
+		if err != nil {
+			if tc.expectedMessageFragment != "" {
+				if !strings.Contains(err.Error(), tc.expectedMessageFragment) {
+					t.Errorf("%v: unexpected error message: %q, expected to contain %q", tc.name, err, tc.expectedMessageFragment)
+				}
+			} else {
+				t.Errorf("%v: unexpected error: %v", tc.name, err)
+			}
+		} else if tc.expectedMessageFragment != "" {
+			t.Errorf("%v: expected error: %v", tc.name, tc.expectedMessageFragment)
+		} else if e := tc.expectedValue; e != "" && e != actual {
+			t.Errorf("%v: unexpected result; got %q, expected %q", tc.name, actual, e)
+		}
+	}
+}
+
+func TestSplitMaybeSubscriptedPath(t *testing.T) {
+	cases := []struct {
+		fieldPath         string
+		expectedPath      string
+		expectedSubscript string
+		expectedOK        bool
+	}{
+		{
+			fieldPath:         "metadata.annotations['key']",
+			expectedPath:      "metadata.annotations",
+			expectedSubscript: "key",
+			expectedOK:        true,
+		},
+		{
+			fieldPath:         "metadata.annotations['a[b']c']",
+			expectedPath:      "metadata.annotations",
+			expectedSubscript: "a[b']c",
+			expectedOK:        true,
+		},
+		{
+			fieldPath:         "metadata.labels['['key']",
+			expectedPath:      "metadata.labels",
+			expectedSubscript: "['key",
+			expectedOK:        true,
+		},
+		{
+			fieldPath:         "metadata.labels['key']']",
+			expectedPath:      "metadata.labels",
+			expectedSubscript: "key']",
+			expectedOK:        true,
+		},
+		{
+			fieldPath:         "metadata.labels['']",
+			expectedPath:      "metadata.labels",
+			expectedSubscript: "",
+			expectedOK:        true,
+		},
+		{
+			fieldPath:         "metadata.labels[' ']",
+			expectedPath:      "metadata.labels",
+			expectedSubscript: " ",
+			expectedOK:        true,
+		},
+		{
+			fieldPath:  "metadata.labels[ 'key' ]",
+			expectedOK: false,
+		},
+		{
+			fieldPath:  "metadata.labels[]",
+			expectedOK: false,
+		},
+		{
+			fieldPath:  "metadata.labels[']",
+			expectedOK: false,
+		},
+		{
+			fieldPath:  "metadata.labels['key']foo",
+			expectedOK: false,
+		},
+		{
+			fieldPath:  "['key']",
+			expectedOK: false,
+		},
+		{
+			fieldPath:  "metadata.labels",
+			expectedOK: false,
+		},
+	}
+	for _, tc := range cases {
+		path, subscript, ok := SplitMaybeSubscriptedPath(tc.fieldPath)
+		if !ok {
+			if tc.expectedOK {
+				t.Errorf("SplitMaybeSubscriptedPath(%q) expected to return (_, _, true)", tc.fieldPath)
+			}
+			continue
+		}
+		if path != tc.expectedPath || subscript != tc.expectedSubscript {
+			t.Errorf("SplitMaybeSubscriptedPath(%q) = (%q, %q, true), expect (%q, %q, true)",
+				tc.fieldPath, path, subscript, tc.expectedPath, tc.expectedSubscript)
+		}
+	}
+}

--- a/pkg/utils/jsonpatch.go
+++ b/pkg/utils/jsonpatch.go
@@ -1,0 +1,19 @@
+package utils
+
+type Op string
+
+const (
+	Add     Op = "add"
+	Remove  Op = "remove"
+	Replace Op = "replace"
+	Move    Op = "move"
+	Copy    Op = "copy"
+	Test    Op = "test"
+)
+
+type JsonPatch struct {
+	Op    Op     `json:"op"`
+	Path  string `json:"path"`
+	From  string `json:"from,omitempty"`
+	Value any    `json:"value,omitempty"`
+}

--- a/pkg/utils/patch_convert.go
+++ b/pkg/utils/patch_convert.go
@@ -1,0 +1,59 @@
+package utils
+
+import (
+	"encoding/json"
+
+	kusttypes "sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/resid"
+
+	piraeusiov1 "github.com/piraeusdatastore/piraeus-operator/v2/api/v1"
+)
+
+func ToEncodedPatch(target *kusttypes.Selector, patch any) (*kusttypes.Patch, error) {
+	switch p := patch.(type) {
+	case string:
+		return &kusttypes.Patch{
+			Target: target,
+			Patch:  p,
+		}, nil
+	default:
+		encoded, err := json.Marshal(p)
+		if err != nil {
+			return nil, err
+		}
+
+		return &kusttypes.Patch{
+			Target: target,
+			Patch:  string(encoded),
+		}, nil
+	}
+}
+
+func MakeKustPatches(patches ...piraeusiov1.Patch) []kusttypes.Patch {
+	var result []kusttypes.Patch
+	for i := range patches {
+		result = append(result, kusttypes.Patch{
+			Target:  makeKustSelector(patches[i].Target),
+			Patch:   patches[i].Patch,
+			Options: patches[i].Options,
+		})
+	}
+
+	return result
+}
+
+func makeKustSelector(selector *piraeusiov1.Selector) *kusttypes.Selector {
+	if selector == nil {
+		return nil
+	}
+
+	return &kusttypes.Selector{
+		ResId: resid.ResId{
+			Gvk:       resid.NewGvk(selector.Group, selector.Version, selector.Kind),
+			Name:      selector.Name,
+			Namespace: selector.Namespace,
+		},
+		AnnotationSelector: selector.AnnotationSelector,
+		LabelSelector:      selector.LabelSelector,
+	}
+}

--- a/pkg/utils/patch_convert_test.go
+++ b/pkg/utils/patch_convert_test.go
@@ -1,0 +1,98 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
+	kusttypes "sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/resid"
+
+	piraeusv1 "github.com/piraeusdatastore/piraeus-operator/v2/api/v1"
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/utils"
+)
+
+func TestToEncodedPatch(t *testing.T) {
+	t.Parallel()
+
+	exampleSelector := &kusttypes.Selector{
+		ResId:         resid.NewResIdKindOnly("Pod", "example"),
+		LabelSelector: "controlled-by=test",
+	}
+
+	testcases := []struct {
+		name     string
+		selector *kusttypes.Selector
+		patch    any
+		result   *kusttypes.Patch
+	}{
+		{
+			name:     "convert-string",
+			patch:    "a-string-patch",
+			selector: exampleSelector,
+			result: &kusttypes.Patch{
+				Target: exampleSelector,
+				Patch:  "a-string-patch",
+			},
+		},
+		{
+			name: "convert-apply-obj",
+			patch: applycorev1.Pod("example", "").
+				WithSpec(applycorev1.PodSpec().
+					WithHostNetwork(true)),
+			selector: exampleSelector,
+			result: &kusttypes.Patch{
+				Target: exampleSelector,
+				Patch:  "{\"kind\":\"Pod\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"example\",\"namespace\":\"\"},\"spec\":{\"hostNetwork\":true}}",
+			},
+		},
+	}
+
+	for i := range testcases {
+		tcase := &testcases[i]
+		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := utils.ToEncodedPatch(tcase.selector, tcase.patch)
+			assert.NoError(t, err)
+			assert.Equal(t, tcase.result, actual)
+		})
+	}
+}
+
+func TestMakeKustPatches(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name    string
+		patches []piraeusv1.Patch
+		result  []kusttypes.Patch
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name: "basic-patches",
+			patches: []piraeusv1.Patch{
+				{Patch: "patch-without-selector"},
+				{Patch: "patch-with-selector", Target: &piraeusv1.Selector{Kind: "Deployment", Version: "v1", Group: "apps", Name: "foo", Namespace: "test-ns", AnnotationSelector: "annotation1=val1", LabelSelector: "label1=val2"}},
+				{Patch: "patch-with-options", Options: map[string]bool{"opt1": true, "opt2": false}},
+			},
+			result: []kusttypes.Patch{
+				{Patch: "patch-without-selector"},
+				{Patch: "patch-with-selector", Target: &kusttypes.Selector{ResId: resid.ResId{Gvk: resid.Gvk{Kind: "Deployment", Version: "v1", Group: "apps"}, Name: "foo", Namespace: "test-ns"}, AnnotationSelector: "annotation1=val1", LabelSelector: "label1=val2"}},
+				{Patch: "patch-with-options", Options: map[string]bool{"opt1": true, "opt2": false}},
+			},
+		},
+	}
+
+	for i := range testcases {
+		tcase := &testcases[i]
+		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := utils.MakeKustPatches(tcase.patches...)
+			assert.Equal(t, tcase.result, actual)
+		})
+	}
+}

--- a/pkg/utils/property_resolution.go
+++ b/pkg/utils/property_resolution.go
@@ -1,0 +1,45 @@
+package utils
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	v1 "github.com/piraeusdatastore/piraeus-operator/v2/api/v1"
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/utils/fieldpath"
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/vars"
+)
+
+func ResolveNodeProperties(node *corev1.Node, props ...v1.LinstorNodeProperty) (map[string]string, error) {
+	result := make(map[string]string)
+	for i := range props {
+		k := props[i].Name
+		switch {
+		case props[i].Value != "":
+			result[k] = props[i].Value
+		case props[i].ValueFrom != nil && props[i].ValueFrom.NodeFieldRef != "":
+			val, err := fieldpath.ExtractFieldPathAsString(node, props[i].ValueFrom.NodeFieldRef)
+			if err != nil {
+				return nil, err
+			}
+
+			if !props[i].Optional || val != "" {
+				result[k] = val
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func ResolveClusterProperties(props ...v1.LinstorControllerProperty) map[string]string {
+	result := make(map[string]string)
+
+	for k, v := range vars.DefaultControllerProperties {
+		result[k] = v
+	}
+
+	for i := range props {
+		result[props[i].Name] = props[i].Value
+	}
+
+	return result
+}

--- a/pkg/utils/property_resolution_test.go
+++ b/pkg/utils/property_resolution_test.go
@@ -1,0 +1,107 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/exp/maps"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	piraeusiov1 "github.com/piraeusdatastore/piraeus-operator/v2/api/v1"
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/utils"
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/vars"
+)
+
+func TestResolveNodeProperties(t *testing.T) {
+	fakeNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"label1": "labelval1",
+				"label2": "labelval2",
+			},
+			Annotations: map[string]string{
+				"annotation1": "annotationval1",
+				"annotation2": "annotationval2",
+			},
+		},
+	}
+
+	result, err := utils.ResolveNodeProperties(fakeNode,
+		piraeusiov1.LinstorNodeProperty{
+			Name:  "prop1",
+			Value: "direct-val",
+		},
+		piraeusiov1.LinstorNodeProperty{
+			Name: "prop2",
+			ValueFrom: &piraeusiov1.LinstorNodePropertyValueFrom{
+				NodeFieldRef: "metadata.labels['label1']",
+			},
+		},
+		piraeusiov1.LinstorNodeProperty{
+			Name: "non-existing-non-optional",
+			ValueFrom: &piraeusiov1.LinstorNodePropertyValueFrom{
+				NodeFieldRef: "metadata.labels['non-existent']",
+			},
+		},
+		piraeusiov1.LinstorNodeProperty{
+			Name:     "non-existing-optional",
+			Optional: true,
+			ValueFrom: &piraeusiov1.LinstorNodePropertyValueFrom{
+				NodeFieldRef: "metadata.labels['non-existent']",
+			},
+		},
+		piraeusiov1.LinstorNodeProperty{
+			Name: "prop3",
+			ValueFrom: &piraeusiov1.LinstorNodePropertyValueFrom{
+				NodeFieldRef: "metadata.annotations['annotation2']",
+			},
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"prop1":                     "direct-val",
+		"prop2":                     "labelval1",
+		"non-existing-non-optional": "",
+		"prop3":                     "annotationval2",
+	}, result)
+}
+
+func TestResolveClusterProperties(t *testing.T) {
+	t.Parallel()
+
+	expected2 := maps.Clone(vars.DefaultControllerProperties)
+	expected2["Aux/foo"] = "val2"
+	expected2["Aux/bar"] = "val3"
+
+	testcases := []struct {
+		name   string
+		props  []piraeusiov1.LinstorControllerProperty
+		result map[string]string
+	}{
+		{
+			name:   "default",
+			result: vars.DefaultControllerProperties,
+		},
+		{
+			name: "some-props",
+			props: []piraeusiov1.LinstorControllerProperty{
+				{Name: "Aux/foo", Value: "val1"},
+				{Name: "Aux/foo", Value: "val2"},
+				{Name: "Aux/bar", Value: "val3"},
+			},
+			result: expected2,
+		},
+	}
+
+	for i := range testcases {
+		tcase := &testcases[i]
+		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := utils.ResolveClusterProperties(tcase.props...)
+			assert.Equal(t, tcase.result, actual)
+		})
+	}
+}

--- a/pkg/utils/prune.go
+++ b/pkg/utils/prune.go
@@ -1,0 +1,57 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/kyaml/resid"
+)
+
+// PruneResources removes all resources that are controlled by the given controller, but that should (no longer) exist.
+func PruneResources(ctx context.Context, cl client.Client, controller client.Object, namespace string, toKeep resmap.ResMap, kindsToPrune ...client.Object) error {
+	for _, kind := range kindsToPrune {
+		gvks, _, err := cl.Scheme().ObjectKinds(kind)
+		if err != nil {
+			return err
+		}
+
+		if len(gvks) < 1 {
+			return fmt.Errorf("'%T' is not known in scheme", kind)
+		}
+
+		u := &unstructured.UnstructuredList{}
+		u.SetGroupVersionKind(gvks[0])
+		err = cl.List(ctx, u, client.InNamespace(namespace))
+		if err != nil {
+			if meta.IsNoMatchError(err) {
+				// Nothing to prune, as there is not even a schema definition for that type.
+				continue
+			}
+
+			return err
+		}
+
+		for _, item := range u.Items {
+			_, err = toKeep.GetByCurrentId(resid.NewResIdWithNamespace(resid.NewGvk(gvks[0].Group, gvks[0].Version, gvks[0].Kind), item.GetName(), item.GetNamespace()))
+			if err == nil {
+				continue
+			}
+
+			if !metav1.IsControlledBy(&item, controller) {
+				continue
+			}
+
+			err := cl.Delete(ctx, &item)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/utils/prune_test.go
+++ b/pkg/utils/prune_test.go
@@ -1,0 +1,150 @@
+package utils_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/kustomize/api/provider"
+	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/api/resource"
+
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/utils"
+)
+
+var (
+	Owner = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "example",
+			UID:  types.UID("00000000-0000-0000-0000-000000000000"),
+		},
+	}
+	NotOwner = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "not-owner",
+			UID:  types.UID("00000000-0000-0000-0000-000000000001"),
+		},
+	}
+
+	Initial = []client.Object{
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "sa1",
+				OwnerReferences: []metav1.OwnerReference{
+					*metav1.NewControllerRef(Owner, schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}),
+				},
+			},
+		},
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "sa2",
+				OwnerReferences: []metav1.OwnerReference{
+					*metav1.NewControllerRef(Owner, schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}),
+				},
+			},
+		},
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "sa3",
+				OwnerReferences: []metav1.OwnerReference{
+					*metav1.NewControllerRef(NotOwner, schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}),
+				},
+			},
+		},
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "sa4",
+			},
+		},
+	}
+
+	factory   = provider.NewDefaultDepProvider().GetResourceFactory()
+	AppliedS1 = factory.FromMap(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ServiceAccount",
+		"metadata": map[string]interface{}{
+			"name": "sa1",
+		},
+	})
+	AppliedS2 = factory.FromMap(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ServiceAccount",
+		"metadata": map[string]interface{}{
+			"name": "sa2",
+		},
+	})
+)
+
+func TestPruneResources(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name      string
+		owner     client.Object
+		toKeep    []*resource.Resource
+		remaining []string
+	}{
+		{
+			name:      "nothing-to-delete",
+			owner:     Owner,
+			toKeep:    []*resource.Resource{AppliedS1, AppliedS2},
+			remaining: []string{"sa1", "sa2", "sa3", "sa4"},
+		},
+		{
+			name:      "delete-all-owned",
+			owner:     Owner,
+			remaining: []string{"sa3", "sa4"},
+		},
+		{
+			name:      "delete-not-applied",
+			owner:     Owner,
+			toKeep:    []*resource.Resource{AppliedS1},
+			remaining: []string{"sa1", "sa3", "sa4"},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	err := corev1.AddToScheme(scheme)
+	assert.NoError(t, err)
+
+	for i := range testcases {
+		tcase := &testcases[i]
+		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			cl := fake.NewClientBuilder().
+				WithObjects(Initial...).
+				Build()
+
+			resm := resmap.New()
+			for _, r := range tcase.toKeep {
+				err := resm.Append(r)
+				assert.NoError(t, err)
+			}
+
+			err := utils.PruneResources(context.Background(), cl, tcase.owner, "", resm, &corev1.ServiceAccount{})
+			assert.NoError(t, err)
+
+			var accounts corev1.ServiceAccountList
+			err = cl.List(context.Background(), &accounts)
+			assert.NoError(t, err)
+			AssertEqualResources(t, tcase.remaining, accounts.Items)
+		})
+	}
+}
+
+func AssertEqualResources(t *testing.T, expected []string, actualList []corev1.ServiceAccount) {
+	var resourceNames []string
+	for _, o := range actualList {
+		resourceNames = append(resourceNames, o.Name)
+	}
+
+	assert.ElementsMatch(t, expected, resourceNames)
+}

--- a/pkg/vars/defaults.go
+++ b/pkg/vars/defaults.go
@@ -1,0 +1,13 @@
+package vars
+
+import linstor "github.com/LINBIT/golinstor"
+
+var DefaultControllerProperties = map[string]string{
+	// TODO: Remove once DRBD does not need this anymore
+	linstor.NamespcDrbdNetOptions + "/rr-conflict":                        "retry-connect",
+	linstor.NamespcDrbdResourceOptions + "/on-suspended-primary-outdated": "force-secondary",
+	linstor.NamespcDrbdResourceOptions + "/on-no-data-accessible":         "suspend-io",
+	linstor.NamespcDrbdOptions + "/auto-quorum":                           "suspend-io",
+	// The operator can do its own eviction when necessary
+	linstor.NamespcDrbdOptions + "/AutoEvictAllowEviction": "false",
+}


### PR DESCRIPTION
This is a collection of utilities that proved useful during development. In order to support some of them, we already add some API structs, but only subtypes for now.

The utils are:
* `AnyError`, which returns any errors that may happened during reconciliation
* `fieldpath`, which is directly imported from `k8s.io/kubernetes/pkg/fieldpath`, just so we don't have to import the complete k8s repo
* `jsonpatch`, just some types for validation
* Some kustomize patch wrapper for type-safe handling of patch creation + validation
* `prune`, to prune no longer needed resources during reconciliation
* property helpers, helping to create LINSTOR properties based on k8s values.

For more information on each utility, check the commit message for each commit