### PR TITLE
patches: convert to yaml-based patches

### DIFF
--- a/controllers/patches.go
+++ b/controllers/patches.go
@@ -1,0 +1,140 @@
+package controllers
+
+import (
+	"bytes"
+	"io"
+	"io/fs"
+	"strings"
+
+	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	kusttypes "sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/yaml"
+
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/resources/cluster"
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/resources/satellite"
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/utils"
+)
+
+func ClusterLinstorPassphrasePatch(secretName string) ([]kusttypes.Patch, error) {
+	return render(
+		cluster.Resources,
+		"patches/passphrase.yaml",
+		map[string]any{
+			"LINSTOR_PASSPHRASE_SECRET_NAME": secretName,
+		},
+	)
+}
+
+func ClusterLinstorInternalTLSPatch(secretName string) ([]kusttypes.Patch, error) {
+	return render(
+		cluster.Resources,
+		"patches/internal-tls.yaml",
+		map[string]any{
+			"LINSTOR_INTERNAL_TLS_SECRET_NAME": secretName,
+		},
+	)
+}
+
+func ClusterLinstorInternalTLSCertManagerPatch(secretName string, issuer *cmmetav1.ObjectReference) ([]kusttypes.Patch, error) {
+	return render(
+		cluster.Resources,
+		"patches/internal-tls-cert-manager.yaml",
+		map[string]any{
+			"LINSTOR_INTERNAL_TLS_SECRET_NAME": secretName,
+			"LINSTOR_INTERNAL_TLS_CERT_ISSUER": issuer,
+		},
+	)
+}
+
+func ClusterCSINodeSelectorPatch(selector map[string]string) ([]kusttypes.Patch, error) {
+	return render(
+		cluster.Resources,
+		"patches/csi-node-selector.yaml",
+		map[string]any{
+			"NODE_SELECTOR": selector,
+		})
+}
+
+func PullSecretPatch(secretName string) ([]kusttypes.Patch, error) {
+	return render(
+		cluster.Resources,
+		"patches/pull-secret.yaml",
+		map[string]any{
+			"IMAGE_PULL_SECRET": secretName,
+		})
+}
+
+func SatelliteLinstorInternalTLSPatch(secretName string) ([]kusttypes.Patch, error) {
+	return render(
+		satellite.Resources,
+		"patches/internal-tls.yaml",
+		map[string]any{
+			"LINSTOR_INTERNAL_TLS_SECRET_NAME": secretName,
+		},
+	)
+}
+
+func SatelliteLinstorInternalTLSCertManagerPatch(secretName string, issuer *cmmetav1.ObjectReference) ([]kusttypes.Patch, error) {
+	return render(
+		satellite.Resources,
+		"patches/internal-tls-cert-manager.yaml",
+		map[string]any{
+			"LINSTOR_INTERNAL_TLS_SECRET_NAME": secretName,
+			"LINSTOR_INTERNAL_TLS_CERT_ISSUER": issuer,
+		},
+	)
+}
+
+func SatelliteCommonNodePatch(nodeName string) ([]kusttypes.Patch, error) {
+	return render(
+		satellite.Resources,
+		"patches/common-node.yaml",
+		map[string]any{
+			"NODE_NAME": nodeName,
+		},
+	)
+}
+
+func SatelliteHostPathVolumePatch(volumeName, hostPath string) ([]kusttypes.Patch, error) {
+	return render(
+		satellite.Resources,
+		"patches/host-path-volume.yaml",
+		map[string]any{
+			"VOLUME_NAME": volumeName,
+			"HOST_PATH":   hostPath,
+		},
+	)
+}
+
+func SatelliteHostPathVolumeEnvPatch(hostPaths []string) ([]kusttypes.Patch, error) {
+	return render(
+		satellite.Resources,
+		"patches/host-path-volume-env.yaml",
+		map[string]any{
+			"HOST_PATHS": strings.Join(hostPaths, ":"),
+		},
+	)
+}
+
+func render(f fs.FS, fileName string, params map[string]any) ([]kusttypes.Patch, error) {
+	raw, err := f.Open(fileName)
+	if err != nil {
+		return nil, err
+	}
+
+	defer raw.Close()
+
+	buf := bytes.Buffer{}
+	_, err = io.Copy(&buf, raw)
+	if err != nil {
+		return nil, err
+	}
+
+	var patches []kusttypes.Patch
+	err = yaml.Unmarshal(buf.Bytes(), &patches)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.RenderPatches(params, patches...)
+}

