### PR TITLE
Introduce controllerStrategy option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Option `controllerStrategy` to describe how to replace existing pods with new ones for csi-controller
+
 ## [v1.10.1] - 2022-12-15
 
 ### Changed

--- a/charts/piraeus/crds/piraeus.linbit.com_linstorcsidrivers.yaml
+++ b/charts/piraeus/crds/piraeus.linbit.com_linstorcsidrivers.yaml
@@ -869,6 +869,55 @@ spec:
                   for the CSI controller deployment.
                 format: int32
                 type: integer
+              controllerStrategy:
+                description: controllerStrategy describes how to replace existing
+                  pods with new ones.
+                nullable: true
+                properties:
+                  rollingUpdate:
+                    description: 'Rolling update config params. Present only if DeploymentStrategyType
+                      = RollingUpdate. --- TODO: Update this to follow our convention
+                      for oneOf, whatever we decide it to be.'
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of pods that can be scheduled
+                          above the desired number of pods. Value can be an absolute
+                          number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          This can not be 0 if MaxUnavailable is 0. Absolute number
+                          is calculated from percentage by rounding up. Defaults to
+                          25%. Example: when this is set to 30%, the new ReplicaSet
+                          can be scaled up immediately when the rolling update starts,
+                          such that the total number of old and new pods do not exceed
+                          130% of desired pods. Once old pods have been killed, new
+                          ReplicaSet can be scaled up further, ensuring that total
+                          number of pods running at any time during the update is
+                          at most 130% of desired pods.'
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of pods that can be unavailable
+                          during the update. Value can be an absolute number (ex:
+                          5) or a percentage of desired pods (ex: 10%). Absolute number
+                          is calculated from percentage by rounding down. This can
+                          not be 0 if MaxSurge is 0. Defaults to 25%. Example: when
+                          this is set to 30%, the old ReplicaSet can be scaled down
+                          to 70% of desired pods immediately when the rolling update
+                          starts. Once new pods are ready, old ReplicaSet can be scaled
+                          down further, followed by scaling up the new ReplicaSet,
+                          ensuring that the total number of pods available at all
+                          times during the update is at least 70% of desired pods.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                      Default is RollingUpdate.
+                    type: string
+                type: object
               controllerTolerations:
                 description: Tolerations for schedluing CSI controller pods
                 items:

--- a/charts/piraeus/templates/operator-csi-driver.yaml
+++ b/charts/piraeus/templates/operator-csi-driver.yaml
@@ -44,6 +44,9 @@ spec:
   linstorHttpsClientSecret: {{ include "client.httpsSecretName" . | quote }}
   priorityClassName: {{ .Values.priorityClassName | default "" | quote }}
   controllerReplicas: {{ .Values.csi.controllerReplicas }}
+{{- if .Values.csi.controllerStrategy }}
+  controllerStrategy: {{ .Values.csi.controllerStrategy }}
+{{- end }}
   controllerEndpoint: {{ template "controller.endpoint" . }}
   nodeAffinity: {{ .Values.csi.nodeAffinity | toJson }}
   nodeTolerations: {{ .Values.csi.nodeTolerations | toJson}}

--- a/charts/piraeus/values.cn.yaml
+++ b/charts/piraeus/values.cn.yaml
@@ -35,6 +35,7 @@ csi:
   csiSnapshotterWorkerThreads: 10
   csiResizerWorkerThreads: 10
   controllerReplicas: 1
+  controllerStrategy: {}
   nodeAffinity: {}
   nodeTolerations: []
   controllerAffinity: {}

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -35,6 +35,7 @@ csi:
   csiSnapshotterWorkerThreads: 10
   csiResizerWorkerThreads: 10
   controllerReplicas: 1
+  controllerStrategy: {}
   nodeAffinity: {}
   nodeTolerations: []
   controllerAffinity: {}

--- a/pkg/apis/piraeus/v1/linstorcsidriver_types.go
+++ b/pkg/apis/piraeus/v1/linstorcsidriver_types.go
@@ -19,6 +19,7 @@ package v1
 
 import (
 	"github.com/piraeusdatastore/piraeus-operator/pkg/apis/piraeus/shared"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -88,6 +89,11 @@ type LinstorCSIDriverSpec struct {
 	// deployment.
 	// +optional
 	ControllerReplicas *int32 `json:"controllerReplicas"`
+
+	// controllerStrategy describes how to replace existing pods with new ones.
+	// +optional
+	// +nullable
+	ControllerStrategy appsv1.DeploymentStrategy `json:"controllerStrategy,omitempty"`
 
 	// Cluster URL of the linstor controller.
 	// If not set, will be determined from the current resource name.

--- a/pkg/apis/piraeus/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/piraeus/v1/zz_generated.deepcopy.go
@@ -95,6 +95,7 @@ func (in *LinstorCSIDriverSpec) DeepCopyInto(out *LinstorCSIDriverSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	in.ControllerStrategy.DeepCopyInto(&out.ControllerStrategy)
 	in.Resources.DeepCopyInto(&out.Resources)
 	if in.NodeAffinity != nil {
 		in, out := &in.NodeAffinity, &out.NodeAffinity

--- a/pkg/controller/linstorcsidriver/linstorcsidriver_controller.go
+++ b/pkg/controller/linstorcsidriver/linstorcsidriver_controller.go
@@ -993,6 +993,7 @@ func newCSIControllerDeployment(csiResource *piraeusv1.LinstorCSIDriver) *appsv1
 				MatchLabels: meta.Labels,
 			},
 			Replicas: csiResource.Spec.ControllerReplicas,
+			Strategy: csiResource.Spec.ControllerStrategy,
 			Template: template,
 		},
 	}


### PR DESCRIPTION
This PR allows to specify deployment strategy for linstor-csi-controller
linstor-csi-controller with podAntiAffinity and default strategy will stuck update in case of two nodes.

The linstor-controller deployment is not affected due to hardcoded `strategy: Recreate`

downstream issue https://github.com/deckhouse/deckhouse/issues/3074
downstream pr https://github.com/deckhouse/deckhouse/pull/3661