### PR TITLE
deploy: add kustomize resources for deployment

### DIFF
--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -1,0 +1,25 @@
+# The following manifests contain a self-signed issuer CR and a certificate CR.
+# More document can be found at https://docs.cert-manager.io
+# WARNING: Targets CertManager v1.0. Check https://cert-manager.io/docs/installation/upgrading/ for breaking changes.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: system
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
+  namespace: system
+spec:
+  # SERVICE_NAME_PLACEHOLDER and SERVICE_NAMESPACE_PLACEHOLDER will be substituted by kustomize
+  dnsNames:
+  - SERVICE_NAME_PLACEHOLDER.SERVICE_NAMESPACE_PLACEHOLDER.svc
+  - SERVICE_NAME_PLACEHOLDER.SERVICE_NAMESPACE_PLACEHOLDER.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: webhook-server-cert # this secret will not be prefixed, since it's not managed by kustomize

--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- certificate.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/certmanager/kustomizeconfig.yaml
+++ b/config/certmanager/kustomizeconfig.yaml
@@ -1,0 +1,16 @@
+# This configuration is for teaching kustomize how to update name ref and var substitution
+nameReference:
+- kind: Issuer
+  group: cert-manager.io
+  fieldSpecs:
+  - kind: Certificate
+    group: cert-manager.io
+    path: spec/issuerRef/name
+
+varReference:
+- kind: Certificate
+  group: cert-manager.io
+  path: spec/commonName
+- kind: Certificate
+  group: cert-manager.io
+  path: spec/dnsNames

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,0 +1,27 @@
+# This kustomization.yaml is not intended to be run by itself,
+# since it depends on service name and namespace that are out of this kustomize package.
+# It should be run by config/default
+resources:
+- bases/piraeus.io_linstorclusters.yaml
+- bases/piraeus.io_linstorsatellites.yaml
+- bases/piraeus.io_linstorsatelliteconfigurations.yaml
+#+kubebuilder:scaffold:crdkustomizeresource
+
+patchesStrategicMerge:
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
+# patches here are for enabling the conversion webhook for each CRD
+- patches/webhook_in_linstorclusters.yaml
+- patches/webhook_in_linstorsatellites.yaml
+- patches/webhook_in_linstorsatelliteconfigurations.yaml
+#+kubebuilder:scaffold:crdkustomizewebhookpatch
+
+# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
+# patches here are for enabling the CA injection for each CRD
+- patches/cainjection_in_linstorclusters.yaml
+- patches/cainjection_in_linstorsatellites.yaml
+- patches/cainjection_in_linstorsatelliteconfigurations.yaml
+#+kubebuilder:scaffold:crdkustomizecainjectionpatch
+
+# the following config is for teaching kustomize how to do kustomization for CRDs.
+configurations:
+- kustomizeconfig.yaml

--- a/config/crd/kustomizeconfig.yaml
+++ b/config/crd/kustomizeconfig.yaml
@@ -1,0 +1,19 @@
+# This file is for teaching kustomize how to substitute name and namespace reference in CRD
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: CustomResourceDefinition
+    version: v1
+    group: apiextensions.k8s.io
+    path: spec/conversion/webhook/clientConfig/service/name
+
+namespace:
+- kind: CustomResourceDefinition
+  version: v1
+  group: apiextensions.k8s.io
+  path: spec/conversion/webhook/clientConfig/service/namespace
+  create: false
+
+varReference:
+- path: metadata/annotations

--- a/config/crd/patches/cainjection_in_linstorclusters.yaml
+++ b/config/crd/patches/cainjection_in_linstorclusters.yaml
@@ -1,0 +1,7 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: linstorclusters.piraeus.io

--- a/config/crd/patches/cainjection_in_linstorsatelliteconfigurations.yaml
+++ b/config/crd/patches/cainjection_in_linstorsatelliteconfigurations.yaml
@@ -1,0 +1,7 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: linstorsatelliteconfigurations.piraeus.io

--- a/config/crd/patches/cainjection_in_linstorsatellites.yaml
+++ b/config/crd/patches/cainjection_in_linstorsatellites.yaml
@@ -1,0 +1,7 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: linstorsatellites.piraeus.io

