### PR TITLE
v2: reintroduce a helm chart

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        exclude: charts/.*/templates/.*
         args:
           - --multi
       - id: check-added-large-files

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ help: ## Display this help.
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	go run ./hack/csvinflater > config/manifests/csv-resource-patch.yaml
 	$(CONTROLLER_GEN) rbac:roleName=controller-manager crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	hack/crd-charts-copy.sh > charts/piraeus/templates/crds.yaml
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/charts/piraeus/.helmignore
+++ b/charts/piraeus/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/piraeus/Chart.yaml
+++ b/charts/piraeus/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: piraeus
+description: |
+  The Piraeus Operator manages software defined storage clusters using LINSTOR in Kubernetes.
+type: application
+version: 2.0.0
+appVersion: "v2.0.0"
+maintainers:
+  - name: Piraeus Datastore
+    url: https://piraeus.io
+home: https://piraeus.io
+icon: https://raw.githubusercontent.com/piraeusdatastore/piraeus/master/artwork/sandbox-artwork/icon/color.svg
+keywords:
+  - storage
+sources:
+  - https://github.com/piraeusdatastore/piraeus-operator
+  - https://github.com/piraeusdatastore/linstor-csi
+  - https://github.com/LINBIT/linstor-server

--- a/charts/piraeus/README.md
+++ b/charts/piraeus/README.md
@@ -1,0 +1,35 @@
+# Piraeus Operator
+
+Deploys the [Piraeus Operator](https://github.com/piraeusdatastore/piraeus-operator) which deploys and manages a simple
+and resilient storage solution for Kubernetes.
+
+The main deployment method for Piraeus Operator switched to [`kustomize`](../../docs/tutorial)
+in release `v2.0.0`. This chart is intended for users who want to continue using Helm.
+
+This chart **only** configures the Operator, but does not create the `LinstorCluster` resource creating the actual
+storage system. Refer to the existing [tutorials](../../docs/tutorial)
+and [how-to guides](../../docs/how-to).
+
+## Deploying Piraeus Operator
+
+To deploy Piraeus Operator with Helm, clone this repository and deploy the chart:
+
+```
+$ git clone --branch v2 https://github.com/piraeusdatastore/piraeus-operator
+$ cd piraeus-operator
+$ helm install piraeus-operator charts/piraeus-operator --create-namespace -n piraeus-datastore
+```
+
+Follow the instructions printed by Helm to create your storage cluster:
+
+```
+$ kubectl apply -f - <<EOF
+apiVersion: piraeus.io/v1
+kind: LinstorCluster
+metadata:
+  name: linstorcluster
+spec: {}
+EOF
+```
+
+Check out our [documentation](../../docs) for more information.

--- a/charts/piraeus/templates/NOTES.txt
+++ b/charts/piraeus/templates/NOTES.txt
@@ -1,0 +1,26 @@
+Piraeus Operator installed.
+
+{{- if not (.Capabilities.APIVersions.Has "piraeus.io/v1/LinstorCluster") }}
+It looks like the necessary CRDs for Piraeus Operator are still missing.
+
+To apply them via helm now use:
+
+  helm upgrade {{ .Release.Name }} ./charts/piraeus-operator --reuse-values --set installCRDs=true
+
+Alternatively, you can manage them manually:
+
+  kubectl apply --server-side -k "https://github.com/piraeusdatastore/piraeus-operator//config/crd?ref=v2"
+
+{{- end }}
+
+To get started with Piraeus, simply run:
+
+$ kubectl apply -f - <<EOF
+apiVersion: piraeus.io/v1
+kind: LinstorCluster
+metadata:
+  name: linstorcluster
+spec: {}
+EOF
+
+For next steps, check out our documentation at https://github.com/piraeusdatastore/piraeus-operator/tree/v2/docs

--- a/charts/piraeus/templates/_helpers.tpl
+++ b/charts/piraeus/templates/_helpers.tpl
@@ -1,0 +1,74 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "piraeus-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "piraeus-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "piraeus-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "piraeus-operator.labels" -}}
+helm.sh/chart: {{ include "piraeus-operator.chart" . }}
+{{ include "piraeus-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "piraeus-operator.selectorLabels" -}}
+app.kubernetes.io/component: piraeus-operator
+app.kubernetes.io/name: piraeus-datastore
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "piraeus-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "piraeus-operator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Certificate secret name
+*/}}
+{{- define "piraeus-operator.certifcateName" -}}
+{{- if .Values.tls.certificateSecret }}
+{{- .Values.tls.certificateSecret }}
+{{- else }}
+{{- include "piraeus-operator.fullname" . }}-tls
+{{- end }}
+{{- end }}

--- a/charts/piraeus/templates/config.yaml
+++ b/charts/piraeus/templates/config.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "piraeus-operator.fullname" . }}-config
+  labels:
+  {{- include "piraeus-operator.labels" . | nindent 4 }}
+data:
+  default_images.yaml: |
+    ---
+    # This is the configuration for default images used by piraeus-operator
+    #
+    # "base" is the default repository prefix to use.
+    base: quay.io/piraeusdatastore
+    # "components" is a mapping of image placeholders to actual image names with tag.
+    # For example, the image name "linstor-controller" in the kustomize-resources will be replaced by:
+    #   quay.io/piraeusdatastore/piraeus-server:v1.20.2
+    components:
+      linstor-controller:
+        tag: v1.20.2
+        image: piraeus-server
+      linstor-satellite:
+        tag: v1.20.2
+        image: piraeus-server
+      linstor-csi:
+        tag: v0.22.1
+        image: piraeus-csi
+      drbd-reactor:
+        tag: v0.10.2
+        image: drbd-reactor
+      drbd-module-loader:
+        tag: v9.2.1
+        # The special "match" attribute is used to select an image based on the node's reported OS.
+        # The operator will first check the k8s node's ".status.nodeInfo.osImage" field, and compare it against the list
+        # here. If one matches, that specific image name will be used instead of the fallback image.
+        image: drbd9-jammy # Fallback image: chose a fairly recent kernel, which can hopefully compile whatever config is actually in use
+        match:
+          - osImage: CentOS Linux 7
+            name: drbd9-centos7
+          - osImage: CentOS Linux 8
+            name: drbd9-centos8
+          - osImage: AlmaLinux 8
+            image: drbd9-almalinux8
+          - osImage: AlmaLinux 9
+            image: drbd9-almalinux9
+          - osImage: Ubuntu 18\.04
+            image: drbd9-bionic
+          - osImage: Ubuntu 20\.04
+            image: drbd9-focal
+          - osImage: Ubuntu 22\.04
+            image: drbd9-jammy

