### PR TITLE
controller: enable leader election

### DIFF
--- a/pkg/resources/cluster/controller/controller-deployment.yaml
+++ b/pkg/resources/cluster/controller/controller-deployment.yaml
@@ -26,6 +26,20 @@ spec:
           env:
             - name: JAVA_OPTS
               value: '-Djdk.tls.acknowledgeCloseNotify=true'
+            - name: K8S_AWAIT_ELECTION_ENABLED
+              value: "1"
+            - name: K8S_AWAIT_ELECTION_NAME
+              value: "linstor-controller"
+            - name: "K8S_AWAIT_ELECTION_LOCK_NAME"
+              value: "linstor-controller"
+            - name: "K8S_AWAIT_ELECTION_LOCK_NAMESPACE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: K8S_AWAIT_ELECTION_IDENTITY
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           ports:
             - name: api
               containerPort: 3370

--- a/pkg/resources/cluster/controller/controller-role-binding.yaml
+++ b/pkg/resources/cluster/controller/controller-role-binding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: linstor-controller
+  labels:
+    app.kubernetes.io/component: linstor-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: linstor-controller
+subjects:
+  - kind: ServiceAccount
+    name: linstor-controller

--- a/pkg/resources/cluster/controller/controller-role.yaml
+++ b/pkg/resources/cluster/controller/controller-role.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: linstor-controller
+  labels:
+    app.kubernetes.io/component: linstor-controller
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+      - delete

--- a/pkg/resources/cluster/controller/kustomization.yaml
+++ b/pkg/resources/cluster/controller/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
   - controller-service-account.yaml
   - controller-cluster-role.yaml
   - controller-cluster-role-binding.yaml
+  - controller-role.yaml
+  - controller-role-binding.yaml


### PR DESCRIPTION
Leader election is used to ensure only one LINSTOR Controller is running
at any single point in time. We only use the basic form of leader election
without manually configuring the Kubernetes service: We rely on a single
replica on the Deployment, with shortened tolerations for disconnected
nodes.

This means we don't have to rely on manually updating the Service,
while still having reasonably fast fail-over times.

Signed-off-by: Moritz "WanzenBug" Wanzenböck <moritz.wanzenboeck@linbit.com>