--- a/config/crd/patches/webhook_in_linstorclusters.yaml
+++ b/config/crd/patches/webhook_in_linstorclusters.yaml
@@ -1,0 +1,16 @@
+# The following patch enables a conversion webhook for the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: linstorclusters.piraeus.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert
+      conversionReviewVersions:
+      - v1

--- a/config/crd/patches/webhook_in_linstorsatelliteconfigurations.yaml
+++ b/config/crd/patches/webhook_in_linstorsatelliteconfigurations.yaml
@@ -1,0 +1,16 @@
+# The following patch enables a conversion webhook for the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: linstorsatelliteconfigurations.piraeus.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert
+      conversionReviewVersions:
+      - v1

--- a/config/crd/patches/webhook_in_linstorsatellites.yaml
+++ b/config/crd/patches/webhook_in_linstorsatellites.yaml
@@ -1,0 +1,16 @@
+# The following patch enables a conversion webhook for the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: linstorsatellites.piraeus.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert
+      conversionReviewVersions:
+      - v1

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -22,7 +22,6 @@ resources:
 - ../manager
 - ../webhook
 - ../certmanager
-- linstor_passphrase.yaml
 
 patchesStrategicMerge:
 - manager_auth_proxy_patch.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,0 +1,108 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Adds namespace to all resources.
+namespace: piraeus-datastore
+namePrefix: piraeus-operator-
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/name: piraeus-datastore
+
+images:
+- name: controller
+  newName: quay.io/piraeusdatastore/piraeus-operator
+  newTag: v2
+
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
+#- ../prometheus
+resources:
+- ../crd
+- ../rbac
+- ../manager
+- ../webhook
+- ../certmanager
+- linstor_passphrase.yaml
+
+patchesStrategicMerge:
+- manager_auth_proxy_patch.yaml
+- manager_webhook_patch.yaml
+- webhookcainjection_patch.yaml
+
+replacements:
+- source:
+    fieldPath: metadata.namespace
+    kind: Service
+    name: webhook-service
+  targets:
+  - fieldPaths:
+    - spec.dnsNames.0
+    options:
+      delimiter: .
+      index: 1
+    select:
+      group: cert-manager.io
+      kind: Certificate
+      name: serving-cert
+      namespace: system
+      version: v1
+  - fieldPaths:
+    - spec.dnsNames.1
+    options:
+      delimiter: .
+      index: 1
+    select:
+      group: cert-manager.io
+      kind: Certificate
+      name: serving-cert
+      namespace: system
+      version: v1
+- source:
+    kind: Service
+    name: webhook-service
+  targets:
+  - fieldPaths:
+    - spec.dnsNames.0
+    options:
+      delimiter: .
+    select:
+      group: cert-manager.io
+      kind: Certificate
+      name: serving-cert
+      namespace: system
+      version: v1
+  - fieldPaths:
+    - spec.dnsNames.1
+    options:
+      delimiter: .
+    select:
+      group: cert-manager.io
+      kind: Certificate
+      name: serving-cert
+      namespace: system
+      version: v1
+- source:
+    fieldPath: metadata.namespace
+    kind: Certificate
+    name: serving-cert
+  targets:
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+    select:
+      kind: ValidatingWebhookConfiguration
+      name: validating-webhook-configuration
+- source:
+    fieldPath: metadata.name
+    kind: Certificate
+    name: serving-cert
+  targets:
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 1
+    select:
+      kind: ValidatingWebhookConfiguration
+      name: validating-webhook-configuration

--- a/config/default/linstor_passphrase.yaml
+++ b/config/default/linstor_passphrase.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: linstor-controller-passphrase
+  namespace: system
+immutable: true
+data:
+  MASTER_PASSPHRASE: cGxlYXNlLWNoYW5nZS1tZQ== # please-change-me

