### PR TITLE
Add podpatcher utility

### DIFF
--- a/pkg/podpatcher/podpatcher.go
+++ b/pkg/podpatcher/podpatcher.go
@@ -1,0 +1,86 @@
+package podpatcher
+
+import (
+	"context"
+	"encoding/json"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Patch patches a Pod.
+//
+// The differences to the normal client.Patch method are:
+// * We recreate the Pod if the patch failed to apply, as Pods generally can't be altered dynamically.
+// * We also recreate for image changes. Normally, these would be applied by kubelet eventually, but will cause a
+//   "restarted container" event, which many users will have alerts for. It also can't be nicely controlled by the
+//   operator. So we just have to make sure to detect any changes.
+func Patch(ctx context.Context, cl client.Client, pod client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	var oldPod corev1.Pod
+	err := cl.Get(ctx, types.NamespacedName{Name: pod.GetName(), Namespace: pod.GetNamespace()}, &oldPod)
+	if apierrors.IsNotFound(err) {
+		return cl.Patch(ctx, pod, patch, opts...)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	// For some reason, Pods allow updating the images for a Pod. While this could work for our case a lot of users will
+	// have alerts for restarted container pods configured. So it is better to delete + recreate the pod. But only if
+	// something substantial actually changed.
+	var newPod corev1.Pod
+	newEncoded, err := json.Marshal(pod)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(newEncoded, &newPod)
+	if err != nil {
+		return err
+	}
+
+	if EqualImages(&oldPod, &newPod) {
+		err := cl.Patch(ctx, pod, patch, opts...)
+		// IsInvalid gets returned if the patch fails to apply. In that case we want to continue with delete+recreate
+		// below.
+		if !apierrors.IsInvalid(err) {
+			return err
+		}
+	}
+
+	// If we reached this point, either the images have changed between old and new pod, or some other unpatchable
+	// item needs changing. The solution is simple: delete the pod and try again.
+	err = cl.Delete(ctx, &oldPod)
+	if err != nil {
+		return err
+	}
+
+	return cl.Patch(ctx, pod, patch, opts...)
+}
+
+func EqualImages(a, b *corev1.Pod) bool {
+	if len(a.Spec.InitContainers) != len(b.Spec.InitContainers) {
+		return false
+	}
+
+	for i := range a.Spec.InitContainers {
+		if a.Spec.InitContainers[i].Image != b.Spec.InitContainers[i].Image {
+			return false
+		}
+	}
+
+	if len(a.Spec.Containers) != len(b.Spec.Containers) {
+		return false
+	}
+
+	for i := range a.Spec.Containers {
+		if a.Spec.Containers[i].Image != b.Spec.Containers[i].Image {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/podpatcher/podpatcher_test.go
+++ b/pkg/podpatcher/podpatcher_test.go
@@ -1,0 +1,101 @@
+package podpatcher_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/podpatcher"
+)
+
+var (
+	ExamplePod1 = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "example",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "container-1", Image: "image-1"},
+				{Name: "container-2", Image: "image-2"},
+			},
+			InitContainers: []corev1.Container{
+				{Name: "init-1", Image: "image-init-1"},
+				{Name: "init-2", Image: "image-init-2"},
+			},
+		},
+	}
+	ExamplePod2 = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "example",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "container-1", Image: "image-1"},
+				{Name: "container-3", Image: "image-3"},
+			},
+			InitContainers: []corev1.Container{
+				{Name: "init-1", Image: "image-init-1"},
+				{Name: "init-2", Image: "image-init-2"},
+			},
+		},
+	}
+	ExamplePod3 = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "example",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "container-1", Image: "image-1"},
+				{Name: "container-2", Image: "image-2"},
+			},
+			InitContainers: []corev1.Container{
+				{Name: "init-1", Image: "image-init-1"},
+				{Name: "init-2", Image: "image-init-3"},
+			},
+		},
+	}
+)
+
+func TestEqualImages(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name     string
+		a        *corev1.Pod
+		b        *corev1.Pod
+		expected bool
+	}{
+		{
+			name:     "same-obj",
+			a:        ExamplePod1,
+			b:        ExamplePod1,
+			expected: true,
+		},
+		{
+			name:     "diff-container",
+			a:        ExamplePod1,
+			b:        ExamplePod2,
+			expected: false,
+		},
+		{
+			name:     "diff-init",
+			a:        ExamplePod1,
+			b:        ExamplePod3,
+			expected: false,
+		},
+	}
+
+	for i := range testcases {
+		tcase := &testcases[i]
+		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := podpatcher.EqualImages(tcase.a, tcase.b)
+			assert.Equal(t, tcase.expected, actual)
+		})
+	}
+}
+
+// NB: sadly, the fake client does not support "Apply" patches, so we can't test podpatcher.Patch easily


### PR DESCRIPTION
In the case of satellites, the operator will have to deal with raw Pods instead of Deployments or Daemonsets. This is because we have some very particular requirements:

* We potentially have different Pod Specs per node, for example to use different DRBD loader images or include different Satellite configs.
* Satellites should have stable hostnames. This is because LINSTOR does not take to kindly to changed "uname"s for deployed resources. Since we no longer run in the host network by default, we inherit the Pod name as "kernel" hostname.

The issue with using raw Pods is that you can't just patch them like other resources: Pods are mostly immutable. This could be dealt with quite easily, if not for the fact that updates to images are allowed.

Updated images would mean that the user would see an unexpected container restart. In addition, the operator could not easily tell which version of the container was actually running, as that is not something we can easily get out of the Pod status.

So our solution is a custom patch function for Pods, that:

* Checks if the Pod already exists
  * If not, just apply the normal patch
* If the new Pod Spec uses the same images, try a normal patch
* If the new Pod Spec uses different images, or the patch could not be applied: delete and recreate the Pod.

Signed-off-by: Moritz "WanzenBug" Wanzenböck <moritz.wanzenboeck@linbit.com>