### PR TITLE
csi: restart node pods if topology labels changed

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -61,6 +61,14 @@ rules:
   verbs:
   - patch
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - list
+  - watch
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
@@ -253,10 +261,10 @@ rules:
   - storage.k8s.io
   resources:
   - csinodes
-  - storageclasses
   verbs:
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - storage.k8s.io
@@ -269,6 +277,14 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - storage.k8s.io

--- a/pkg/conditions/conditions_test.go
+++ b/pkg/conditions/conditions_test.go
@@ -65,6 +65,18 @@ func TestConditions(t *testing.T) {
 				{Type: string(conditions.Configured), Status: metav1.ConditionUnknown, Reason: string(conditions.ReasonNotObserved)},
 			},
 		},
+		{
+			name: "condition-set-multiple-no-reset-error",
+			mutate: func(c conditions.Conditions) {
+				c.AddError(conditions.Applied, errors.New("actually an error"))
+				c.AddSuccess(conditions.Applied, "success")
+			},
+			expected: []metav1.Condition{
+				{Type: string(conditions.Applied), Status: metav1.ConditionFalse, Reason: string(conditions.ReasonError), Message: "Error: actually an error\nsuccess"},
+				{Type: string(conditions.Available), Status: metav1.ConditionUnknown, Reason: string(conditions.ReasonNotObserved)},
+				{Type: string(conditions.Configured), Status: metav1.ConditionUnknown, Reason: string(conditions.ReasonNotObserved)},
+			},
+		},
 	}
 
 	for i := range testcases {


### PR DESCRIPTION
Reimplementation of 1b1e30d2e74e.
    
The satellite operator applies k8s node labels as aux properties. These are
then reported by the csi nodes as supported topology keys. This report
only happens once on plugin startup. Later changes are not reflected, leaving
the volume provisioning steps with old or outdated topology keys.
    
The only way to force a re-sync of those keys is to delete pod. This change
compares the LINSTOR Node auxilliary properties with the keys reported by
the csi plugin registration. If the set of labels has diverged, the
registration and pod is deleted. After the daemonset restarts the pod,
kubelet will trigger a new registration, making the updated keys available.