--- a/config/default/linstor_passphrase.yaml
+++ b/config/default/linstor_passphrase.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: linstor-controller-passphrase
-  namespace: system
-immutable: true
-data:
-  MASTER_PASSPHRASE: cGxlYXNlLWNoYW5nZS1tZQ== # please-change-me

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -1,0 +1,33 @@
+# This patch inject a sidecar container which is a HTTP proxy for the
+# controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-rbac-proxy
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=0"
+        ports:
+        - containerPort: 8443
+          protocol: TCP
+          name: https
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+      - name: manager
+        args:
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -1,0 +1,9 @@
+# This patch add annotation to admission webhook config and
+# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,0 +1,12 @@
+resources:
+- manager.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+- files:
+  - default_images.yaml
+  name: config
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: system
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  labels:
+    app.kubernetes.io/component: piraeus-operator
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: piraeus-operator
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/component: piraeus-operator
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+      - command:
+        - /manager
+        args:
+        - --leader-elect
+        - --namespace=$(NAMESPACE)
+        - --image-versions=/etc/operator/default_images.yaml
+        image: controller:latest
+        name: manager
+        env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        volumeMounts:
+          - mountPath: /etc/operator
+            name: operator-config
+            readOnly: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 256Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+      serviceAccountName: controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: operator-config
+          configMap:
+            name: config

--- a/config/manifests/bases/piraeus-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/piraeus-operator.clusterserviceversion.yaml
@@ -1,0 +1,56 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[]'
+    capabilities: Basic Install
+  name: piraeus-operator.v0.0.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: LinstorCluster is the Schema for the linstorclusters API
+      displayName: Linstor Cluster
+      kind: LinstorCluster
+      name: linstorclusters.piraeus.io
+      version: v1
+    - description: LinstorSatelliteConfiguration is the Schema for the linstorsatelliteconfigurations
+        API
+      displayName: Linstor Satellite Configuration
+      kind: LinstorSatelliteConfiguration
+      name: linstorsatelliteconfigurations.piraeus.io
+      version: v1
+    - description: LinstorSatellite is the Schema for the linstorsatellites API
+      displayName: Linstor Satellite
+      kind: LinstorSatellite
+      name: linstorsatellites.piraeus.io
+      version: v1
+  description: Some operator
+  displayName: piraeus-operator
+  icon:
+  - base64data: ""
+    mediatype: ""
+  install:
+    spec:
+      deployments: null
+    strategy: ""
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - storage
+  links:
+  - name: Piraeus Operator
+    url: https://piraeus-operator.domain
+  maturity: alpha
+  provider:
+    name: Piraeus Datastore
+    url: https://piraeus.io
+  version: 0.0.0

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -1,0 +1,27 @@
+# These resources constitute the fully configured set of manifests
+# used to generate the 'manifests/' directory in a bundle.
+resources:
+- bases/piraeus-operator.clusterserviceversion.yaml
+- ../default
+- ../samples
+- ../scorecard
+
+# [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
+# Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.
+# These patches remove the unnecessary "cert" volume and its manager container volumeMount.
+#patchesJson6902:
+#- target:
+#    group: apps
+#    version: v1
+#    kind: Deployment
+#    name: controller-manager
+#    namespace: system
+#  patch: |-
+#    # Remove the manager container's "cert" volumeMount, since OLM will create and mount a set of certs.
+#    # Update the indices in this path if adding or removing containers/volumeMounts in the manager's Deployment.
+#    - op: remove
+#      path: /spec/template/spec/containers/1/volumeMounts/0
+#    # Remove the "cert" volume, since OLM will create and mount a set of certs.
+#    # Update the indices in this path if adding or removing volumes in the manager's Deployment.
+#    - op: remove
+#      path: /spec/template/spec/volumes/0

--- a/config/prometheus/controllermonitor.yaml
+++ b/config/prometheus/controllermonitor.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: linstor-controller
+  namespace: system
+  labels:
+    app.kubernetes.io/component: linstor-controller
+spec:
+  endpoints:
+    - port: api
+      scheme: http
+      path: /metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: linstor-controller

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- controllermonitor.yaml
+- monitor.yaml
+- satellitemonitor.yaml

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -1,0 +1,20 @@
+
+# Prometheus Monitor Service (Metrics)
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: piraeus-operator
+  name: controller-manager-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - path: /metrics
+      port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: piraeus-operator

--- a/config/prometheus/satellitemonitor.yaml
+++ b/config/prometheus/satellitemonitor.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: linstor-satellite
+  namespace: system
+  labels:
+    app.kubernetes.io/component: linstor-satellite
+spec:
+  podMetricsEndpoints:
+    - port: prometheus
+      scheme: http
+      relabelings:
+        - action: replace
+          sourceLabels:
+            - __meta_kubernetes_pod_node_name
+          targetLabel: node
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: linstor-satellite

--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metrics-reader
+rules:
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get

