### PR TITLE
add conditions helper

### DIFF
--- a/pkg/conditions/conditions.go
+++ b/pkg/conditions/conditions.go
@@ -1,0 +1,94 @@
+package conditions
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type (
+	CondType string
+	Reason   string
+)
+
+const (
+	Applied    CondType = "Applied"
+	Available  CondType = "Available"
+	Configured CondType = "Configured"
+
+	ReasonNotObserved Reason = "NotObserved"
+	ReasonAsExpected  Reason = "AsExpected"
+	ReasonUnknown     Reason = "Unknown"
+	ReasonError       Reason = "Error"
+)
+
+type condition struct {
+	Status  metav1.ConditionStatus
+	Reason  Reason
+	Errors  []error
+	Message []string
+}
+
+type Conditions map[CondType]*condition
+
+func New() Conditions {
+	return map[CondType]*condition{
+		Applied:    {Reason: ReasonNotObserved, Status: metav1.ConditionUnknown},
+		Available:  {Reason: ReasonNotObserved, Status: metav1.ConditionUnknown},
+		Configured: {Reason: ReasonNotObserved, Status: metav1.ConditionUnknown},
+	}
+}
+
+func (c Conditions) get(condType CondType) *condition {
+	res, ok := c[condType]
+	if ok {
+		return res
+	}
+
+	c[condType] = &condition{Reason: ReasonNotObserved, Status: metav1.ConditionUnknown}
+	return c[condType]
+}
+
+func (c Conditions) AddSuccess(condType CondType, message string) {
+	ct := c.get(condType)
+	ct.Status = metav1.ConditionTrue
+	ct.Reason = ReasonAsExpected
+	ct.Message = append(ct.Message, message)
+}
+
+func (c Conditions) AddError(condType CondType, err error) {
+	ct := c.get(condType)
+	ct.Status = metav1.ConditionFalse
+	ct.Reason = ReasonError
+	ct.Message = append(ct.Message, fmt.Sprintf("Error: %s", err))
+}
+
+func (c Conditions) AddUnknown(condType CondType, message string) {
+	ct := c.get(condType)
+	ct.Status = metav1.ConditionUnknown
+	ct.Reason = ReasonUnknown
+	ct.Message = append(ct.Message, message)
+}
+
+func (c Conditions) ToConditions(generation int64) []metav1.Condition {
+	var result []metav1.Condition
+	for k, v := range c {
+		message := strings.Join(v.Message, "\n")
+
+		result = append(result, metav1.Condition{
+			Type:               string(k),
+			Status:             v.Status,
+			Reason:             string(v.Reason),
+			Message:            message,
+			ObservedGeneration: generation,
+		})
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Type < result[j].Type
+	})
+
+	return result
+}

--- a/pkg/conditions/conditions_test.go
+++ b/pkg/conditions/conditions_test.go
@@ -1,0 +1,83 @@
+package conditions_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/conditions"
+)
+
+func TestConditions(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name       string
+		mutate     func(c conditions.Conditions)
+		generation int64
+		expected   []metav1.Condition
+	}{
+		{
+			name: "empty-default-unknown",
+			expected: []metav1.Condition{
+				{Type: string(conditions.Applied), Status: metav1.ConditionUnknown, Reason: string(conditions.ReasonNotObserved)},
+				{Type: string(conditions.Available), Status: metav1.ConditionUnknown, Reason: string(conditions.ReasonNotObserved)},
+				{Type: string(conditions.Configured), Status: metav1.ConditionUnknown, Reason: string(conditions.ReasonNotObserved)},
+			},
+		},
+		{
+			name:       "with-observations-and-generation",
+			generation: 2,
+			mutate: func(c conditions.Conditions) {
+				c.AddSuccess(conditions.Applied, "Applied success")
+				c.AddUnknown(conditions.Available, "Not checked")
+				c.AddError(conditions.Configured, errors.New("not available"))
+			},
+			expected: []metav1.Condition{
+				{Type: string(conditions.Applied), Status: metav1.ConditionTrue, Reason: string(conditions.ReasonAsExpected), Message: "Applied success", ObservedGeneration: 2},
+				{Type: string(conditions.Available), Status: metav1.ConditionUnknown, Reason: string(conditions.ReasonUnknown), Message: "Not checked", ObservedGeneration: 2},
+				{Type: string(conditions.Configured), Status: metav1.ConditionFalse, Reason: string(conditions.ReasonError), Message: "Error: not available", ObservedGeneration: 2},
+			},
+		},
+		{
+			name: "add-new-conditions",
+			mutate: func(c conditions.Conditions) {
+				c.AddSuccess("NewCond", "success")
+			},
+			expected: []metav1.Condition{
+				{Type: string(conditions.Applied), Status: metav1.ConditionUnknown, Reason: string(conditions.ReasonNotObserved)},
+				{Type: string(conditions.Available), Status: metav1.ConditionUnknown, Reason: string(conditions.ReasonNotObserved)},
+				{Type: string(conditions.Configured), Status: metav1.ConditionUnknown, Reason: string(conditions.ReasonNotObserved)},
+				{Type: "NewCond", Status: metav1.ConditionTrue, Reason: string(conditions.ReasonAsExpected), Message: "success"},
+			},
+		},
+		{
+			name: "condition-set-multiple",
+			mutate: func(c conditions.Conditions) {
+				c.AddSuccess(conditions.Applied, "success")
+				c.AddError(conditions.Applied, errors.New("actually an error"))
+			},
+			expected: []metav1.Condition{
+				{Type: string(conditions.Applied), Status: metav1.ConditionFalse, Reason: string(conditions.ReasonError), Message: "success\nError: actually an error"},
+				{Type: string(conditions.Available), Status: metav1.ConditionUnknown, Reason: string(conditions.ReasonNotObserved)},
+				{Type: string(conditions.Configured), Status: metav1.ConditionUnknown, Reason: string(conditions.ReasonNotObserved)},
+			},
+		},
+	}
+
+	for i := range testcases {
+		tcase := &testcases[i]
+		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := conditions.New()
+			if tcase.mutate != nil {
+				tcase.mutate(c)
+			}
+			actual := c.ToConditions(tcase.generation)
+			assert.Equal(t, tcase.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
Conditions are a common way to communicate the state of a k8s resource. We want to use them for our operator. A usability issue that came up during development is that the best place to observe a specific condition often varies wildly based on the exact thing to observe.

The solution is to use our own Conditions helper, which keeps track of a set of default conditions that all our resources should implement. The Conditions can be passed around, keeping track of which condition was already observed, with the intention of letting the operator set the actual conditions at the end of reconciliation.

Signed-off-by: Moritz "WanzenBug" Wanzenböck <moritz.wanzenboeck@linbit.com>