### PR TITLE
csi: add health monitor sidecar

### DIFF
--- a/pkg/resources/cluster/csi/csi-controller-deployment.yaml
+++ b/pkg/resources/cluster/csi/csi-controller-deployment.yaml
@@ -185,6 +185,30 @@ spec:
             capabilities:
               drop:
                 - ALL
+        - name: csi-health-monitor
+          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.8.0
+          args:
+            - '--v=5'
+            - '--csi-address=$(ADDRESS)'
+            - '--timeout=1m'
+            - '--leader-election=true'
+            - '--leader-election-namespace=$(NAMESPACE)'
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          securityContext:
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
       volumes:
         - name: socket-dir
           emptyDir: {}

--- a/pkg/resources/cluster/csi/csi-controller-service-account.yaml
+++ b/pkg/resources/cluster/csi/csi-controller-service-account.yaml
@@ -84,6 +84,22 @@ rules:
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents/status" ]
     verbs: [ "update", "patch" ]
+# csi-health-monitor rules
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumes" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumeclaims" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "nodes" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "pods" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "events" ]
+    verbs: [ "get", "list", "watch", "create", "patch" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
The health monitor sidecar monitors the volume condition as reported by the CSI driver. It then propagates this condition in the form of events to the PV, PVC and Pods.

Since it is purely information without any actual actions being triggered, it can't hurt to have it as part of our CSI offering.