--- a/config/rbac/auth_proxy_role.yaml
+++ b/config/rbac/auth_proxy_role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: proxy-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: piraeus-operator
+  name: controller-manager-metrics-service
+  namespace: system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    app.kubernetes.io/component: piraeus-operator

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,0 +1,18 @@
+resources:
+# All RBAC will be applied under this service account in
+# the deployment namespace. You may comment out this resource
+# if your manager will use a service account that exists at
+# runtime. Be sure to update RoleBinding and ClusterRoleBinding
+# subjects if changing service account names.
+- service_account.yaml
+- role.yaml
+- role_binding.yaml
+- leader_election_role.yaml
+- leader_election_role_binding.yaml
+# Comment the following 4 lines if you want to disable
+# the auth proxy (https://github.com/brancz/kube-rbac-proxy)
+# which protects your /metrics endpoint.
+- auth_proxy_service.yaml
+- auth_proxy_role.yaml
+- auth_proxy_role_binding.yaml
+- auth_proxy_client_clusterrole.yaml

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -1,0 +1,37 @@
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager

--- a/config/rbac/linstorcluster_editor_role.yaml
+++ b/config/rbac/linstorcluster_editor_role.yaml
@@ -1,0 +1,24 @@
+# permissions for end users to edit linstorclusters.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: linstorcluster-editor-role
+rules:
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorclusters/status
+  verbs:
+  - get

--- a/config/rbac/linstorcluster_viewer_role.yaml
+++ b/config/rbac/linstorcluster_viewer_role.yaml
@@ -1,0 +1,20 @@
+# permissions for end users to view linstorclusters.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: linstorcluster-viewer-role
+rules:
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorclusters/status
+  verbs:
+  - get

--- a/config/rbac/linstorsatellite_editor_role.yaml
+++ b/config/rbac/linstorsatellite_editor_role.yaml
@@ -1,0 +1,24 @@
+# permissions for end users to edit linstorsatellites.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: linstorsatellite-editor-role
+rules:
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorsatellites
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorsatellites/status
+  verbs:
+  - get

--- a/config/rbac/linstorsatellite_viewer_role.yaml
+++ b/config/rbac/linstorsatellite_viewer_role.yaml
@@ -1,0 +1,20 @@
+# permissions for end users to view linstorsatellites.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: linstorsatellite-viewer-role
+rules:
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorsatellites
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorsatellites/status
+  verbs:
+  - get

--- a/config/rbac/linstorsatelliteconfiguration_editor_role.yaml
+++ b/config/rbac/linstorsatelliteconfiguration_editor_role.yaml
@@ -1,0 +1,24 @@
+# permissions for end users to edit linstorsatelliteconfigurations.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: linstorsatelliteconfiguration-editor-role
+rules:
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorsatelliteconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorsatelliteconfigurations/status
+  verbs:
+  - get

--- a/config/rbac/linstorsatelliteconfiguration_viewer_role.yaml
+++ b/config/rbac/linstorsatelliteconfiguration_viewer_role.yaml
@@ -1,0 +1,20 @@
+# permissions for end users to view linstorsatelliteconfigurations.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: linstorsatelliteconfiguration-viewer-role
+rules:
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorsatelliteconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorsatelliteconfigurations/status
+  verbs:
+  - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,0 +1,275 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: controller-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - events
+  - persistentvolumes
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - patch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - internal.linstor.linbit.com
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorclusters/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorsatelliteconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorsatelliteconfigurations/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorsatellites
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorsatellites/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorsatellites/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csidrivers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csistoragecapacities
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments/status
+  verbs:
+  - patch

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: controller-manager
+subjects:
+- kind: ServiceAccount
+  name: controller-manager

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-manager

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- linstorcluster.yaml
+- linstorsatelliteconfiguration.yaml
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/linstorcluster.yaml
+++ b/config/samples/linstorcluster.yaml
@@ -1,0 +1,21 @@
+apiVersion: piraeus.io/v1
+kind: LinstorCluster
+metadata:
+  name: linstorcluster
+spec: {}
+#  repository: registry.example.com
+#  nodeSelector:
+#    piraeus.io/satellite: "true"
+#  patches:
+#    - target:
+#        kind: Pod
+#        name: satellite
+#      patch: |-
+#        apiVersion: v1
+#        kind: Pod
+#        metadata:
+#          name: satellite
+#        spec:
+#          initContainers:
+#          - name: drbd-module-loader
+#            image: registry.example.com/my-custom-drbd9-loader:latest

