### PR TITLE
controller: requeue reconcile in intervals

### DIFF
--- a/controllers/linstorcluster_controller.go
+++ b/controllers/linstorcluster_controller.go
@@ -132,7 +132,15 @@ func (r *LinstorClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return nil
 	})
 
-	return ctrl.Result{}, utils.AnyError(applyErr, stateErr, condErr)
+	result := ctrl.Result{
+		RequeueAfter: 1 * time.Minute,
+	}
+
+	if !conds.AllHaveStatus(metav1.ConditionTrue) {
+		result.RequeueAfter = 10 * time.Second
+	}
+
+	return result, utils.AnyError(applyErr, stateErr, condErr)
 }
 
 func (r *LinstorClusterReconciler) reconcileAppliedResource(ctx context.Context, lcluster *piraeusiov1.LinstorCluster) error {

--- a/pkg/conditions/conditions.go
+++ b/pkg/conditions/conditions.go
@@ -105,3 +105,13 @@ func (c Conditions) ToConditions(generation int64) []metav1.Condition {
 
 	return result
 }
+
+func (c Conditions) AllHaveStatus(status metav1.ConditionStatus) bool {
+	for _, cond := range c {
+		if cond.Status != status {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/conditions/conditions_test.go
+++ b/pkg/conditions/conditions_test.go
@@ -93,3 +93,71 @@ func TestConditions(t *testing.T) {
 		})
 	}
 }
+
+func TestConditions_AllHaveStatus(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name     string
+		mutate   func(c conditions.Conditions)
+		status   metav1.ConditionStatus
+		expected bool
+	}{
+		{
+			name:     "default",
+			status:   metav1.ConditionTrue,
+			expected: false,
+		},
+		{
+			name:     "default-all-unknown",
+			status:   metav1.ConditionUnknown,
+			expected: true,
+		},
+		{
+			name: "all-true",
+			mutate: func(c conditions.Conditions) {
+				c.AddSuccess(conditions.Applied, "Applied")
+				c.AddSuccess(conditions.Available, "Available")
+				c.AddSuccess(conditions.Configured, "Configured")
+				c.AddSuccess("NewCondition", "new")
+			},
+			status:   metav1.ConditionTrue,
+			expected: true,
+		},
+		{
+			name: "new-condition-false",
+			mutate: func(c conditions.Conditions) {
+				c.AddSuccess(conditions.Applied, "Applied")
+				c.AddSuccess(conditions.Available, "Available")
+				c.AddSuccess(conditions.Configured, "Configured")
+				c.AddError("NewCondition", errors.New("new"))
+			},
+			status:   metav1.ConditionTrue,
+			expected: false,
+		},
+		{
+			name: "all-false",
+			mutate: func(c conditions.Conditions) {
+				c.AddError(conditions.Applied, errors.New("Applied"))
+				c.AddError(conditions.Available, errors.New("Available"))
+				c.AddError(conditions.Configured, errors.New("Configured"))
+			},
+			status:   metav1.ConditionFalse,
+			expected: true,
+		},
+	}
+
+	for i := range testcases {
+		tcase := &testcases[i]
+		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := conditions.New()
+			if tcase.mutate != nil {
+				tcase.mutate(c)
+			}
+			actual := c.AllHaveStatus(tcase.status)
+			assert.Equal(t, tcase.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
Since we don't get notifications from LINSTOR Controller for all relevant events, we have to ensure we requeue reconcile attempts from time to time.

One particular occurance where this is relevant are starting LINSTOR Satellites: since the Pod can be ready long before LINSTOR reconnects, we might miss the window to update the status once the satellite is actually online.