### PR TITLE
cluster: add linstor passphrase to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ The following customizations are available in the `LinstorCluster` resource:
     nodeSelector:
       piraeus.io/satellite: "true"
   ```
+* A reference to a secret, containing the passphrase to unlock
+  [LINSTOR's secret store](https://linbit.com/drbd-user-guide/linstor-guide-1_0-en/#s-encrypt_commands). The secret
+  should contain a single key `MASTER_PASSPHRASE`.
+  ```yaml
+  apiVersion: piraeus.io/v1
+  kind: LinstorCluster
+  metadata:
+    name: linstorcluster
+  spec:
+    linstorPassphraseSecret: my-linstor-passphrase
+  ```
 * A list of properties to apply on the controller level. For example, to configure LINSTOR to allocate Ports for DRBD
   starting at 8000 (instead of the default 7000), you can apply the following change to the LinstorCluster resource
   ```yaml
@@ -74,7 +85,7 @@ The following customizations are available in the `LinstorCluster` resource:
   spec:
     properties:
       - name: TcpPortAutoRange
-        value: "8000"
+        value: "8000-8999"
   ```
 * [Kustomize patches](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patches/) to apply to
   resources. When the operator applies resources, it will use `kustomize` to adapt the [base resources](./pkg/resources).

--- a/api/v1/linstorcluster_types.go
+++ b/api/v1/linstorcluster_types.go
@@ -47,6 +47,15 @@ type LinstorClusterSpec struct {
 	// See https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patches/ for how to create patches.
 	// +kubebuilder:validation:Optional
 	Patches []Patch `json:"patches,omitempty"`
+
+	// LinstorPassphraseSecret used to configure the LINSTOR master passphrase.
+	//
+	// The referenced secret must contain a single key "MASTER_PASSPHRASE". The master passphrase is used to
+	// * Derive encryption keys for volumes using the LUKS layer.
+	// * Store credentials for accessing remotes for backups.
+	// See https://linbit.com/drbd-user-guide/linstor-guide-1_0-en/#s-encrypt_commands for more information.
+	// +kubebuilder:validation:Optional
+	LinstorPassphraseSecret string `json:"linstorPassphraseSecret,omitempty"`
 }
 
 // LinstorClusterStatus defines the observed state of LinstorCluster

--- a/config/crd/bases/piraeus.io_linstorclusters.yaml
+++ b/config/crd/bases/piraeus.io_linstorclusters.yaml
@@ -35,6 +35,14 @@ spec:
           spec:
             description: LinstorClusterSpec defines the desired state of LinstorCluster
             properties:
+              linstorPassphraseSecret:
+                description: "LinstorPassphraseSecret used to configure the LINSTOR
+                  master passphrase. \n The referenced secret must contain a single
+                  key \"MASTER_PASSPHRASE\". The master passphrase is used to * Derive
+                  encryption keys for volumes using the LUKS layer. * Store credentials
+                  for accessing remotes for backups. See https://linbit.com/drbd-user-guide/linstor-guide-1_0-en/#s-encrypt_commands
+                  for more information."
+                type: string
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/config/samples/linstorcluster.yaml
+++ b/config/samples/linstorcluster.yaml
@@ -6,16 +6,18 @@ spec: {}
 #  repository: registry.example.com
 #  nodeSelector:
 #    piraeus.io/satellite: "true"
+#  linstorPassphraseSecret: my-linstor-passphrase
+#  properties:
+#    - name: TcpPortAutoRange
+#      value: "8000-8999"
 #  patches:
 #    - target:
-#        kind: Pod
-#        name: satellite
+#        kind: Deployment
+#        name: csi-controller
 #      patch: |-
-#        apiVersion: v1
-#        kind: Pod
+#        apiVersion: apps/v1
+#        kind: csi-controller
 #        metadata:
-#          name: satellite
+#          name: csi-controller
 #        spec:
-#          initContainers:
-#          - name: drbd-module-loader
-#            image: registry.example.com/my-custom-drbd9-loader:latest
+#          replicas: 3


### PR DESCRIPTION
Add the option to reference a secret holding the LINSTOR master passphrase. The passphrase is then injected into the LINSTOR Controller pod via environment variables.

This is quite similar to how it worked in Operator v1. The main difference is that for v2, we do not plan to automatically create such a secret. This was always poorly thought out, especially as temporary removal of the deployment could lead to complete loss of the passphrase. By requiring the user to create one on their own, they hopefully keep better track of it (or use some external solution for storing it).

Signed-off-by: Moritz "WanzenBug" Wanzenböck <moritz.wanzenboeck@linbit.com>