### PR TITLE
cluster: add reconciler

### DIFF
--- a/controllers/linstorcluster_controller.go
+++ b/controllers/linstorcluster_controller.go
@@ -1,0 +1,534 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	netwv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	applyappsv1 "k8s.io/client-go/applyconfigurations/apps/v1"
+	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+	"sigs.k8s.io/kustomize/api/krusty"
+	"sigs.k8s.io/kustomize/api/resmap"
+	kusttypes "sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/resid"
+
+	piraeusiov1 "github.com/piraeusdatastore/piraeus-operator/v2/api/v1"
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/conditions"
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/imageversions"
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/linstorhelper"
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/merge"
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/resources"
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/resources/cluster"
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/utils"
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/vars"
+)
+
+// LinstorClusterReconciler reconciles a LinstorCluster object
+type LinstorClusterReconciler struct {
+	client.Client
+	Scheme        *runtime.Scheme
+	Namespace     string
+	PullSecret    string
+	ImageVersions *imageversions.Config
+	Kustomizer    *resources.Kustomizer
+}
+
+//+kubebuilder:rbac:groups=piraeus.io,resources=linstorclusters,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=piraeus.io,resources=linstorclusters/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=piraeus.io,resources=linstorclusters/finalizers,verbs=update
+//+kubebuilder:rbac:groups=piraeus.io,resources=linstorsatellites,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=piraeus.io,resources=linstorsatelliteconfigurations,verbs=get;list;watch
+//+kubebuilder:rbac:groups=piraeus.io,resources=linstorsatelliteconfigurations/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups="",resources=persistentvolumes;events;configmaps;secrets;services;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=apps,resources=daemonsets;deployments,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=apps,resources=replicasets,verbs=get
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;clusterroles;rolebindings;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=nodes;persistentvolumeclaims,verbs=get;list;watch;update
+//+kubebuilder:rbac:groups="",resources=persistentvolumeclaims/status,verbs=patch
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=internal.linstor.linbit.com,resources=*,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=storage.k8s.io,resources=csidrivers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=storage.k8s.io,resources=csinodes;storageclasses,verbs=get;list;watch
+//+kubebuilder:rbac:groups=storage.k8s.io,resources=volumeattachments,verbs=get;list;watch;patch
+//+kubebuilder:rbac:groups=storage.k8s.io,resources=volumeattachments/status,verbs=patch
+//+kubebuilder:rbac:groups=storage.k8s.io,resources=csistoragecapacities,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshotclasses;volumesnapshots,verbs=get;list;watch
+//+kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshotcontents,verbs=get;list;watch;patch;update;delete
+//+kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshotcontents/status,verbs=patch;update
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+func (r *LinstorClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	_ = log.FromContext(ctx)
+
+	lcluster := &piraeusiov1.LinstorCluster{}
+	err := r.Get(ctx, req.NamespacedName, lcluster)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	conds := conditions.New()
+
+	applyErr := r.reconcileAppliedResource(ctx, lcluster)
+	if applyErr != nil {
+		conds.AddError(conditions.Applied, err)
+	} else {
+		conds.AddSuccess(conditions.Applied, "Resources applied")
+	}
+
+	stateErr := r.reconcileClusterState(ctx, lcluster, conds)
+
+	_, condErr := controllerutil.CreateOrPatch(ctx, r.Client, lcluster, func() error {
+		for _, cond := range conds.ToConditions(lcluster.Generation) {
+			meta.SetStatusCondition(&lcluster.Status.Conditions, cond)
+		}
+
+		return nil
+	})
+
+	return ctrl.Result{}, utils.AnyError(applyErr, stateErr, condErr)
+}
+
+func (r *LinstorClusterReconciler) reconcileAppliedResource(ctx context.Context, lcluster *piraeusiov1.LinstorCluster) error {
+	satelliteNodes := corev1.NodeList{}
+	err := r.Client.List(ctx, &satelliteNodes, client.MatchingLabels(lcluster.Spec.NodeSelector))
+	if err != nil {
+		return err
+	}
+
+	satelliteConfigs := piraeusiov1.LinstorSatelliteConfigurationList{}
+	err = r.Client.List(ctx, &satelliteConfigs)
+	if err != nil {
+		return err
+	}
+
+	resMap, err := r.kustomizeResources(lcluster, satelliteNodes.Items, satelliteConfigs.Items)
+	if err != nil {
+		return err
+	}
+
+	for _, res := range resMap.Resources() {
+		raw, err := res.Map()
+		if err != nil {
+			return err
+		}
+
+		u := &unstructured.Unstructured{Object: raw}
+		err = controllerutil.SetControllerReference(lcluster, u, r.Scheme)
+		if err != nil {
+			return err
+		}
+
+		// We don't need to check the delete-flag here for requeue: if a controlled item changes, we will get notified
+		// and run the reconcile-loop again.
+		err = r.Client.Patch(ctx, u, client.Apply, client.ForceOwnership, client.FieldOwner(vars.FieldOwner))
+		if err != nil {
+			return err
+		}
+	}
+
+	// Update conditions on satellite configs
+	for i := range satelliteConfigs.Items {
+		config := &satelliteConfigs.Items[i]
+		_, err = controllerutil.CreateOrPatch(ctx, r.Client, config, func() error {
+			meta.SetStatusCondition(&config.Status.Conditions, metav1.Condition{
+				Type:               string(conditions.Applied),
+				Reason:             string(conditions.ReasonAsExpected),
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: config.Generation,
+			})
+
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	err = utils.PruneResources(ctx, r.Client, lcluster, r.Namespace, resMap,
+		&piraeusiov1.LinstorSatellite{},
+		&corev1.Service{},
+		&corev1.ServiceAccount{},
+		&corev1.ConfigMap{},
+		&corev1.Secret{},
+		&appsv1.DaemonSet{},
+		&appsv1.Deployment{},
+		&rbacv1.Role{},
+		&rbacv1.ClusterRole{},
+		&rbacv1.RoleBinding{},
+		&rbacv1.ClusterRoleBinding{},
+		&netwv1.NetworkPolicy{},
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *LinstorClusterReconciler) kustomizeResources(lcluster *piraeusiov1.LinstorCluster, satelliteNodes []corev1.Node, configs []piraeusiov1.LinstorSatelliteConfiguration) (resmap.ResMap, error) {
+	ctrlRes, err := r.kustomizeControllerResources(lcluster)
+	if err != nil {
+		return nil, err
+	}
+
+	csiRes, err := r.kustomizeCsiResources(lcluster)
+	if err != nil {
+		return nil, err
+	}
+
+	commonNodeRes, err := r.kustomizeNodeCommonResources(lcluster)
+	if err != nil {
+		return nil, err
+	}
+
+	resMap := resmap.New()
+
+	sort.Slice(configs, func(i, j int) bool {
+		return configs[i].Name < configs[j].Name
+	})
+
+	for i := range satelliteNodes {
+		satRes, err := r.kustomizeLinstorSatellite(lcluster, &satelliteNodes[i], configs)
+		if err != nil {
+			return nil, err
+		}
+
+		err = resMap.AppendAll(satRes)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	err = resMap.AppendAll(ctrlRes)
+	if err != nil {
+		return nil, err
+	}
+
+	err = resMap.AppendAll(csiRes)
+	if err != nil {
+		return nil, err
+	}
+
+	err = resMap.AppendAll(commonNodeRes)
+	if err != nil {
+		return nil, err
+	}
+
+	return resMap, nil
+}
+
+// Create the LINSTOR Controller resources.
+//
+// Applies the following changes over the base resources:
+// * Namespace
+// * default labels
+// * default images
+// * pull secret (if any)
+// * user defined patches
+func (r *LinstorClusterReconciler) kustomizeControllerResources(lcluster *piraeusiov1.LinstorCluster) (resmap.ResMap, error) {
+	return r.kustomize("controller", lcluster)
+}
+
+// Create the CSI controller and node agent resources.
+//
+// Applies the following changes over the base resources:
+// * Namespace
+// * default labels
+// * default images
+// * pull secret (if any)
+// * restrict CSI driver daemon set to cluster's node selector
+// * user defined patches
+func (r *LinstorClusterReconciler) kustomizeCsiResources(lcluster *piraeusiov1.LinstorCluster) (resmap.ResMap, error) {
+	selectorPatch, err := utils.ToEncodedPatch(
+		&kusttypes.Selector{ResId: resid.NewResId(resid.NewGvk(appsv1.GroupName, "v1", "DaemonSet"), "csi-node")},
+		applyappsv1.DaemonSet("satellite", "").
+			WithSpec(applyappsv1.DaemonSetSpec().
+				WithTemplate(applycorev1.PodTemplateSpec().
+					WithSpec(applycorev1.PodSpec().WithNodeSelector(lcluster.Spec.NodeSelector))),
+			),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.kustomize("csi", lcluster, *selectorPatch)
+}
+
+// Create the common resources for LINSTOR satellites, but not the actual LinstorSatellite resources.
+//
+// The resources here are shared by all LinstorSatellite instances. This is used for:
+// * A common ServiceAccount, with optional pull secret configured
+// * A NetworkPolicy to protect DRBD ports from unauthorized access.
+//
+// Applies the following changes over the base resources:
+// * Namespace
+// * default labels
+// * default images
+// * pull secret (if any)
+// * user defined patches
+func (r *LinstorClusterReconciler) kustomizeNodeCommonResources(lcluster *piraeusiov1.LinstorCluster) (resmap.ResMap, error) {
+	return r.kustomize("satellite-common", lcluster)
+}
+
+// Create the LINSTOR Satellite resources for a specific node.
+//
+// Applies the following changes over the base resources:
+// * Use exact names for LinstorSatellite resources (== node name)
+// * default labels
+// * Set the cluster reference to the owning LinstorCluster
+// * Apply the result of merging all LinstorSatelliteConfigurations to the LinstorSatellite
+// * user defined patches
+func (r *LinstorClusterReconciler) kustomizeLinstorSatellite(lcluster *piraeusiov1.LinstorCluster, node *corev1.Node, configs []piraeusiov1.LinstorSatelliteConfiguration) (resmap.ResMap, error) {
+	renamePatch := utils.JsonPatch{
+		Op:    utils.Replace,
+		Path:  "/metadata/name",
+		Value: node.Name,
+	}
+
+	repositoryPatch := utils.JsonPatch{
+		Op:    utils.Replace,
+		Path:  "/spec/repository",
+		Value: lcluster.Spec.Repository,
+	}
+
+	clusterRefPatch := utils.JsonPatch{
+		Op:   utils.Replace,
+		Path: "/spec/clusterRef",
+		Value: &piraeusiov1.ClusterReference{
+			Name: lcluster.Name,
+		},
+	}
+
+	patches := []utils.JsonPatch{renamePatch, repositoryPatch, clusterRefPatch}
+
+	cfg := merge.SatelliteConfigurations(node.ObjectMeta.Labels, configs...)
+
+	for j := range cfg.Spec.Properties {
+		patches = append(patches, utils.JsonPatch{
+			Op:    utils.Add,
+			Path:  "/spec/properties/-",
+			Value: &cfg.Spec.Properties[j],
+		})
+	}
+
+	for j := range cfg.Spec.StoragePools {
+		patches = append(patches, utils.JsonPatch{
+			Op:    utils.Add,
+			Path:  "/spec/storagePools/-",
+			Value: &cfg.Spec.StoragePools[j],
+		})
+	}
+
+	for j := range cfg.Spec.Patches {
+		patches = append(patches, utils.JsonPatch{
+			Op:    utils.Add,
+			Path:  "/spec/patches/-",
+			Value: &cfg.Spec.Patches[j],
+		})
+	}
+
+	patch, err := utils.ToEncodedPatch(
+		&kusttypes.Selector{ResId: resid.ResId{Gvk: resid.NewGvk(piraeusiov1.GroupVersion.Group, piraeusiov1.GroupVersion.Version, "LinstorSatellite"), Name: "satellite"}},
+		patches,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.kustomize("satellite", lcluster, *patch)
+}
+
+// kustomize applies the common Kustomizations along with the given patches.
+func (r *LinstorClusterReconciler) kustomize(resources string, lcluster *piraeusiov1.LinstorCluster, patches ...kusttypes.Patch) (resmap.ResMap, error) {
+	imgs, err := r.ImageVersions.GetVersions(lcluster.Spec.Repository, "")
+	if err != nil {
+		return nil, err
+	}
+
+	saPatch, err := r.pullSecretPatch()
+	if err != nil {
+		return nil, err
+	}
+
+	k := &kusttypes.Kustomization{
+		Namespace: r.Namespace,
+		Labels:    r.kustomLabels(lcluster),
+		Resources: []string{resources},
+		Images:    imgs,
+		Patches:   append(append(utils.MakeKustPatches(lcluster.Spec.Patches...), saPatch...), patches...),
+	}
+
+	return r.Kustomizer.Kustomize(k)
+}
+
+func (r *LinstorClusterReconciler) pullSecretPatch() ([]kusttypes.Patch, error) {
+	if r.PullSecret == "" {
+		return nil, nil
+	}
+
+	patch, err := utils.ToEncodedPatch(
+		&kusttypes.Selector{ResId: resid.NewResId(resid.NewGvk("", "v1", "ServiceAccount"), "")},
+		applycorev1.ServiceAccount("default", "").WithImagePullSecrets(applycorev1.LocalObjectReference().WithName(r.PullSecret)),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return []kusttypes.Patch{*patch}, nil
+}
+
+func (r *LinstorClusterReconciler) kustomLabels(lcluster *piraeusiov1.LinstorCluster) []kusttypes.Label {
+	return []kusttypes.Label{
+		{
+			Pairs: map[string]string{
+				"app.kubernetes.io/name":     vars.ProjectName,
+				"app.kubernetes.io/instance": lcluster.Name,
+			},
+			IncludeSelectors: true,
+			IncludeTemplates: true,
+		},
+		{
+			Pairs: vars.ExtraLabels,
+		},
+	}
+}
+
+func (r *LinstorClusterReconciler) reconcileClusterState(ctx context.Context, lcluster *piraeusiov1.LinstorCluster, conds conditions.Conditions) error {
+	lc, err := linstorhelper.NewClientForCluster(
+		ctx,
+		r.Client,
+		lcluster.Name,
+		linstorhelper.Logr(log.FromContext(ctx)),
+	)
+	if err != nil || lc == nil {
+		conds.AddError(conditions.Available, err)
+		conds.AddUnknown(conditions.Configured, "Controller unreachable")
+		return err
+	}
+
+	connectCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	version, err := lc.Controller.GetVersion(connectCtx)
+	if err != nil {
+		conds.AddError(conditions.Available, err)
+		conds.AddUnknown(conditions.Configured, "Controller unreachable")
+		return err
+	}
+
+	conds.AddSuccess(conditions.Available, fmt.Sprintf("Deployed Controller %s (API: %s, Git: %s)", version.Version, version.RestApiVersion, version.GitHash))
+
+	current, err := lc.Controller.GetProps(ctx)
+	if err != nil {
+		conds.AddError(conditions.Configured, err)
+		return err
+	}
+
+	expectedProperties := utils.ResolveClusterProperties(lcluster.Spec.Properties...)
+	expectedProperties[linstorhelper.ManagedByProperty] = vars.OperatorName
+
+	modification := linstorhelper.MakePropertiesModification(current, expectedProperties)
+	if modification != nil {
+		err = lc.Controller.Modify(ctx, *modification)
+		if err != nil {
+			conds.AddError(conditions.Configured, err)
+			return err
+		}
+	}
+
+	conds.AddSuccess(conditions.Configured, "Properties applied")
+	return nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *LinstorClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	kustomizer, err := resources.NewKustomizer(&cluster.Resources, krusty.MakeDefaultOptions())
+	if err != nil {
+		return err
+	}
+	r.Kustomizer = kustomizer
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&piraeusiov1.LinstorCluster{}).
+		Owns(&piraeusiov1.LinstorSatellite{}).
+		Owns(&appsv1.Deployment{}).
+		Owns(&appsv1.DaemonSet{}).
+		Owns(&corev1.ConfigMap{}).
+		Owns(&corev1.Service{}).
+		Owns(&corev1.ServiceAccount{}).
+		Owns(&rbacv1.ClusterRole{}).
+		Owns(&rbacv1.ClusterRoleBinding{}).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
+		Owns(&netwv1.NetworkPolicy{}, builder.WithPredicates(predicate.Or(predicate.LabelChangedPredicate{}, predicate.Funcs{
+			// NetworkPolicy registers a change event when we just apply the same resource, so we have to filter out
+			// events that do not touch the spec.
+			UpdateFunc: func(updateEvent event.UpdateEvent) bool {
+				oldO := updateEvent.ObjectOld.(*netwv1.NetworkPolicy)
+				newO := updateEvent.ObjectNew.(*netwv1.NetworkPolicy)
+
+				return !reflect.DeepEqual(oldO.Spec, newO.Spec)
+			},
+		}))).
+		Watches(
+			&source.Kind{Type: &corev1.Node{}}, handler.EnqueueRequestsFromMapFunc(r.allClustersRequests),
+			builder.WithPredicates(predicate.LabelChangedPredicate{}),
+		).
+		Watches(
+			&source.Kind{Type: &piraeusiov1.LinstorSatelliteConfiguration{}}, handler.EnqueueRequestsFromMapFunc(r.allClustersRequests),
+			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{})),
+		).
+		Complete(r)
+}
+
+func (r *LinstorClusterReconciler) allClustersRequests(_ client.Object) []reconcile.Request {
+	clusters := piraeusiov1.LinstorClusterList{}
+	_ = r.Client.List(context.Background(), &clusters)
+	requests := make([]reconcile.Request, 0, len(clusters.Items))
+
+	for i := range clusters.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: clusters.Items[i].Name},
+		})
+	}
+
+	return requests
+}

--- a/controllers/linstorcluster_controller.go
+++ b/controllers/linstorcluster_controller.go
@@ -436,6 +436,7 @@ func (r *LinstorClusterReconciler) reconcileClusterState(ctx context.Context, lc
 	lc, err := linstorhelper.NewClientForCluster(
 		ctx,
 		r.Client,
+		r.Namespace,
 		lcluster.Name,
 		linstorhelper.Logr(log.FromContext(ctx)),
 	)

--- a/controllers/linstorcluster_test.go
+++ b/controllers/linstorcluster_test.go
@@ -1,0 +1,201 @@
+package controllers_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	piraeusiov1 "github.com/piraeusdatastore/piraeus-operator/v2/api/v1"
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/conditions"
+)
+
+var _ = Describe("LinstorCluster controller", func() {
+	const (
+		DefaultTimeout       = 30 * time.Second
+		DefaultCheckInterval = 5 * time.Second
+	)
+
+	Context("When creating an empty LinstorCluster", func() {
+		BeforeEach(func(ctx context.Context) {
+			err := k8sClient.Create(ctx, &piraeusiov1.LinstorCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+		AfterEach(func(ctx context.Context) {
+			err := k8sClient.Delete(ctx, &piraeusiov1.LinstorCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should set the available condition", func(ctx context.Context) {
+			Eventually(func() bool {
+				cluster := &piraeusiov1.LinstorCluster{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "default"}, cluster)
+				if err != nil {
+					return false
+				}
+
+				return meta.FindStatusCondition(cluster.Status.Conditions, string(conditions.Applied)) != nil
+			}, DefaultTimeout, DefaultCheckInterval).Should(BeTrue())
+		})
+		It("Should create controller resources", func(ctx context.Context) {
+			Eventually(func() bool {
+				deploy := appsv1.Deployment{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "linstor-controller", Namespace: "piraeus-datastore"}, &deploy)
+
+				return err == nil
+			}, DefaultTimeout, DefaultCheckInterval).Should(BeTrue())
+		})
+
+		Describe("With cluster nodes present", func() {
+			BeforeEach(func(ctx context.Context) {
+				err := k8sClient.Create(ctx, &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-1a", Labels: map[string]string{"topology.kubernetes.io/zone": "a"}},
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				err = k8sClient.Create(ctx, &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-2a", Labels: map[string]string{"topology.kubernetes.io/zone": "a"}},
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				err = k8sClient.Create(ctx, &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-1b", Labels: map[string]string{"topology.kubernetes.io/zone": "b"}},
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			AfterEach(func(ctx context.Context) {
+				err := k8sClient.DeleteAllOf(ctx, &corev1.Node{})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("Should create LinstorSatellite resources", func(ctx context.Context) {
+				Eventually(func() bool {
+					var satellites piraeusiov1.LinstorSatelliteList
+					err := k8sClient.List(ctx, &satellites)
+					Expect(err).NotTo(HaveOccurred())
+
+					return len(satellites.Items) == 3
+				}, DefaultTimeout, DefaultCheckInterval).Should(BeTrue())
+			})
+
+			It("Should apply LinstorSatelliteConfigs to matching nodes", func(ctx context.Context) {
+				err := k8sClient.Create(ctx, &piraeusiov1.LinstorSatelliteConfiguration{
+					ObjectMeta: metav1.ObjectMeta{Name: "00-all-satellites"},
+					Spec: piraeusiov1.LinstorSatelliteConfigurationSpec{
+						Properties: []piraeusiov1.LinstorNodeProperty{
+							{Name: "prop1", Value: "val1"},
+							{Name: "prop2", Value: "val2"},
+						},
+						StoragePools: []piraeusiov1.LinstorStoragePool{
+							{Name: "pool1", Lvm: &piraeusiov1.LinstorStoragePoolLvm{}},
+							{Name: "pool2", LvmThin: &piraeusiov1.LinstorStoragePoolLvmThin{}},
+						},
+						Patches: []piraeusiov1.Patch{
+							{Target: &piraeusiov1.Selector{Kind: "ServiceAccount"}, Patch: "sa-patch1"},
+						},
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				err = k8sClient.Create(ctx, &piraeusiov1.LinstorSatelliteConfiguration{
+					ObjectMeta: metav1.ObjectMeta{Name: "01-all-zone-a"},
+					Spec: piraeusiov1.LinstorSatelliteConfigurationSpec{
+						NodeSelector: map[string]string{"topology.kubernetes.io/zone": "a"},
+						Properties: []piraeusiov1.LinstorNodeProperty{
+							{Name: "prop2", Value: "new-val-2"},
+							{Name: "prop3", Value: "val3"},
+						},
+						StoragePools: []piraeusiov1.LinstorStoragePool{
+							{Name: "pool2", LvmThin: &piraeusiov1.LinstorStoragePoolLvmThin{VolumeGroup: "vg1", ThinPool: "thin1"}, Source: &piraeusiov1.LinstorStoragePoolSource{HostDevices: []string{"/dev/vdb"}}},
+						},
+						Patches: []piraeusiov1.Patch{
+							{Target: &piraeusiov1.Selector{Kind: "Pod"}, Patch: "pod-patch1"},
+						},
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func() bool {
+					var satelliteConfigs piraeusiov1.LinstorSatelliteConfigurationList
+					err := k8sClient.List(ctx, &satelliteConfigs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(satelliteConfigs.Items).To(HaveLen(2))
+
+					for i := range satelliteConfigs.Items {
+						cond := meta.FindStatusCondition(satelliteConfigs.Items[i].Status.Conditions, string(conditions.Applied))
+						if cond == nil || cond.ObservedGeneration != satelliteConfigs.Items[i].Generation {
+							return false
+						}
+					}
+
+					return true
+				}, DefaultTimeout, DefaultCheckInterval).Should(BeTrue())
+
+				var satNode1A, satNode1B, satNode2A piraeusiov1.LinstorSatellite
+				err = k8sClient.Get(ctx, types.NamespacedName{Name: "node-1a"}, &satNode1A)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = k8sClient.Get(ctx, types.NamespacedName{Name: "node-1b"}, &satNode1B)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = k8sClient.Get(ctx, types.NamespacedName{Name: "node-2a"}, &satNode2A)
+				Expect(err).NotTo(HaveOccurred())
+
+				defaultProps := []piraeusiov1.LinstorNodeProperty{
+					{Name: "Aux/topology/linbit.com/hostname", ValueFrom: &piraeusiov1.LinstorNodePropertyValueFrom{NodeFieldRef: "metadata.name"}},
+					{Name: "Aux/topology/kubernetes.io/hostname", ValueFrom: &piraeusiov1.LinstorNodePropertyValueFrom{NodeFieldRef: "metadata.labels['kubernetes.io/hostname']"}},
+					{Name: "Aux/topology/topology.kubernetes.io/region", ValueFrom: &piraeusiov1.LinstorNodePropertyValueFrom{NodeFieldRef: "metadata.labels['topology.kubernetes.io/region']"}, Optional: true},
+					{Name: "Aux/topology/topology.kubernetes.io/zone", ValueFrom: &piraeusiov1.LinstorNodePropertyValueFrom{NodeFieldRef: "metadata.labels['topology.kubernetes.io/zone']"}, Optional: true},
+				}
+
+				specZoneA := &piraeusiov1.LinstorSatelliteSpec{
+					ClusterRef: piraeusiov1.ClusterReference{Name: "default"},
+					Patches: []piraeusiov1.Patch{
+						{Target: &piraeusiov1.Selector{Kind: "ServiceAccount"}, Patch: "sa-patch1"},
+						{Target: &piraeusiov1.Selector{Kind: "Pod"}, Patch: "pod-patch1"},
+					},
+					Properties: append(defaultProps,
+						piraeusiov1.LinstorNodeProperty{Name: "prop1", Value: "val1"},
+						piraeusiov1.LinstorNodeProperty{Name: "prop2", Value: "new-val-2"},
+						piraeusiov1.LinstorNodeProperty{Name: "prop3", Value: "val3"},
+					),
+					StoragePools: []piraeusiov1.LinstorStoragePool{
+						{Name: "pool1", Lvm: &piraeusiov1.LinstorStoragePoolLvm{}},
+						{Name: "pool2", LvmThin: &piraeusiov1.LinstorStoragePoolLvmThin{VolumeGroup: "vg1", ThinPool: "thin1"}, Source: &piraeusiov1.LinstorStoragePoolSource{HostDevices: []string{"/dev/vdb"}}},
+					},
+				}
+
+				specZoneB := &piraeusiov1.LinstorSatelliteSpec{
+					ClusterRef: piraeusiov1.ClusterReference{Name: "default"},
+					Patches: []piraeusiov1.Patch{
+						{Target: &piraeusiov1.Selector{Kind: "ServiceAccount"}, Patch: "sa-patch1"},
+					},
+					Properties: append(defaultProps,
+						piraeusiov1.LinstorNodeProperty{Name: "prop1", Value: "val1"},
+						piraeusiov1.LinstorNodeProperty{Name: "prop2", Value: "val2"},
+					),
+					StoragePools: []piraeusiov1.LinstorStoragePool{
+						{Name: "pool1", Lvm: &piraeusiov1.LinstorStoragePoolLvm{}},
+						{Name: "pool2", LvmThin: &piraeusiov1.LinstorStoragePoolLvmThin{}},
+					},
+				}
+
+				Expect(&satNode1A.Spec).To(Equal(specZoneA))
+				Expect(&satNode1B.Spec).To(Equal(specZoneB))
+				Expect(&satNode2A.Spec).To(Equal(specZoneA))
+			})
+		})
+	})
+})

--- a/controllers/linstorcluster_test.go
+++ b/controllers/linstorcluster_test.go
@@ -2,7 +2,6 @@ package controllers_test
 
 import (
 	"context"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -18,11 +17,6 @@ import (
 )
 
 var _ = Describe("LinstorCluster controller", func() {
-	const (
-		DefaultTimeout       = 30 * time.Second
-		DefaultCheckInterval = 5 * time.Second
-	)
-
 	Context("When creating an empty LinstorCluster", func() {
 		BeforeEach(func(ctx context.Context) {
 			err := k8sClient.Create(ctx, &piraeusiov1.LinstorCluster{
@@ -31,10 +25,15 @@ var _ = Describe("LinstorCluster controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 		AfterEach(func(ctx context.Context) {
-			err := k8sClient.Delete(ctx, &piraeusiov1.LinstorCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: "default"},
-			})
+			err := k8sClient.DeleteAllOf(ctx, &piraeusiov1.LinstorCluster{})
 			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() []piraeusiov1.LinstorCluster {
+				var clusters piraeusiov1.LinstorClusterList
+				err := k8sClient.List(ctx, &clusters)
+				Expect(err).NotTo(HaveOccurred())
+				return clusters.Items
+			}).Should(BeEmpty())
 		})
 
 		It("Should set the available condition", func(ctx context.Context) {

--- a/controllers/linstorsatellite_controller.go
+++ b/controllers/linstorsatellite_controller.go
@@ -252,6 +252,7 @@ func (r *LinstorSatelliteReconciler) reconcileLinstorSatelliteState(ctx context.
 	lc, err := linstorhelper.NewClientForCluster(
 		ctx,
 		r.Client,
+		r.Namespace,
 		lsatellite.Spec.ClusterRef.Name,
 		linstorhelper.Logr(log.FromContext(ctx)),
 	)
@@ -443,6 +444,7 @@ func (r *LinstorSatelliteReconciler) deleteSatellite(ctx context.Context, lsatel
 	lc, err := linstorhelper.NewClientForCluster(
 		ctx,
 		r.Client,
+		r.Namespace,
 		lsatellite.Spec.ClusterRef.Name,
 		linstorhelper.Logr(log.FromContext(ctx)),
 	)

--- a/controllers/linstorsatellite_test.go
+++ b/controllers/linstorsatellite_test.go
@@ -19,7 +19,19 @@ import (
 var _ = Describe("LinstorSatelliteReconciler", func() {
 	Context("When creating LinstorSatellite resources", func() {
 		BeforeEach(func(ctx context.Context) {
-			err := k8sClient.Create(ctx, &piraeusiov1.LinstorSatellite{
+			err := k8sClient.Create(ctx, &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: ExampleNodeName},
+				Status: corev1.NodeStatus{
+					NodeInfo: corev1.NodeSystemInfo{
+						Architecture:  "amd64",
+						KernelVersion: "5.14.0-70.26.1.el9_0.x86_64",
+						OSImage:       "AlmaLinux 9.0 (Emerald Puma)",
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = k8sClient.Create(ctx, &piraeusiov1.LinstorSatellite{
 				ObjectMeta: metav1.ObjectMeta{Name: ExampleNodeName},
 				Spec: piraeusiov1.LinstorSatelliteSpec{
 					ClusterRef: piraeusiov1.ClusterReference{Name: "example"},
@@ -39,6 +51,11 @@ var _ = Describe("LinstorSatelliteReconciler", func() {
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: ExampleNodeName}, &satellite)
 				return apierrors.IsNotFound(err)
 			}, DefaultTimeout, DefaultCheckInterval).Should(BeTrue())
+
+			err = k8sClient.Delete(ctx, &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: ExampleNodeName},
+			})
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should select loader image, apply resources, setting finalizer and condition", func(ctx context.Context) {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -98,21 +98,17 @@ var _ = BeforeSuite(func() {
 	err = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: Namespace}})
 	Expect(err).NotTo(HaveOccurred())
 
-	err = k8sClient.Create(ctx, &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: ExampleNodeName},
-		Status: corev1.NodeStatus{
-			NodeInfo: corev1.NodeSystemInfo{
-				Architecture:  "amd64",
-				KernelVersion: "5.14.0-70.26.1.el9_0.x86_64",
-				OSImage:       "AlmaLinux 9.0 (Emerald Puma)",
-			},
-		},
-	})
-	Expect(err).NotTo(HaveOccurred())
-
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
 	})
+	Expect(err).ToNot(HaveOccurred())
+
+	err = (&controllers.LinstorClusterReconciler{
+		Client:        k8sManager.GetClient(),
+		Scheme:        k8sManager.GetScheme(),
+		Namespace:     Namespace,
+		ImageVersions: &imageDefaults,
+	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&controllers.LinstorSatelliteReconciler{

--- a/main.go
+++ b/main.go
@@ -111,6 +111,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = (&controllers.LinstorClusterReconciler{
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		Namespace:     namespace,
+		ImageVersions: &imageDefaults,
+		PullSecret:    pullSecret,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "LinstorCluster")
+		os.Exit(1)
+	}
 	if err = (&controllers.LinstorSatelliteReconciler{
 		Client:        mgr.GetClient(),
 		Scheme:        mgr.GetScheme(),

--- a/pkg/k8sgc/k8sgc.go
+++ b/pkg/k8sgc/k8sgc.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package k8sgc implements a basic for of garbage collection on the Kubernetes API.
+//
+// This job is normally performed by the controller-manager. The component is not available in a test setting, with only
+// the basic API server deployed. This is where k8sgc comes in to fill the gap, so deletion of objects can be tested as
+// expected.
+package k8sgc
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GC offers a basic form of garbage collection for Kubernetes resources
+type GC interface {
+	// Run the garbage collector until all orphaned resources are collected.
+	// Returns true if any resources where collected.
+	Run(ctx context.Context) (bool, error)
+}
+
+type gc struct {
+	client  client.Client
+	toWatch []schema.GroupVersionKind
+}
+
+// New creates a new GC using the passed kubernetes client.
+// The GC will watch all resources for which the client has a Scheme.
+func New(ctx context.Context, cl client.Client) (GC, error) {
+	var toWatch []schema.GroupVersionKind
+	// The known types include types only used for specialised tasks, such as the status subfields and request options
+	// for GET, POST, DELETE, etc. So we just see if we can list the resource: anything we can list we should also be
+	// able to delete.
+	for gvk := range cl.Scheme().AllKnownTypes() {
+		u := &unstructured.UnstructuredList{}
+		u.SetGroupVersionKind(gvk)
+		err := cl.List(ctx, u)
+		if err != nil {
+			if meta.IsNoMatchError(err) {
+				continue
+			}
+
+			if _, ok := err.(*apierrors.StatusError); ok {
+				continue
+			}
+
+			return nil, err
+		}
+
+		toWatch = append(toWatch, gvk)
+	}
+
+	return &gc{
+		client:  cl,
+		toWatch: toWatch,
+	}, nil
+}
+
+func (g *gc) Run(ctx context.Context) (bool, error) {
+	collected := false
+	for {
+		madeModification := false
+
+		for _, gvk := range g.toWatch {
+			u := &unstructured.UnstructuredList{}
+			u.SetGroupVersionKind(gvk)
+			err := g.client.List(ctx, u)
+			if err != nil {
+				return collected, err
+			}
+
+			for i := range u.Items {
+				obj := &u.Items[i]
+				collect, err := g.shouldCollect(ctx, obj)
+				if err != nil {
+					return collected, err
+				}
+
+				if collect {
+					collected = true
+					madeModification = true
+					err := g.client.Delete(ctx, obj)
+					if err != nil && !apierrors.IsNotFound(err) {
+						return collected, err
+					}
+				}
+			}
+		}
+
+		if !madeModification {
+			break
+		}
+	}
+
+	return collected, nil
+}
+
+func (g *gc) shouldCollect(ctx context.Context, obj client.Object) (bool, error) {
+	owners := obj.GetOwnerReferences()
+	if len(owners) == 0 {
+		return false, nil
+	}
+
+	if obj.GetDeletionTimestamp() != nil {
+		return false, nil
+	}
+
+	for _, owner := range owners {
+		ownObj := &unstructured.Unstructured{}
+		ownObj.SetGroupVersionKind(schema.FromAPIVersionAndKind(owner.APIVersion, owner.Kind))
+		err := g.client.Get(ctx, client.ObjectKey{Name: owner.Name, Namespace: obj.GetNamespace()}, ownObj)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return false, err
+		}
+
+		if ownObj.GetDeletionTimestamp() != nil {
+			continue
+		}
+
+		if ownObj.GetUID() == owner.UID {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}

--- a/pkg/k8sgc/k8sgc_test.go
+++ b/pkg/k8sgc/k8sgc_test.go
@@ -1,0 +1,229 @@
+package k8sgc_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	piraeusiov1 "github.com/piraeusdatastore/piraeus-operator/v2/api/v1"
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/k8sgc"
+)
+
+var (
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "K8s-gc Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{}
+
+	cfg, err := testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	err = piraeusiov1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = Describe("K8s-gc", func() {
+	var gc k8sgc.GC
+	var namespace string
+
+	BeforeEach(func(ctx context.Context) {
+		var err error
+		gc, err = k8sgc.New(ctx, k8sClient)
+		Expect(err).NotTo(HaveOccurred())
+
+		namespace = fmt.Sprintf("gc-%04d", rand.Intn(10_000))
+		err = k8sClient.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should not be needed for simple deletions", func(ctx context.Context) {
+		simpleSA := corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: "simple", Namespace: namespace},
+		}
+
+		err := k8sClient.Create(ctx, &simpleSA)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = k8sClient.Delete(ctx, &simpleSA)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = k8sClient.Get(ctx, client.ObjectKey{Name: simpleSA.Name, Namespace: simpleSA.Namespace}, &corev1.ServiceAccount{})
+		Expect(errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("should delete objects when owners not present", func(ctx context.Context) {
+		simpleSA := corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "with-owner",
+				Namespace: namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{Name: "non-existent-owner-sa", APIVersion: "v1", Kind: "ServiceAccount", UID: "00000000-0000-0000-0000-000000000000"},
+				},
+			},
+		}
+
+		err := k8sClient.Create(ctx, &simpleSA)
+		Expect(err).NotTo(HaveOccurred())
+
+		deleted, err := gc.Run(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deleted).To(BeTrue())
+
+		err = k8sClient.Get(ctx, client.ObjectKey{Name: simpleSA.Name, Namespace: simpleSA.Namespace}, &corev1.ServiceAccount{})
+		Expect(errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("should delete objects when owners not present in a cascade", func(ctx context.Context) {
+		simpleSA := corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "with-owner",
+				Namespace: namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{Name: "non-existent-owner-sa", APIVersion: "v1", Kind: "ServiceAccount", UID: "00000000-0000-0000-0000-000000000000"},
+				},
+			},
+		}
+		err := k8sClient.Create(ctx, &simpleSA)
+		Expect(err).NotTo(HaveOccurred())
+
+		subOwnerSA := corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "with-owned-owner",
+				Namespace: namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{Name: simpleSA.Name, APIVersion: "v1", Kind: "ServiceAccount", UID: simpleSA.UID},
+				},
+			},
+		}
+		err = k8sClient.Create(ctx, &subOwnerSA)
+		Expect(err).NotTo(HaveOccurred())
+
+		deleted, err := gc.Run(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deleted).To(BeTrue())
+
+		err = k8sClient.Get(ctx, client.ObjectKey{Name: simpleSA.Name, Namespace: simpleSA.Namespace}, &corev1.ServiceAccount{})
+		Expect(errors.IsNotFound(err)).To(BeTrue())
+
+		err = k8sClient.Get(ctx, client.ObjectKey{Name: subOwnerSA.Name, Namespace: subOwnerSA.Namespace}, &corev1.ServiceAccount{})
+		Expect(errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("should not delete objects with finalizer", func(ctx context.Context) {
+		withFinalizer := corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "with-owner",
+				Namespace:  namespace,
+				Finalizers: []string{"piraeus.io/test"},
+			},
+		}
+		err := k8sClient.Create(ctx, &withFinalizer)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = k8sClient.Delete(ctx, &withFinalizer)
+		Expect(err).NotTo(HaveOccurred())
+
+		var currentSA corev1.ServiceAccount
+		err = k8sClient.Get(ctx, client.ObjectKey{Name: withFinalizer.Name, Namespace: withFinalizer.Namespace}, &currentSA)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(currentSA.DeletionTimestamp).NotTo(BeNil())
+
+		deleted, err := gc.Run(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deleted).To(BeFalse())
+
+		cleanupWithFinalizer(ctx, withFinalizer.Name, withFinalizer.Namespace)
+	})
+
+	It("should break cycles", func(ctx context.Context) {
+		withFinalizer1 := corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "with-owner-cycle1",
+				Namespace:  namespace,
+				Finalizers: []string{"piraeus.io/test"},
+			},
+		}
+		err := k8sClient.Create(ctx, &withFinalizer1)
+		Expect(err).NotTo(HaveOccurred())
+
+		withFinalizer2 := corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "with-owner-cycle2",
+				Namespace:  namespace,
+				Finalizers: []string{"piraeus.io/test"},
+				OwnerReferences: []metav1.OwnerReference{
+					{Name: withFinalizer1.Name, APIVersion: "v1", Kind: "ServiceAccount", UID: withFinalizer1.UID},
+				},
+			},
+		}
+		err = k8sClient.Create(ctx, &withFinalizer2)
+		Expect(err).NotTo(HaveOccurred())
+
+		withFinalizer1.OwnerReferences = []metav1.OwnerReference{
+			{Name: withFinalizer2.Name, APIVersion: "v1", Kind: "ServiceAccount", UID: withFinalizer2.UID},
+		}
+		err = k8sClient.Update(ctx, &withFinalizer1)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = k8sClient.Delete(ctx, &withFinalizer2)
+		Expect(err).NotTo(HaveOccurred())
+
+		deleted, err := gc.Run(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deleted).To(BeTrue())
+
+		cleanupWithFinalizer(ctx, withFinalizer1.Name, withFinalizer1.Namespace)
+		cleanupWithFinalizer(ctx, withFinalizer2.Name, withFinalizer2.Namespace)
+	})
+})
+
+func cleanupWithFinalizer(ctx context.Context, name, namespace string) {
+	var currentSA corev1.ServiceAccount
+	err := k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, &currentSA)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(currentSA.DeletionTimestamp).NotTo(BeNil())
+
+	currentSA.Finalizers = nil
+	err = k8sClient.Update(ctx, &currentSA)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, &currentSA)
+	Expect(err).To(HaveOccurred())
+	Expect(errors.IsNotFound(err)).To(BeTrue())
+}

--- a/pkg/linstorhelper/client.go
+++ b/pkg/linstorhelper/client.go
@@ -17,9 +17,9 @@ type Client struct {
 }
 
 // NewClientForCluster returns a LINSTOR client for a LINSTOR Controller managed by the operator.
-func NewClientForCluster(ctx context.Context, cl client.Client, clusterName string, options ...lapi.Option) (*Client, error) {
+func NewClientForCluster(ctx context.Context, cl client.Client, namespace, clusterName string, options ...lapi.Option) (*Client, error) {
 	services := corev1.ServiceList{}
-	err := cl.List(ctx, &services, client.MatchingLabels{
+	err := cl.List(ctx, &services, client.InNamespace(namespace), client.MatchingLabels{
 		"app.kubernetes.io/instance":  clusterName,
 		"app.kubernetes.io/component": "linstor-controller",
 	})

--- a/pkg/resources/loader.go
+++ b/pkg/resources/loader.go
@@ -8,12 +8,57 @@ import (
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
+	"sigs.k8s.io/kustomize/kyaml/openapi"
 	"sigs.k8s.io/yaml"
 )
 
 type Kustomizer struct {
 	fsys       filesys.FileSystem
 	kustomizer *krusty.Kustomizer
+}
+
+func init() {
+	// We need to inform kustomize that our own CRD are cluster scoped, i.e. they don't have a namespace.
+	// Otherwise, we would have namespaces after kustomization on object that do not support it. This would then
+	// potentially trip up our pruning logic. So we add a simple schema here, which then gets used internally by
+	// kustomize to determine that our resources are cluster scoped.
+	_ = openapi.AddSchema([]byte(`
+{
+  "definitions": {},
+  "paths": {
+    "/apis/piraeus.io/v1/linstorclusters": {
+      "get": {
+        "x-kubernetes-action": "get",
+        "x-kubernetes-group-version-kind": {
+          "group": "piraeus.io",
+          "kind": "LinstorCluster",
+          "version": "v1"
+        }
+      }
+    },
+    "/apis/piraeus.io/v1/linstorsatelliteconfigurations": {
+      "get": {
+        "x-kubernetes-action": "get",
+        "x-kubernetes-group-version-kind": {
+          "group": "piraeus.io",
+          "kind": "LinstorSatelliteConfiguration",
+          "version": "v1"
+        }
+      }
+    },
+    "/apis/piraeus.io/v1/linstorsatellites": {
+      "get": {
+        "x-kubernetes-action": "get",
+        "x-kubernetes-group-version-kind": {
+          "group": "piraeus.io",
+          "kind": "LinstorSatellite",
+          "version": "v1"
+        }
+      }
+    }
+  }
+}
+`))
 }
 
 func NewKustomizer(base *embed.FS, options *krusty.Options) (*Kustomizer, error) {

--- a/pkg/resources/loader_test.go
+++ b/pkg/resources/loader_test.go
@@ -7,7 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/api/krusty"
 	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/openapi"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 
+	piraeusv1 "github.com/piraeusdatastore/piraeus-operator/v2/api/v1"
 	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/resources"
 	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/resources/test"
 )
@@ -77,6 +80,29 @@ metadata:
 			actual, err := resmap.AsYaml()
 			assert.NoError(t, err)
 			assert.Equal(t, tcase.expected, string(actual))
+		})
+	}
+}
+
+func TestOpenApiInit(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		Kind       string
+		APIVersion string
+	}{
+		{Kind: "LinstorCluster", APIVersion: piraeusv1.GroupVersion.String()},
+		{Kind: "LinstorSatelliteConfiguration", APIVersion: piraeusv1.GroupVersion.String()},
+		{Kind: "LinstorSatellite", APIVersion: piraeusv1.GroupVersion.String()},
+	}
+
+	for i := range testcases {
+		tcase := &testcases[i]
+		t.Run(tcase.Kind, func(t *testing.T) {
+			t.Parallel()
+
+			actual := openapi.IsCertainlyClusterScoped(yaml.TypeMeta{Kind: tcase.Kind, APIVersion: tcase.APIVersion})
+			assert.True(t, actual)
 		})
 	}
 }


### PR DESCRIPTION
Adds the main control loop for LinstorCluster resources. It deploy k8s resources, including LinstorSatellites for every node based on the available LinstorSatelliteConfigurations.

It also configures the LINSTOR controller by making modifictions to the controller properties based on default values and user customization.