### PR TITLE
add reference docs for LinstorCluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,120 +43,13 @@ linstorsatelliteconfigurations.piraeus.io/all-satellites created
 
 ## Configuration
 
-The following customizations are available in the `LinstorCluster` resource:
+We are currently working on improving our documentation. Additional tutorials, how-to guides and explanation will be
+added soon.
 
-* Set a custom registry base. All Piraeus images will use that registry instead of `quay.io/piraeusdatastore`.
-  ```yaml
-  apiVersion: piraeus.io/v1
-  kind: LinstorCluster
-  metadata:
-    name: linstorcluster
-  spec:
-    repository: registry.example.com/piraeus
-  ```
-* A node selector. Satellites will only be started on nodes matching the given labels.
-  ```yaml
-  apiVersion: piraeus.io/v1
-  kind: LinstorCluster
-  metadata:
-    name: linstorcluster
-  spec:
-    nodeSelector:
-      piraeus.io/satellite: "true"
-  ```
-* A reference to a secret, containing the passphrase to unlock
-  [LINSTOR's secret store](https://linbit.com/drbd-user-guide/linstor-guide-1_0-en/#s-encrypt_commands). The secret
-  should contain a single key `MASTER_PASSPHRASE`.
-  ```yaml
-  apiVersion: piraeus.io/v1
-  kind: LinstorCluster
-  metadata:
-    name: linstorcluster
-  spec:
-    linstorPassphraseSecret: my-linstor-passphrase
-  ```
-* A reference to a TLS secret, containing the secret key and certificate use in mutual authentication of  the satellites.
-  If [cert-manager](https://cert-manager.io/) is available, the certificates can be created on demand by the operator.
-  ```yaml
-  apiVersion: piraeus.io/v1
-  kind: LinstorCluster
-  metadata:
-    name: linstorcluster
-  spec:
-    internalTLS:
-      secretName: linstor-controller-internal-tls
-      certManager:
-        kind: Issuer
-        name: piraeus-root
-  ```
-* A list of properties to apply on the controller level. For example, to configure LINSTOR to allocate Ports for DRBD
-  starting at 8000 (instead of the default 7000), you can apply the following change to the LinstorCluster resource
-  ```yaml
-  apiVersion: piraeus.io/v1
-  kind: LinstorCluster
-  metadata:
-    name: linstorcluster
-  spec:
-    properties:
-      - name: TcpPortAutoRange
-        value: "8000-8999"
-  ```
-* [Kustomize patches](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patches/) to apply to
-  resources. When the operator applies resources, it will use `kustomize` to adapt the [base resources](./pkg/resources).
+### [API Reference](./docs/reference)
 
-  For example, to change the number of replicas for the CSI Controller deployment, you can use the following patch:
-  ```yaml
-  apiVersion: piraeus.io/v1
-  kind: LinstorCluster
-  metadata:
-    name: linstorcluster
-  spec:
-    patches:
-      - target:
-          kind: Deployment
-          name: csi-controller
-        patch: |-
-          apiVersion: apps/v1
-          kind: csi-controller
-          metadata:
-            name: csi-controller
-          spec:
-            replicas: 3
-  ```
-
-The `LinstorSatelliteConfiguration` resources allow customizing a set of satellites at once. The `spec.nodeSelector` is
-used to determine which customization is applied on a node.
-
-For example, if you have a set of storage nodes, all labelled with `example.com/storage-node=""`, and you want to:
-* Configure the default network interface to be the IPv6 address of your Pods.
-* Configure secured control plane traffic via TLS, using a [cert-manager](https://cert-manager.io/) issuer named
-  `piraeus-root`.
-* Configure a storage pool on all nodes, setting up on the devices `/dev/vdb` using a LVM thinpool `vg1/thin1` and naming
-  it `thin1` in LINSTOR.
-```
-apiVersion: piraeus.io/v1
-kind: LinstorSatelliteConfiguration
-metadata:
-  name: storage-satellites
-spec:
-  nodeSelector:
-    example.com/storage-node: ""
-  internalTLS:
-    certManager:
-      kind: Issuer
-      name: piraeus-root
-  properties:
-    - name: PrefNic
-      value: default-ipv6
-  storagePools:
-    - name: thin1
-      lvmThin:
-        volumeGroup: vg1
-        thinPool: thin1
-      source:
-        hostDevices:
-          - /dev/vdb
-```
+The API Reference for the Piraeus Operator. Contains documentation of the LINSTOR related resources that the user can
+modify or observe.
 
 ## Missing features
 

--- a/config/manager/default_images.yaml
+++ b/config/manager/default_images.yaml
@@ -1,5 +1,11 @@
 ---
+# This is the configuration for default images used by piraeus-operator
+#
+# "base" is the default repository prefix to use.
 base: quay.io/piraeusdatastore
+# "components" is a mapping of image placeholders to actual image names with tag.
+# For example, the image name "linstor-controller" in the kustomize-resources will be replaced by:
+#   quay.io/piraeusdatastore/piraeus-server:v1.20.0
 components:
   linstor-controller:
     tag: v1.20.0
@@ -15,6 +21,9 @@ components:
     image: drbd-reactor
   drbd-module-loader:
     tag: v9.2.1
+    # The special "match" attribute is used to select an image based on the node's reported OS.
+    # The operator will first check the k8s node's ".status.nodeInfo.osImage" field, and compare it against the list
+    # here. If one matches, that specific image name will be used instead of the fallback image.
     image: drbd9-jammy # Fallback image: chose a fairly recent kernel, which can hopefully compile whatever config is actually in use
     match:
       - osImage: CentOS Linux 7

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,0 +1,19 @@
+# API Reference
+
+This is the API Reference for Piraeus Operator. A user may make modifications to these resources to change the cluster
+state (`LinstorCluster` or `LinstorSatelliteConfiguration`) or check the status of a resource (`LinstorSatellite`).
+
+### [`LinstorCluster`](./linstorcluster.md)
+
+This resource controls the state of the LINSTOR® cluster and integration with Kubernetes.
+
+### [`LinstorSatelliteConfiguration`](./linstorsatelliteconfiguration.md)
+
+This resource controls the state of the LINSTOR Satellites, optionally applying it to only a subset of nodes.
+
+### `LinstorSatellite`
+
+*Coming soon*
+
+This resource controls the state of a single LINSTOR Satellite. This resource is not intended to be changed directly,
+instead it is created by the Piraeus Operator by merging all matching `LinstorSatelliteConfigurations`.

--- a/docs/reference/linstorcluster.md
+++ b/docs/reference/linstorcluster.md
@@ -1,0 +1,225 @@
+# `LinstorCluster`
+
+This resource controls the state of the LINSTOR® cluster and integration with Kubernetes.
+In particular, it controls:
+
+* LINSTOR Controller
+* LINSTOR CSI Driver
+* `LinstorSatellite`, configured through `LinstorSatelliteConfiguration` resources.
+
+## `.spec`
+
+Configures the desired state of the cluster.
+
+### `.spec.nodeSelector`
+
+Selects on which nodes Piraeus Datastore should be deployed. Nodes that are
+excluded by the selector will not be able to run any workload using a Piraeus volume.
+
+If empty (the default), Piraeus will be deployed on all nodes in the cluster.
+
+#### Example
+
+This example restricts Piraeus Datastore to nodes matching `example.com/storage: "yes"`:
+
+```yaml
+apiVersion: piraeus.io/v1
+kind: LinstorCluster
+metadata:
+  name: linstorcluster
+spec:
+  nodeSelector:
+    example.com/storage: "yes"
+```
+
+### `.spec.repository`
+
+Sets the default image registry to use for all Piraeus images. The full image name is
+created by appending an image identifier and tag.
+
+If empty (the default), Piraeus will use `quay.io/piraeusdatastore`.
+
+The current list of default images is available [here](../../config/manager/default_images.yaml).
+
+#### Example
+
+This example pulls all Piraeus images from `registry.example.com/piraeus-mirror`
+rather than `quay.io/piraeusdatastore`.
+
+```yaml
+apiVersion: piraeus.io/v1
+kind: LinstorCluster
+metadata:
+  name: linstorcluster
+spec:
+  repository: registry.example.com/piraeus-mirror
+```
+
+### `.spec.properties`
+
+Sets the given properties on the LINSTOR Controller level, applying them to the whole Cluster.
+
+#### Example
+
+This example sets the port range used for DRBD® volumes to `10000-20000`.
+
+```yaml
+apiVersion: piraeus.io/v1
+kind: LinstorCluster
+metadata:
+  name: linstorcluster
+spec:
+  properties:
+    - name: TcpPortAutoRange
+      value: "10000-20000"
+```
+
+### `.spec.linstorPassphraseSecret`
+
+Configures the [LINSTOR passphrase](https://linbit.com/drbd-user-guide/linstor-guide-1_0-en/#s-linstor-encrypted-volumes),
+used by LINSTOR when creating encrypted volumes and storing access credentials
+for backups.
+
+The referenced secret must exist in the same namespace as the operator
+(by default `piraeus-datastore`), and have a `MASTER_PASSPHRASE` entry.
+
+#### Example
+
+This example configures a passphrase `example-passphrase`. Please **choose a different passphrase** for your deployment.
+
+```yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: linstor-passphrase
+  namespace: piraeus-datastore
+data:
+  # CHANGE THIS TO USE YOUR OWN PASSPHRASE!
+  # Created by: echo -n "example-passphrase" | base64
+  MASTER_PASSPHRASE: ZXhhbXBsZS1wYXNzcGhyYXNl
+---
+apiVersion: piraeus.io/v1
+kind: LinstorCluster
+metadata:
+  name: linstorcluster
+spec:
+  linstorPassphraseSecret: linstor-passphrase
+```
+
+### `.spec.patches`
+
+The given patches will be applied to all resources controlled by the operator. The patches are
+forwarded to `kustomize` internally, and take the [same format](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patches/).
+
+The unpatched resources are available in the [subdirectories of the `pkg/resources` directory](../../pkg/resources).
+
+#### Warning
+
+No checks are run on the result of user-supplied patches: the resources are applied
+as-is. Patching some fundamental aspect, such as removing a specific volume from a
+container may lead to a degraded cluster.
+
+#### Example
+
+This example sets a CPU limit of `10m` on the CSI Node init container and changes the
+LINSTOR Controller service to run in `SingleStack` mode.
+
+```yaml
+apiVersion: piraeus.io/v1
+kind: LinstorCluster
+metadata:
+  name: linstorcluster
+spec:
+  patches:
+    - target:
+        kind: Daemonset
+        name: csi-node
+      patch: |-
+        - op: add
+          path: /spec/template/spec/initContainers/0/resources
+          value:
+            limits:
+               cpu: 10m
+    - target:
+        kind: Service
+        name: linstor-controller
+      patch: |-
+        apiVersion: v1
+        kind: service
+        metadata:
+          name: linstor-controller
+        spec:
+          ipFamilyPolicy: SingleStack
+```
+
+### `.spec.internalTLS`
+
+Configures a TLS secret used by the LINSTOR Controller to:
+* Validate the certificate of the LINSTOR Satellites, that is the Satellites must have certificates signed by `ca.crt`.
+* Provide a client certificate for authentication with LINSTOR Satellites, that is `tls.key` and `tls.crt` must be accepted by the Satellites.
+
+To configure TLS communication between Satellite and Controller, `LinstorSatellite.spec.internalTLS` must be set accordingly.
+
+Setting a `secretName` is optional, it will default to `linstor-controller-internal-tls`.
+
+Optional, a reference to a [cert-manager `Issuer`](https://cert-manager.io/docs/concepts/issuer/) can be provided
+to let the operator create the required secret.
+
+#### Example
+
+This example creates a manually provisioned TLS secret and references it in the
+LinstorCluster configuration.
+
+```yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-linstor-controller-tls
+  namespace: piraeus-datastore
+data:
+  ca.crt: LS0tLS1CRUdJT...
+  tls.crt: LS0tLS1CRUdJT...
+  tls.key: LS0tLS1CRUdJT...
+---
+apiVersion: piraeus.io/v1
+kind: LinstorCluster
+metadata:
+  name: linstorcluster
+spec:
+  internalTLS:
+    secretName: my-linstor-controller-tls
+```
+
+#### Example
+
+This example sets up automatic creation of the LINSTOR Controller TLS secret using a
+cert-manager issuer named `piraeus-root`.
+
+```yaml
+apiVersion: piraeus.io/v1
+kind: LinstorCluster
+metadata:
+  name: linstorcluster
+spec:
+  internalTLS:
+    certManager:
+      kind: Issuer
+      name: piraeus-root
+```
+
+## `.status`
+
+Reports the actual state of the cluster
+
+## `.status.conditions`
+
+The Operator reports the current state of the Cluster through a set of conditions. Conditions are identified by their
+`type`.
+
+| `type`       | Explanation                                                                      |
+|--------------|----------------------------------------------------------------------------------|
+| `Applied`    | All Kubernetes resources controlled by the Operator are applied and up to date.  |
+| `Available`  | The LINSTOR Controller is deployed and reponding to requests.                    |
+| `Configured` | The LINSTOR Controller is configured with the properties from `.spec.properties` |

--- a/docs/reference/linstorsatelliteconfiguration.md
+++ b/docs/reference/linstorsatelliteconfiguration.md
@@ -1,0 +1,35 @@
+# `LinstorSatelliteConfiguration`
+
+This resource allows customizing a set of satellites at once. The `spec.nodeSelector` is
+used to determine which customization is applied on a node.
+
+For example, if you have a set of storage nodes, all labelled with `example.com/storage-node=""`, and you want to:
+* Configure the default network interface to be the IPv6 address of your Pods.
+* Configure secured control plane traffic through TLS, using a [cert-manager](https://cert-manager.io/) issuer named
+  `piraeus-root`.
+* Configure a storage pool on all nodes, setting up on the devices `/dev/vdb` using a LVM thinpool `vg1/thin1` and naming
+  it `thin1` in LINSTOR.
+```
+apiVersion: piraeus.io/v1
+kind: LinstorSatelliteConfiguration
+metadata:
+  name: storage-satellites
+spec:
+  nodeSelector:
+    example.com/storage-node: ""
+  internalTLS:
+    certManager:
+      kind: Issuer
+      name: piraeus-root
+  properties:
+    - name: PrefNic
+      value: default-ipv6
+  storagePools:
+    - name: thin1
+      lvmThin:
+        volumeGroup: vg1
+        thinPool: thin1
+      source:
+        hostDevices:
+          - /dev/vdb
+```


### PR DESCRIPTION
Adds reference docs for all fields of the LinstorCluster CRD, including examples.

Also adds a few comments on the default image configuration, should any user wish to override.
