### PR TITLE
add "linstor" prefix to CSI resources

### DIFF
--- a/api/v1/linstorcluster_webhook_test.go
+++ b/api/v1/linstorcluster_webhook_test.go
@@ -31,10 +31,10 @@ var _ = Describe("LinstorCluster webhook", func() {
 			Patches: []piraeusv1.Patch{
 				{
 					Target: &piraeusv1.Selector{
-						Name: "csi-controller",
+						Name: "linstor-csi-controller",
 						Kind: "Deployment",
 					},
-					Patch: "[{\"op\": \"replace\", \"path\": \"/metadata/name\", \"value\": \"csi-controller-of-the-universe\"}]",
+					Patch: "[{\"op\": \"replace\", \"path\": \"/metadata/name\", \"value\": \"linstor-csi-controller-of-the-universe\"}]",
 				},
 			},
 		},

--- a/controllers/linstorcluster_controller.go
+++ b/controllers/linstorcluster_controller.go
@@ -540,10 +540,10 @@ func (r *LinstorClusterReconciler) reconcileCSINodes(ctx context.Context, lclust
 	var csiPods corev1.PodList
 	err := r.Client.List(ctx, &csiPods, client.InNamespace(r.Namespace), client.MatchingLabels{
 		"app.kubernetes.io/instance":  lcluster.Name,
-		"app.kubernetes.io/component": "csi-node",
+		"app.kubernetes.io/component": "linstor-csi-node",
 	})
 	if err != nil {
-		err := fmt.Errorf("failed to list csi-node pods: %w", err)
+		err := fmt.Errorf("failed to list linstor-csi-node pods: %w", err)
 		conds.AddUnknown(conditions.Configured, err.Error())
 		return err
 	}

--- a/pkg/resources/cluster/csi/csi-controller-deployment.yaml
+++ b/pkg/resources/cluster/csi/csi-controller-deployment.yaml
@@ -2,22 +2,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: csi-controller
+  name: linstor-csi-controller
   labels:
-    app.kubernetes.io/component: csi-controller
+    app.kubernetes.io/component: linstor-csi-controller
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: csi-controller
+      app.kubernetes.io/component: linstor-csi-controller
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: linstor-csi
       labels:
-        app.kubernetes.io/component: csi-controller
+        app.kubernetes.io/component: linstor-csi-controller
     spec:
       enableServiceLinks: false
-      serviceAccountName: csi-controller
+      serviceAccountName: linstor-csi-controller
       initContainers:
         - name: linstor-wait-api-online
           image: linstor-csi

--- a/pkg/resources/cluster/csi/csi-controller-service-account.yaml
+++ b/pkg/resources/cluster/csi/csi-controller-service-account.yaml
@@ -2,14 +2,14 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: csi-controller
+  name: linstor-csi-controller
   labels:
-    app.kubernetes.io/component: csi-controller
+    app.kubernetes.io/component: linstor-csi-controller
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: csi-controller
+  name: linstor-csi-controller
 rules:
 # csi attacher rules
   - apiGroups: [ "" ]
@@ -88,23 +88,23 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: csi-controller
+  name: linstor-csi-controller
   labels:
-    app.kubernetes.io/component: csi-controller
+    app.kubernetes.io/component: linstor-csi-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: csi-controller
+  name: linstor-csi-controller
 subjects:
   - kind: ServiceAccount
-    name: csi-controller
+    name: linstor-csi-controller
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: csi-controller
+  name: linstor-csi-controller
   labels:
-    app.kubernetes.io/component: csi-controller
+    app.kubernetes.io/component: linstor-csi-controller
 rules:
   - apiGroups: [ "coordination.k8s.io" ]
     resources: [ "leases" ]
@@ -122,13 +122,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: csi-controller
+  name: linstor-csi-controller
   labels:
-    app.kubernetes.io/component: csi-controller
+    app.kubernetes.io/component: linstor-csi-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: csi-controller
+  name: linstor-csi-controller
 subjects:
   - kind: ServiceAccount
-    name: csi-controller
+    name: linstor-csi-controller

--- a/pkg/resources/cluster/csi/csi-node-daemon-set.yaml
+++ b/pkg/resources/cluster/csi/csi-node-daemon-set.yaml
@@ -2,23 +2,23 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: csi-node
+  name: linstor-csi-node
   labels:
-    app.kubernetes.io/component: csi-node
+    app.kubernetes.io/component: linstor-csi-node
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: csi-node
+      app.kubernetes.io/component: linstor-csi-node
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: linstor-csi
       labels:
-        app.kubernetes.io/component: csi-node
+        app.kubernetes.io/component: linstor-csi-node
     spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
-      serviceAccountName: csi-node
+      serviceAccountName: linstor-csi-node
       initContainers:
         - name: linstor-wait-node-online
           image: linstor-csi

--- a/pkg/resources/cluster/csi/csi-node-service-account.yaml
+++ b/pkg/resources/cluster/csi/csi-node-service-account.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: csi-node
+  name: linstor-csi-node
   labels:
-    app.kubernetes.io/component: csi-node
+    app.kubernetes.io/component: linstor-csi-node

--- a/pkg/resources/cluster/patches/csi-node-selector.yaml
+++ b/pkg/resources/cluster/patches/csi-node-selector.yaml
@@ -3,12 +3,12 @@
     group: apps
     version: v1
     kind: DaemonSet
-    name: csi-node
+    name: linstor-csi-node
   patch: |
     apiVersion: apps/v1
     kind: DaemonSet
     metadata:
-      name: csi-node
+      name: linstor-csi-node
     spec:
       template:
         spec:


### PR DESCRIPTION
Some resources for the CSI Driver are cluster scoped, notably the ClusterRole and ClusterRoleBinding. Since our CSI driver might not be the only one, we should ensure our resources do not conflict with others.