--- a/config/samples/linstorsatelliteconfiguration.yaml
+++ b/config/samples/linstorsatelliteconfiguration.yaml
@@ -1,0 +1,16 @@
+apiVersion: piraeus.io/v1
+kind: LinstorSatelliteConfiguration
+metadata:
+  name: all-satellites
+spec: {}
+#  nodeSelector:
+#    node-role.kubernetes.io/control-plane: ""
+#  properties:
+#    - name: PrefNic
+#      value: default-ipv6
+#  storagePools:
+#    - name: thinpool
+#      lvmThin: {}
+#      source:
+#        hostDevices:
+#          - /dev/vdb

--- a/config/scorecard/bases/config.yaml
+++ b/config/scorecard/bases/config.yaml
@@ -1,0 +1,7 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests: []

--- a/config/scorecard/kustomization.yaml
+++ b/config/scorecard/kustomization.yaml
@@ -1,0 +1,16 @@
+resources:
+- bases/config.yaml
+patchesJson6902:
+- path: patches/basic.config.yaml
+  target:
+    group: scorecard.operatorframework.io
+    version: v1alpha3
+    kind: Configuration
+    name: config
+- path: patches/olm.config.yaml
+  target:
+    group: scorecard.operatorframework.io
+    version: v1alpha3
+    kind: Configuration
+    name: config
+#+kubebuilder:scaffold:patchesJson6902

--- a/config/scorecard/patches/basic.config.yaml
+++ b/config/scorecard/patches/basic.config.yaml
@@ -1,0 +1,10 @@
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.21.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test

--- a/config/scorecard/patches/olm.config.yaml
+++ b/config/scorecard/patches/olm.config.yaml
@@ -1,0 +1,50 @@
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.21.0
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.21.0
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.21.0
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.21.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.21.0
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- manifests.yaml
+- service.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/webhook/kustomizeconfig.yaml
+++ b/config/webhook/kustomizeconfig.yaml
@@ -1,0 +1,25 @@
+# the following config is for teaching kustomize where to look at when substituting vars.
+# It requires kustomize v2.1.0 or newer to work properly.
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: MutatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+
+namespace:
+- kind: MutatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+- kind: ValidatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+
+varReference:
+- path: metadata/annotations

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-piraeus-io-v1-linstorcluster
+  failurePolicy: Fail
+  name: vlinstorcluster.kb.io
+  rules:
+  - apiGroups:
+    - piraeus.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - linstorclusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-piraeus-io-v1-linstorsatellite
+  failurePolicy: Fail
+  name: vlinstorsatellite.kb.io
+  rules:
+  - apiGroups:
+    - piraeus.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - linstorsatellites
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-piraeus-io-v1-linstorsatelliteconfiguration
+  failurePolicy: Fail
+  name: vlinstorsatelliteconfiguration.kb.io
+  rules:
+  - apiGroups:
+    - piraeus.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - linstorsatelliteconfigurations
+  sideEffects: None

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+  namespace: system
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    app.kubernetes.io/component: piraeus-operator

--- a/pkg/resources/cluster/controller/controller-deployment.yaml
+++ b/pkg/resources/cluster/controller/controller-deployment.yaml
@@ -26,12 +26,6 @@ spec:
           env:
             - name: JAVA_OPTS
               value: '-Djdk.tls.acknowledgeCloseNotify=true'
-            - name: MASTER_PASSPHRASE
-              valueFrom:
-                secretKeyRef:
-                  name: linstor-controller-passphrase
-                  key: MASTER_PASSPHRASE
-                  optional: true
           ports:
             - name: api
               containerPort: 3370


### PR DESCRIPTION
Adds resources needed to deploy the operator itself. Most of it is taken as-is from the resources generated by operator-sdk.

The main changes:
* Deploy webhook configuration by default.
* Use cert-manager for webhook certificates by default.
* Add default_images.yaml as config map to operator.
* Use piraeus-datastore namespace.
* Remove LinstorSatellite sample: creation is reserved for the operator itself.

Signed-off-by: Moritz "WanzenBug" Wanzenböck <moritz.wanzenboeck@linbit.com>