--- a/charts/piraeus/templates/crds.yaml
+++ b/charts/piraeus/templates/crds.yaml
@@ -1,0 +1,957 @@
+ {{ if .Values.installCRDs }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: linstorclusters.piraeus.io
+spec:
+  group: piraeus.io
+  names:
+    kind: LinstorCluster
+    listKind: LinstorClusterList
+    plural: linstorclusters
+    singular: linstorcluster
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: LinstorCluster is the Schema for the linstorclusters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LinstorClusterSpec defines the desired state of LinstorCluster
+            properties:
+              apiTLS:
+                description: "ApiTLS secures the LINSTOR API. \n This configures the
+                  TLS key and certificate used to secure the LINSTOR API."
+                nullable: true
+                properties:
+                  apiSecretName:
+                    description: ApiSecretName references a secret holding the TLS
+                      key and certificate used to protect the API. Defaults to "linstor-api-tls".
+                    type: string
+                  certManager:
+                    description: CertManager references a cert-manager Issuer or ClusterIssuer.
+                      If set, cert-manager.io/Certificate resources will be created,
+                      provisioning the secrets referenced in *SecretName using the
+                      issuer configured here.
+                    properties:
+                      group:
+                        description: Group of the resource being referred to.
+                        type: string
+                      kind:
+                        description: Kind of the resource being referred to.
+                        type: string
+                      name:
+                        description: Name of the resource being referred to.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  clientSecretName:
+                    description: ClientSecretName references a secret holding the
+                      TLS key and certificate used by the operator to configure the
+                      cluster. Defaults to "linstor-client-tls".
+                    type: string
+                  csiControllerSecretName:
+                    description: CsiControllerSecretName references a secret holding
+                      the TLS key and certificate used by the CSI Controller to provision
+                      volumes. Defaults to "linstor-csi-controller-tls".
+                    type: string
+                  csiNodeSecretName:
+                    description: CsiNodeSecretName references a secret holding the
+                      TLS key and certificate used by the CSI Nodes to query the volume
+                      state. Defaults to "linstor-csi-node-tls".
+                    type: string
+                type: object
+              internalTLS:
+                description: "InternalTLS secures the connection between LINSTOR Controller
+                  and Satellite. \n This configures the client certificate used when
+                  the Controller connects to a Satellite. This only has an effect
+                  when the Satellite is configured to for secure connections using
+                  `LinstorSatellite.spec.internalTLS`."
+                nullable: true
+                properties:
+                  certManager:
+                    description: CertManager references a cert-manager Issuer or ClusterIssuer.
+                      If set, a Certificate resource will be created, provisioning
+                      the secret references in SecretName using the issuer configured
+                      here.
+                    properties:
+                      group:
+                        description: Group of the resource being referred to.
+                        type: string
+                      kind:
+                        description: Kind of the resource being referred to.
+                        type: string
+                      name:
+                        description: Name of the resource being referred to.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  secretName:
+                    description: SecretName references a secret holding the TLS key
+                      and certificates.
+                    type: string
+                type: object
+              linstorPassphraseSecret:
+                description: "LinstorPassphraseSecret used to configure the LINSTOR
+                  master passphrase. \n The referenced secret must contain a single
+                  key \"MASTER_PASSPHRASE\". The master passphrase is used to * Derive
+                  encryption keys for volumes using the LUKS layer. * Store credentials
+                  for accessing remotes for backups. See https://linbit.com/drbd-user-guide/linstor-guide-1_0-en/#s-encrypt_commands
+                  for more information."
+                type: string
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector selects the nodes on which LINSTOR Satellites
+                  will be deployed. See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                type: object
+              patches:
+                description: "Patches is a list of kustomize patches to apply. \n
+                  See https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patches/
+                  for how to create patches."
+                items:
+                  description: Patch represent either a Strategic Merge Patch or a
+                    JSON patch and its targets.
+                  properties:
+                    options:
+                      additionalProperties:
+                        type: boolean
+                      description: Options is a list of options for the patch
+                      type: object
+                    patch:
+                      description: Patch is the content of a patch.
+                      minLength: 1
+                      type: string
+                    target:
+                      description: Target points to the resources that the patch is
+                        applied to
+                      properties:
+                        annotationSelector:
+                          description: AnnotationSelector is a string that follows
+                            the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                            It matches against the resource annotations.
+                          type: string
+                        group:
+                          type: string
+                        kind:
+                          type: string
+                        labelSelector:
+                          description: LabelSelector is a string that follows the
+                            label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                            It matches against the resource labels.
+                          type: string
+                        name:
+                          description: Name of the resource.
+                          type: string
+                        namespace:
+                          description: Namespace the resource belongs to, if it can
+                            belong to a namespace.
+                          type: string
+                        version:
+                          type: string
+                      type: object
+                  type: object
+                type: array
+              properties:
+                description: "Properties to apply on the cluster level. \n Use to
+                  create default settings for DRBD that should apply to all resources
+                  or to configure some other cluster wide default."
+                items:
+                  properties:
+                    name:
+                      description: Name of the property to set.
+                      minLength: 1
+                      type: string
+                    value:
+                      description: Value to set the property to.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              repository:
+                description: Repository used to pull workload images.
+                type: string
+            type: object
+          status:
+            description: LinstorClusterStatus defines the observed state of LinstorCluster
+            properties:
+              conditions:
+                description: Current LINSTOR Cluster state
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: linstorsatelliteconfigurations.piraeus.io
+spec:
+  group: piraeus.io
+  names:
+    kind: LinstorSatelliteConfiguration
+    listKind: LinstorSatelliteConfigurationList
+    plural: linstorsatelliteconfigurations
+    singular: linstorsatelliteconfiguration
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: LinstorSatelliteConfiguration is the Schema for the linstorsatelliteconfigurations
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: "LinstorSatelliteConfigurationSpec defines a partial, desired
+              state of a LinstorSatelliteSpec. \n All the LinstorSatelliteConfiguration
+              resources with matching NodeSelector will be merged into a single LinstorSatelliteSpec."
+            properties:
+              internalTLS:
+                description: "InternalTLS configures secure communication for the
+                  LINSTOR Satellite. \n If set, the control traffic between LINSTOR
+                  Controller and Satellite will be encrypted using mTLS."
+                nullable: true
+                properties:
+                  certManager:
+                    description: CertManager references a cert-manager Issuer or ClusterIssuer.
+                      If set, a Certificate resource will be created, provisioning
+                      the secret references in SecretName using the issuer configured
+                      here.
+                    properties:
+                      group:
+                        description: Group of the resource being referred to.
+                        type: string
+                      kind:
+                        description: Kind of the resource being referred to.
+                        type: string
+                      name:
+                        description: Name of the resource being referred to.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  secretName:
+                    description: SecretName references a secret holding the TLS key
+                      and certificates.
+                    type: string
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector selects which LinstorSatellite resources
+                  this spec should be applied to. See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                type: object
+              patches:
+                description: "Patches is a list of kustomize patches to apply. \n
+                  See https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patches/
+                  for how to create patches."
+                items:
+                  description: Patch represent either a Strategic Merge Patch or a
+                    JSON patch and its targets.
+                  properties:
+                    options:
+                      additionalProperties:
+                        type: boolean
+                      description: Options is a list of options for the patch
+                      type: object
+                    patch:
+                      description: Patch is the content of a patch.
+                      minLength: 1
+                      type: string
+                    target:
+                      description: Target points to the resources that the patch is
+                        applied to
+                      properties:
+                        annotationSelector:
+                          description: AnnotationSelector is a string that follows
+                            the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                            It matches against the resource annotations.
+                          type: string
+                        group:
+                          type: string
+                        kind:
+                          type: string
+                        labelSelector:
+                          description: LabelSelector is a string that follows the
+                            label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                            It matches against the resource labels.
+                          type: string
+                        name:
+                          description: Name of the resource.
+                          type: string
+                        namespace:
+                          description: Namespace the resource belongs to, if it can
+                            belong to a namespace.
+                          type: string
+                        version:
+                          type: string
+                      type: object
+                  type: object
+                type: array
+              properties:
+                description: Properties is a list of properties to set on the node.
+                items:
+                  properties:
+                    name:
+                      description: Name of the property to set.
+                      minLength: 1
+                      type: string
+                    optional:
+                      description: Optional values are only set if they have a non-empty
+                        value
+                      type: boolean
+                    value:
+                      description: Value to set the property to.
+                      type: string
+                    valueFrom:
+                      description: ValueFrom sets the value from an existing resource.
+                      properties:
+                        nodeFieldRef:
+                          description: Select a field of the node. Supports `metadata.name`,
+                            `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`.
+                          minLength: 1
+                          type: string
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              storagePools:
+                description: StoragePools is a list of storage pools to configure
+                  on the node.
+                items:
+                  properties:
+                    filePool:
+                      description: Configures a file system based storage pool, allocating
+                        a regular file per volume.
+                      properties:
+                        directory:
+                          description: Directory is the path to the host directory
+                            used to store volume data.
+                          type: string
+                      type: object
+                    fileThinPool:
+                      description: Configures a file system based storage pool, allocating
+                        a sparse file per volume.
+                      properties:
+                        directory:
+                          description: Directory is the path to the host directory
+                            used to store volume data.
+                          type: string
+                      type: object
+                    lvmPool:
+                      description: Configures a LVM Volume Group as storage pool.
+                      properties:
+                        volumeGroup:
+                          type: string
+                      type: object
+                    lvmThinPool:
+                      description: Configures a LVM Thin Pool as storage pool.
+                      properties:
+                        thinPool:
+                          description: ThinPool is the name of the thinpool LV (without
+                            VG prefix).
+                          type: string
+                        volumeGroup:
+                          type: string
+                      type: object
+                    name:
+                      description: Name of the storage pool in linstor.
+                      minLength: 3
+                      type: string
+                    properties:
+                      description: Properties to set on the storage pool.
+                      items:
+                        properties:
+                          name:
+                            description: Name of the property to set.
+                            minLength: 1
+                            type: string
+                          optional:
+                            description: Optional values are only set if they have
+                              a non-empty value
+                            type: boolean
+                          value:
+                            description: Value to set the property to.
+                            type: string
+                          valueFrom:
+                            description: ValueFrom sets the value from an existing
+                              resource.
+                            properties:
+                              nodeFieldRef:
+                                description: Select a field of the node. Supports
+                                  `metadata.name`, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`.
+                                minLength: 1
+                                type: string
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    source:
+                      properties:
+                        hostDevices:
+                          description: HostDevices is a list of device paths used
+                            to configure the given pool.
+                          items:
+                            type: string
+                          minItems: 1
+                          type: array
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+            type: object
+          status:
+            description: LinstorSatelliteConfigurationStatus defines the observed
+              state of LinstorSatelliteConfiguration
+            properties:
+              conditions:
+                description: Current LINSTOR Satellite Config state
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: linstorsatellites.piraeus.io
+spec:
+  group: piraeus.io
+  names:
+    kind: LinstorSatellite
+    listKind: LinstorSatelliteList
+    plural: linstorsatellites
+    singular: linstorsatellite
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: LinstorSatellite is the Schema for the linstorsatellites API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LinstorSatelliteSpec defines the desired state of LinstorSatellite
+            properties:
+              clusterRef:
+                description: ClusterRef references the LinstorCluster used to create
+                  this LinstorSatellite.
+                properties:
+                  clientSecretName:
+                    description: ClientSecretName references the secret used by the
+                      operator to validate the https endpoint.
+                    type: string
+                  name:
+                    description: Name of the LinstorCluster resource controlling this
+                      satellite.
+                    type: string
+                type: object
+              internalTLS:
+                description: "InternalTLS configures secure communication for the
+                  LINSTOR Satellite. \n If set, the control traffic between LINSTOR
+                  Controller and Satellite will be encrypted using mTLS. The Controller
+                  will use the client key from `LinstorCluster.spec.internalTLS` when
+                  connecting."
+                nullable: true
+                properties:
+                  certManager:
+                    description: CertManager references a cert-manager Issuer or ClusterIssuer.
+                      If set, a Certificate resource will be created, provisioning
+                      the secret references in SecretName using the issuer configured
+                      here.
+                    properties:
+                      group:
+                        description: Group of the resource being referred to.
+                        type: string
+                      kind:
+                        description: Kind of the resource being referred to.
+                        type: string
+                      name:
+                        description: Name of the resource being referred to.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  secretName:
+                    description: SecretName references a secret holding the TLS key
+                      and certificates.
+                    type: string
+                type: object
+              patches:
+                description: "Patches is a list of kustomize patches to apply. \n
+                  See https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patches/
+                  for how to create patches."
+                items:
+                  description: Patch represent either a Strategic Merge Patch or a
+                    JSON patch and its targets.
+                  properties:
+                    options:
+                      additionalProperties:
+                        type: boolean
+                      description: Options is a list of options for the patch
+                      type: object
+                    patch:
+                      description: Patch is the content of a patch.
+                      minLength: 1
+                      type: string
+                    target:
+                      description: Target points to the resources that the patch is
+                        applied to
+                      properties:
+                        annotationSelector:
+                          description: AnnotationSelector is a string that follows
+                            the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                            It matches against the resource annotations.
+                          type: string
+                        group:
+                          type: string
+                        kind:
+                          type: string
+                        labelSelector:
+                          description: LabelSelector is a string that follows the
+                            label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                            It matches against the resource labels.
+                          type: string
+                        name:
+                          description: Name of the resource.
+                          type: string
+                        namespace:
+                          description: Namespace the resource belongs to, if it can
+                            belong to a namespace.
+                          type: string
+                        version:
+                          type: string
+                      type: object
+                  type: object
+                type: array
+              properties:
+                description: Properties is a list of properties to set on the node.
+                items:
+                  properties:
+                    name:
+                      description: Name of the property to set.
+                      minLength: 1
+                      type: string
+                    optional:
+                      description: Optional values are only set if they have a non-empty
+                        value
+                      type: boolean
+                    value:
+                      description: Value to set the property to.
+                      type: string
+                    valueFrom:
+                      description: ValueFrom sets the value from an existing resource.
+                      properties:
+                        nodeFieldRef:
+                          description: Select a field of the node. Supports `metadata.name`,
+                            `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`.
+                          minLength: 1
+                          type: string
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              repository:
+                description: Repository used to pull workload images.
+                type: string
+              storagePools:
+                description: StoragePools is a list of storage pools to configure
+                  on the node.
+                items:
+                  properties:
+                    filePool:
+                      description: Configures a file system based storage pool, allocating
+                        a regular file per volume.
+                      properties:
+                        directory:
+                          description: Directory is the path to the host directory
+                            used to store volume data.
+                          type: string
+                      type: object
+                    fileThinPool:
+                      description: Configures a file system based storage pool, allocating
+                        a sparse file per volume.
+                      properties:
+                        directory:
+                          description: Directory is the path to the host directory
+                            used to store volume data.
+                          type: string
+                      type: object
+                    lvmPool:
+                      description: Configures a LVM Volume Group as storage pool.
+                      properties:
+                        volumeGroup:
+                          type: string
+                      type: object
+                    lvmThinPool:
+                      description: Configures a LVM Thin Pool as storage pool.
+                      properties:
+                        thinPool:
+                          description: ThinPool is the name of the thinpool LV (without
+                            VG prefix).
+                          type: string
+                        volumeGroup:
+                          type: string
+                      type: object
+                    name:
+                      description: Name of the storage pool in linstor.
+                      minLength: 3
+                      type: string
+                    properties:
+                      description: Properties to set on the storage pool.
+                      items:
+                        properties:
+                          name:
+                            description: Name of the property to set.
+                            minLength: 1
+                            type: string
+                          optional:
+                            description: Optional values are only set if they have
+                              a non-empty value
+                            type: boolean
+                          value:
+                            description: Value to set the property to.
+                            type: string
+                          valueFrom:
+                            description: ValueFrom sets the value from an existing
+                              resource.
+                            properties:
+                              nodeFieldRef:
+                                description: Select a field of the node. Supports
+                                  `metadata.name`, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`.
+                                minLength: 1
+                                type: string
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    source:
+                      properties:
+                        hostDevices:
+                          description: HostDevices is a list of device paths used
+                            to configure the given pool.
+                          items:
+                            type: string
+                          minItems: 1
+                          type: array
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+            required:
+            - clusterRef
+            type: object
+          status:
+            description: LinstorSatelliteStatus defines the observed state of LinstorSatellite
+            properties:
+              conditions:
+                description: Current LINSTOR Satellite state
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+{{ end }}

--- a/charts/piraeus/templates/deployment.yaml
+++ b/charts/piraeus/templates/deployment.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "piraeus-operator.fullname" . }}-controller-manager
+  labels:
+    {{- include "piraeus-operator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "piraeus-operator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+      {{- include "piraeus-operator.selectorLabels" . | nindent 8 }}
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+    spec:
+      containers:
+      - args:
+          - --health-probe-bind-address=:8081
+          - --metrics-bind-address=127.0.0.1:8080
+        {{- range $opt, $val := .Values.operator.options }}
+          - --{{ $opt | kebabcase }}={{ $val }}
+        {{- end }}
+        command:
+        - /manager
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: {{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag | default .Chart.AppVersion }}
+        imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          {{- toYaml .Values.operator.resources | nindent 12 }}
+        securityContext:
+          {{- toYaml .Values.operator.securityContext | nindent 12}}
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+        - mountPath: /etc/operator
+          name: operator-config
+          readOnly: true
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --tls-private-key-file=/etc/tls/tls.key
+        - --tls-cert-file=/etc/tls/tls.crt
+        {{- range $opt, $val := .Values.kubeRbacProxy.options }}
+        - --{{ $opt | kebabcase }}={{ $val }}
+        {{- end }}
+        image: {{ .Values.kubeRbacProxy.image.repository }}:{{ .Values.kubeRbacProxy.image.tag }}
+        imagePullPolicy: {{ .Values.kubeRbacProxy.image.pullPolicy }}
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        resources:
+          {{- toYaml .Values.kubeRbacProxy.resources | nindent 12 }}
+        securityContext:
+          {{- toYaml .Values.kubeRbacProxy.securityContext | nindent 12}}
+        volumeMounts:
+          - mountPath: /etc/tls
+            name: cert
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: {{ include "piraeus-operator.serviceAccountName" . }}
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: {{ include "piraeus-operator.certifcateName" . }}
+      - configMap:
+          name: {{ include "piraeus-operator.fullname" . }}-config
+        name: operator-config

--- a/charts/piraeus/templates/metrics-service.yaml
+++ b/charts/piraeus/templates/metrics-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "piraeus-operator.fullname" . }}-controller-manager-metrics-service
+  labels:
+  {{- include "piraeus-operator.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+  {{- include "piraeus-operator.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: metrics
+      port: 443
+      targetPort: 8443

--- a/charts/piraeus/templates/rbac.yaml
+++ b/charts/piraeus/templates/rbac.yaml
@@ -1,0 +1,427 @@
+{{ if .Values.serviceAccount.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "piraeus-operator.serviceAccountName" . }}
+  labels:
+  {{- include "piraeus-operator.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "piraeus-operator.fullname" . }}-controller-manager
+  labels:
+    {{- include "piraeus-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - events
+  - persistentvolumes
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - internal.linstor.linbit.com
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorclusters/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorsatelliteconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorsatelliteconfigurations/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorsatellites
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorsatellites/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - piraeus.io
+  resources:
+  - linstorsatellites/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csidrivers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csistoragecapacities
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments/status
+  verbs:
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "piraeus-operator.fullname" . }}-manager-rolebinding
+  labels:
+    {{- include "piraeus-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ include "piraeus-operator.fullname" . }}-controller-manager'
+subjects:
+  - kind: ServiceAccount
+    name: '{{ include "piraeus-operator.serviceAccountName" . }}'
+    namespace: '{{ .Release.Namespace }}'
+{{ end }}
+{{ if.Values.rbac.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "piraeus-operator.fullname" . }}-proxy-role
+  labels:
+    {{- include "piraeus-operator.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "piraeus-operator.fullname" . }}-proxy-rolebinding
+  labels:
+    {{- include "piraeus-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ include "piraeus-operator.fullname" . }}-proxy-role'
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "piraeus-operator.serviceAccountName" . }}
+    namespace: '{{ .Release.Namespace }}'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "piraeus-operator.fullname" . }}-leader-election-role
+  labels:
+    {{- include "piraeus-operator.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "piraeus-operator.fullname" . }}-leader-election-rolebinding
+  labels:
+    {{- include "piraeus-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: '{{ include "piraeus-operator.fullname" . }}-leader-election-role'
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "piraeus-operator.serviceAccountName" . }}
+    namespace: '{{ .Release.Namespace }}'
+{{ end }}

--- a/charts/piraeus/templates/validating-webhook-configuration.yaml
+++ b/charts/piraeus/templates/validating-webhook-configuration.yaml
@@ -1,0 +1,130 @@
+# Check if the TLS secret already exists and initialize variables for later use at the top level
+{{- $secret := lookup "v1" "Secret" .Release.Namespace (include "piraeus-operator.certifcateName" .) }}
+{{ $ca := "" }}
+{{ $key := "" }}
+{{ $crt := "" }}
+{{- if .Values.tls.certManagerIssuerRef }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "piraeus-operator.fullname" . }}
+  labels:
+  {{- include "piraeus-operator.labels" . | nindent 4 }}
+spec:
+  secretName: {{ include "piraeus-operator.certifcateName" . }}
+  dnsNames:
+    - {{ include "piraeus-operator.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc
+  issuerRef:
+  {{- toYaml .Values.tls.certManagerIssuerRef | nindent 4 }}
+  privateKey:
+    rotationPolicy: Always
+---
+{{- else if .Values.tls.autogenerate }}
+  {{- if and $secret (not .Values.tls.renew) }}
+    {{- $ca = get $secret.data "ca.crt" }}
+    {{- $key = get $secret.data "tls.key" }}
+    {{- $crt = get $secret.data "tls.crt" }}
+  {{- else }}
+    {{- $serviceName := (printf "%s-webhook-service.%s.svc" (include "piraeus-operator.fullname" .) .Release.Namespace)}}
+    {{- $cert := genSelfSignedCert $serviceName nil (list $serviceName) 3650 }}
+    {{- $ca = b64enc $cert.Cert }}
+    {{- $key = b64enc $cert.Key }}
+    {{- $crt = b64enc $cert.Cert }}
+  {{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "piraeus-operator.certifcateName" . }}
+  labels:
+    {{- include "piraeus-operator.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  ca.crt: {{ $ca }}
+  tls.key: {{ $key }}
+  tls.crt: {{ $crt }}
+{{- end }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ include "piraeus-operator.fullname" . }}-validating-webhook-configuration
+  labels:
+    {{- include "piraeus-operator.labels" . | nindent 4 }}
+  {{- if .Values.tls.certManagerIssuerRef }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "piraeus-operator.fullname" . }}
+  {{- end }}
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: '{{ include "piraeus-operator.fullname" . }}-webhook-service'
+      namespace: '{{ .Release.Namespace }}'
+      path: /validate-piraeus-io-v1-linstorcluster
+    {{- if not .Values.tls.certManagerIssuerRef }}
+    caBundle: {{ $ca }}
+    {{- end }}
+  failurePolicy: {{ .Values.webhook.failurePolicy }}
+  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
+  name: vlinstorcluster.kb.io
+  rules:
+  - apiGroups:
+    - piraeus.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - linstorclusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: '{{ include "piraeus-operator.fullname" . }}-webhook-service'
+      namespace: '{{ .Release.Namespace }}'
+      path: /validate-piraeus-io-v1-linstorsatellite
+    {{- if not .Values.tls.certManagerIssuerRef }}
+    caBundle: {{ $ca }}
+    {{- end }}
+  failurePolicy: {{ .Values.webhook.failurePolicy }}
+  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
+  name: vlinstorsatellite.kb.io
+  rules:
+  - apiGroups:
+    - piraeus.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - linstorsatellites
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: '{{ include "piraeus-operator.fullname" . }}-webhook-service'
+      namespace: '{{ .Release.Namespace }}'
+      path: /validate-piraeus-io-v1-linstorsatelliteconfiguration
+    {{- if not .Values.tls.certManagerIssuerRef }}
+    caBundle: {{ $ca }}
+    {{- end }}
+  failurePolicy: {{ .Values.webhook.failurePolicy }}
+  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
+  name: vlinstorsatelliteconfiguration.kb.io
+  rules:
+  - apiGroups:
+    - piraeus.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - linstorsatelliteconfigurations
+  sideEffects: None

--- a/charts/piraeus/templates/webhook-service.yaml
+++ b/charts/piraeus/templates/webhook-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "piraeus-operator.fullname" . }}-webhook-service
+  labels:
+    {{- include "piraeus-operator.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "piraeus-operator.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: https
+      port: 443
+      targetPort: 9443

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -1,0 +1,94 @@
+replicaCount: 1
+
+installCRDs: false
+
+operator:
+  image:
+    repository: quay.io/piraeusdatastore/piraeus-operator
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1000
+
+  options:
+    leaderElect: true
+
+  resources: { }
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+kubeRbacProxy:
+  image:
+    repository: gcr.io/kubebuilder/kube-rbac-proxy
+    pullPolicy: IfNotPresent
+    tag: v0.13.1
+  options:
+    logtostderr: "true"
+    v: 0
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1000
+
+  resources: { }
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+webhook:
+  timeoutSeconds: 2
+  failurePolicy: Fail
+
+tls:
+  certificateSecret: ""
+  autogenerate: true
+  renew: false
+  certManagerIssuerRef: {}
+
+imagePullSecrets: [ ]
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: { }
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+podAnnotations: { }
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+nodeSelector: { }
+
+tolerations: [ ]
+affinity: { }
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+  # maxUnavailable: 1

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -17,9 +17,9 @@ patchesStrategicMerge:
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-- patches/cainjection_in_linstorclusters.yaml
-- patches/cainjection_in_linstorsatellites.yaml
-- patches/cainjection_in_linstorsatelliteconfigurations.yaml
+#- patches/cainjection_in_linstorclusters.yaml
+#- patches/cainjection_in_linstorsatellites.yaml
+#- patches/cainjection_in_linstorsatelliteconfigurations.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# Piraeus Operator Documentation
+
+Here you find the documentation for Piraeus Operator and the whole Piraeus Datastore system.
+
+### [Tutorials](./docs/tutorial)
+
+Tutorials help you get started with Piraeus Operator.
+
+### [How-To Guides](./docs/how-to)
+
+How-To Guides show you how to configure a specific aspect or achieve a specific task with Piraeus Operator.
+
+### [API Reference](./docs/reference)
+
+The API Reference for the Piraeus Operator. Contains documentation of the LINSTOR related resources that the user can
+modify or observe.

--- a/hack/crd-charts-copy.sh
+++ b/hack/crd-charts-copy.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+echo ' {{ if .Values.installCRDs }}'
+find ./config/crd/bases -type f | sort | xargs --no-run-if-empty cat
+echo '{{ end }}'


### PR DESCRIPTION
Reintroduce a Helm Chart, for users that really need it. We don't want to put too much effot into it, so most of it was created by running https://github.com/arttor/helmify once.

We have a separate README for the Chart, but otherwise avoid mentioning Helm in our main guides: new users should be using kustomize.