--- a/controllers/patches_test.go
+++ b/controllers/patches_test.go
@@ -1,0 +1,86 @@
+package controllers_test
+
+import (
+	"testing"
+
+	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/stretchr/testify/assert"
+	kusttypes "sigs.k8s.io/kustomize/api/types"
+
+	"github.com/piraeusdatastore/piraeus-operator/v2/controllers"
+)
+
+func TestPatches(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name string
+		call func() ([]kusttypes.Patch, error)
+	}{
+		{
+			name: "ClusterLinstorPassphrasePatch",
+			call: func() ([]kusttypes.Patch, error) {
+				return controllers.ClusterLinstorPassphrasePatch("secret")
+			},
+		},
+		{
+			name: "ClusterLinstorInternalTLSPatch",
+			call: func() ([]kusttypes.Patch, error) {
+				return controllers.ClusterLinstorInternalTLSPatch("secret")
+			},
+		},
+		{
+			name: "ClusterLinstorInternalTLSCertManagerPatch",
+			call: func() ([]kusttypes.Patch, error) {
+				return controllers.ClusterLinstorInternalTLSCertManagerPatch("secret", &cmmetav1.ObjectReference{
+					Name: "issuer",
+				})
+			},
+		},
+		{
+			name: "ClusterCSINodeSelectorPatch",
+			call: func() ([]kusttypes.Patch, error) {
+				return controllers.ClusterCSINodeSelectorPatch(map[string]string{"foo": "bar"})
+			},
+		},
+		{
+			name: "PullSecretPatch",
+			call: func() ([]kusttypes.Patch, error) {
+				return controllers.PullSecretPatch("secret")
+			},
+		},
+		{
+			name: "SatelliteLinstorInternalTLSPatch",
+			call: func() ([]kusttypes.Patch, error) {
+				return controllers.SatelliteLinstorInternalTLSPatch("secret")
+			},
+		},
+		{
+			name: "SatelliteCommonNodePatch",
+			call: func() ([]kusttypes.Patch, error) {
+				return controllers.SatelliteCommonNodePatch("node")
+			},
+		},
+		{
+			name: "SatelliteHostPathVolumePatch",
+			call: func() ([]kusttypes.Patch, error) {
+				return controllers.SatelliteHostPathVolumePatch("vol-name", "/host/path")
+			},
+		},
+		{
+			name: "SatelliteHostPathVolumeEnvPatch",
+			call: func() ([]kusttypes.Patch, error) {
+				return controllers.SatelliteHostPathVolumeEnvPatch([]string{"/path1", "/path2"})
+			},
+		},
+	}
+
+	for i := range testcases {
+		testcase := &testcases[i]
+		t.Run(testcase.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := testcase.call()
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/hack/csvinflater/csvinflater.go
+++ b/hack/csvinflater/csvinflater.go
@@ -106,9 +106,13 @@ func CombineAllEmbededResources(fs *embed.FS) (resmap.ResMap, error) {
 		return nil, fmt.Errorf("failed to list embedded directories: %w", err)
 	}
 
-	subDirNames := make([]string, len(subDirs))
+	var subDirNames []string
 	for i := range subDirs {
-		subDirNames[i] = subDirs[i].Name()
+		if subDirs[i].Name() == "patches" {
+			continue
+		}
+
+		subDirNames = append(subDirNames, subDirs[i].Name())
 	}
 
 	return kustomizer.Kustomize(&kusttypes.Kustomization{

--- a/pkg/resources/cluster/patches/csi-node-selector.yaml
+++ b/pkg/resources/cluster/patches/csi-node-selector.yaml
@@ -1,0 +1,15 @@
+---
+- target:
+    group: apps
+    version: v1
+    kind: DaemonSet
+    name: csi-node
+  patch: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: csi-node
+    spec:
+      template:
+        spec:
+          nodeSelector: $NODE_SELECTOR

--- a/pkg/resources/cluster/patches/internal-tls-cert-manager.yaml
+++ b/pkg/resources/cluster/patches/internal-tls-cert-manager.yaml
@@ -5,12 +5,10 @@
     kind: Certificate
     name: linstor-controller-internal-tls
   patch: |
-    - op: replace
-      path: /metadata/name
-      value: $LINSTOR_INTERNAL_TLS_SECRET_NAME
-    - op: replace
-      path: /spec/secretName
-      value: $LINSTOR_INTERNAL_TLS_SECRET_NAME
-    - op: replace
-      path: /spec/issuerRef
-      value: $LINSTOR_INTERNAL_TLS_CERT_ISSUER
+    apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+      name: linstor-controller-internal-tls
+    spec:
+      secretName: $LINSTOR_INTERNAL_TLS_SECRET_NAME
+      issuerRef: $LINSTOR_INTERNAL_TLS_CERT_ISSUER

--- a/pkg/resources/cluster/patches/internal-tls-cert-manager.yaml
+++ b/pkg/resources/cluster/patches/internal-tls-cert-manager.yaml
@@ -1,0 +1,16 @@
+---
+- target:
+    group: cert-manager.io
+    version: v1
+    kind: Certificate
+    name: linstor-controller-internal-tls
+  patch: |
+    - op: replace
+      path: /metadata/name
+      value: $LINSTOR_INTERNAL_TLS_SECRET_NAME
+    - op: replace
+      path: /spec/secretName
+      value: $LINSTOR_INTERNAL_TLS_SECRET_NAME
+    - op: replace
+      path: /spec/issuerRef
+      value: $LINSTOR_INTERNAL_TLS_CERT_ISSUER

--- a/pkg/resources/cluster/patches/internal-tls.yaml
+++ b/pkg/resources/cluster/patches/internal-tls.yaml
@@ -1,0 +1,28 @@
+---
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: linstor-controller
+  patch: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: linstor-controller
+    spec:
+      template:
+        spec:
+          volumes:
+          - name: internal-tls
+            secret:
+              secretName: $LINSTOR_INTERNAL_TLS_SECRET_NAME
+          - name: java-internal-tls
+            emptyDir: {}
+          containers:
+          - name: linstor-controller
+            volumeMounts:
+              - name: internal-tls
+                mountPath: /etc/linstor/ssl-pem
+                readOnly: true
+              - name: java-internal-tls
+                mountPath: /etc/linstor/ssl

--- a/pkg/resources/cluster/patches/passphrase.yaml
+++ b/pkg/resources/cluster/patches/passphrase.yaml
@@ -1,0 +1,22 @@
+---
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: linstor-controller
+  patch: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: linstor-controller
+    spec:
+      template:
+        spec:
+          containers:
+          - name: linstor-controller
+            env:
+            - name: MASTER_PASSPHRASE
+              valueFrom:
+                secretKeyRef:
+                  name: $LINSTOR_PASSPHRASE_SECRET_NAME
+                  key: MASTER_PASSPHRASE

--- a/pkg/resources/cluster/patches/pull-secret.yaml
+++ b/pkg/resources/cluster/patches/pull-secret.yaml
@@ -1,0 +1,11 @@
+---
+- target:
+    version: v1
+    kind: ServiceAccount
+  patch: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: default
+    imagePullSecrets:
+    - name: $IMAGE_PULL_SECRET

--- a/pkg/resources/cluster/resources.go
+++ b/pkg/resources/cluster/resources.go
@@ -2,5 +2,5 @@ package cluster
 
 import "embed"
 
-//go:embed satellite-common controller csi satellite
+//go:embed satellite-common controller csi satellite patches
 var Resources embed.FS

--- a/pkg/resources/satellite/patches/common-node.yaml
+++ b/pkg/resources/satellite/patches/common-node.yaml
@@ -1,0 +1,28 @@
+---
+- target:
+    version: v1
+    kind: Pod
+    name: satellite
+  patch: |
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: satellite
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchFields:
+                  - key: metadata.name
+                    operator: In
+                    values:
+                      - $NODE_NAME
+- target:
+    version: v1
+    kind: Pod
+    name: satellite
+  patch: |
+    - op: replace
+      path: /metadata/name
+      value: $NODE_NAME

--- a/pkg/resources/satellite/patches/common-node.yaml
+++ b/pkg/resources/satellite/patches/common-node.yaml
@@ -18,11 +18,3 @@
                     operator: In
                     values:
                       - $NODE_NAME
-- target:
-    version: v1
-    kind: Pod
-    name: satellite
-  patch: |
-    - op: replace
-      path: /metadata/name
-      value: $NODE_NAME

--- a/pkg/resources/satellite/patches/host-path-volume-env.yaml
+++ b/pkg/resources/satellite/patches/host-path-volume-env.yaml
@@ -1,0 +1,16 @@
+---
+- target:
+    version: v1
+    kind: Pod
+    name: satellite
+  patch: |
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: satellite
+    spec:
+      containers:
+        - name: linstor-satellite
+          env:
+          - name: LOSETUP_CONTAINER_BIND_MOUNTS
+            value: $HOST_PATHS

--- a/pkg/resources/satellite/patches/host-path-volume.yaml
+++ b/pkg/resources/satellite/patches/host-path-volume.yaml
@@ -1,0 +1,21 @@
+---
+- target:
+    version: v1
+    kind: Pod
+    name: satellite
+  patch: |
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: satellite
+    spec:
+      volumes:
+        - name: $VOLUME_NAME
+          hostPath:
+            path: $HOST_PATH
+            type: DirectoryOrCreate
+      containers:
+        - name: linstor-satellite
+          volumeMounts:
+            - name: $VOLUME_NAME
+              mountPath: $HOST_PATH

--- a/pkg/resources/satellite/patches/internal-tls-cert-manager.yaml
+++ b/pkg/resources/satellite/patches/internal-tls-cert-manager.yaml
@@ -5,12 +5,10 @@
     kind: Certificate
     name: tls
   patch: |
-    - op: replace
-      path: /metadata/name
-      value: $LINSTOR_INTERNAL_TLS_SECRET_NAME
-    - op: replace
-      path: /spec/secretName
-      value: $LINSTOR_INTERNAL_TLS_SECRET_NAME
-    - op: replace
-      path: /spec/issuerRef
-      value: $LINSTOR_INTERNAL_TLS_CERT_ISSUER
+    apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+      name: tls
+    spec:
+      secretName: $LINSTOR_INTERNAL_TLS_SECRET_NAME
+      issuerRef: $LINSTOR_INTERNAL_TLS_CERT_ISSUER

--- a/pkg/resources/satellite/patches/internal-tls-cert-manager.yaml
+++ b/pkg/resources/satellite/patches/internal-tls-cert-manager.yaml
@@ -1,0 +1,16 @@
+---
+- target:
+    group: cert-manager.io
+    version: v1
+    kind: Certificate
+    name: tls
+  patch: |
+    - op: replace
+      path: /metadata/name
+      value: $LINSTOR_INTERNAL_TLS_SECRET_NAME
+    - op: replace
+      path: /spec/secretName
+      value: $LINSTOR_INTERNAL_TLS_SECRET_NAME
+    - op: replace
+      path: /spec/issuerRef
+      value: $LINSTOR_INTERNAL_TLS_CERT_ISSUER

--- a/pkg/resources/satellite/patches/internal-tls.yaml
+++ b/pkg/resources/satellite/patches/internal-tls.yaml
@@ -1,0 +1,45 @@
+---
+- target:
+    version: v1
+    kind: Pod
+    name: satellite
+  patch: |
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: satellite
+    spec:
+      volumes:
+        - name: internal-tls
+          secret:
+            secretName: $LINSTOR_INTERNAL_TLS_SECRET_NAME
+        - name: java-internal-tls
+          emptyDir: { }
+      containers:
+        - name: linstor-satellite
+          volumeMounts:
+            - name: internal-tls
+              mountPath: /etc/linstor/ssl-pem
+              readOnly: true
+            - name: java-internal-tls
+              mountPath: /etc/linstor/ssl
+- target:
+    version: v1
+    kind: ConfigMap
+    name: satellite-config
+  patch: |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: satellite-config
+    data:
+      linstor_satellite.toml: |
+        [netcom]
+          type = "ssl"
+          port = 3367
+          server_certificate = "/etc/linstor/ssl/keystore.jks"
+          key_password = "linstor"
+          keystore_password = "linstor"
+          trusted_certificates = "/etc/linstor/ssl/certificates.jks"
+          truststore_password = "linstor"
+          ssl_protocol = "TLSv1.2"

--- a/pkg/resources/satellite/resources.go
+++ b/pkg/resources/satellite/resources.go
@@ -2,5 +2,5 @@ package satellite
 
 import "embed"
 
-//go:embed pod
+//go:embed pod patches
 var Resources embed.FS


### PR DESCRIPTION
Having patches to k8s resources directly in the controller code made the code quite hard to follow.

To replace those patches, use predefined patches, already in the kustomize format. Since the patches only need setting of single values, we create a basic "yaml-safe" template system, where we can replace a specific part of the patch with minimal fuzz.

This commit also converts almost all of the patches to this new system. Only the LinstorSatellite patch created by the LinstorCluster controller is left as the old set of manual JSONPatch operations, as it does not fit nicely in the "replace single parts of patches" framework.

Signed-off-by: Moritz "WanzenBug" Wanzenböck <moritz.wanzenboeck@linbit.com>