### PR TITLE
Add HA Controller to cluster deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Default deployment for HA Controller. Since we switch to defaulting to `suspend-io` for lost quorum, we should include a way for Pods to get unstuck.
+
 ## [v2.0.0-rc.1] - 2023-02-22
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ All components of the LINSTOR software stack can be managed by the operator:
 * DRBD
 * LINSTOR
 * LINSTOR CSI driver
+* LINSTOR High-Availability Controller
 
 ## Legacy Operator
 
@@ -67,7 +68,6 @@ modify or observe.
 
 These are features that are currently present in Operator v1, and not yet available in this version of Operator v2:
 
-* Helm Chart
 * Backup of LINSTOR database before upgrades
 
 ## Upgrading

--- a/charts/piraeus/templates/config.yaml
+++ b/charts/piraeus/templates/config.yaml
@@ -27,6 +27,9 @@ data:
       drbd-reactor:
         tag: v1.0.0
         image: drbd-reactor
+      ha-controller:
+        tag: v1.1.2
+        image: piraeus-ha-controller
       drbd-module-loader:
         tag: v9.2.2
         # The special "match" attribute is used to select an image based on the node's reported OS.

--- a/charts/piraeus/templates/rbac.yaml
+++ b/charts/piraeus/templates/rbac.yaml
@@ -14,310 +14,329 @@ metadata:
   labels:
     {{- include "piraeus-operator.labels" . | nindent 4 }}
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - events
-  - persistentvolumes
-  - secrets
-  - serviceaccounts
-  - services
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - pods
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  - persistentvolumeclaims
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - persistentvolumeclaims/status
-  verbs:
-  - patch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - delete
-  - list
-  - watch
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  - deployments
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - get
-- apiGroups:
-  - cert-manager.io
-  resources:
-  - certificates
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - internal.linstor.linbit.com
-  resources:
-  - '*'
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - piraeus.io
-  resources:
-  - linstorclusters
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - piraeus.io
-  resources:
-  - linstorclusters/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - piraeus.io
-  resources:
-  - linstorclusters/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - piraeus.io
-  resources:
-  - linstorsatelliteconfigurations
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - piraeus.io
-  resources:
-  - linstorsatelliteconfigurations/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - piraeus.io
-  resources:
-  - linstorsatellites
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - piraeus.io
-  resources:
-  - linstorsatellites/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - piraeus.io
-  resources:
-  - linstorsatellites/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterrolebindings
-  - clusterroles
-  - rolebindings
-  - roles
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - security.openshift.io
-  resourceNames:
-  - privileged
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshotclasses
-  - volumesnapshots
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshotcontents
-  verbs:
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshotcontents/status
-  verbs:
-  - patch
-  - update
-- apiGroups:
-  - storage.k8s.io
-  resources:
-  - csidrivers
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - storage.k8s.io
-  resources:
-  - csinodes
-  verbs:
-  - get
-  - list
-  - patch
-  - watch
-- apiGroups:
-  - storage.k8s.io
-  resources:
-  - csistoragecapacities
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - storage.k8s.io
-  resources:
-  - storageclasses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - storage.k8s.io
-  resources:
-  - volumeattachments
-  verbs:
-  - get
-  - list
-  - patch
-  - watch
-- apiGroups:
-  - storage.k8s.io
-  resources:
-  - volumeattachments/status
-  verbs:
-  - patch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - events
+      - persistentvolumes
+      - secrets
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims/status
+    verbs:
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - certificates
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - internal.linstor.linbit.com
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - piraeus.io
+    resources:
+      - linstorclusters
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - piraeus.io
+    resources:
+      - linstorclusters/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - piraeus.io
+    resources:
+      - linstorclusters/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - piraeus.io
+    resources:
+      - linstorsatelliteconfigurations
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - piraeus.io
+    resources:
+      - linstorsatelliteconfigurations/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - piraeus.io
+    resources:
+      - linstorsatellites
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - piraeus.io
+    resources:
+      - linstorsatellites/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - piraeus.io
+    resources:
+      - linstorsatellites/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+      - rolebindings
+      - roles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - privileged
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - volumesnapshotclasses
+      - volumesnapshots
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - volumesnapshotcontents
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - volumesnapshotcontents/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csinodes
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csistoragecapacities
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - volumeattachments
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - volumeattachments/status
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/config/manager/default_images.yaml
+++ b/config/manager/default_images.yaml
@@ -19,6 +19,9 @@ components:
   drbd-reactor:
     tag: v1.0.0
     image: drbd-reactor
+  ha-controller:
+    image: piraeus-ha-controller
+    tag: v1.1.2
   drbd-module-loader:
     tag: v9.2.2
     # The special "match" attribute is used to select an image based on the node's reported OS.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -52,6 +52,7 @@ rules:
   verbs:
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:
@@ -68,6 +69,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -106,6 +113,17 @@ rules:
   verbs:
   - create
   - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
   - get
   - list
   - patch
@@ -299,6 +317,7 @@ rules:
   resources:
   - volumeattachments
   verbs:
+  - delete
   - get
   - list
   - patch

--- a/controllers/patches.go
+++ b/controllers/patches.go
@@ -55,6 +55,15 @@ func ClusterCSINodeSelectorPatch(selector map[string]string) ([]kusttypes.Patch,
 		})
 }
 
+func ClusterHAControllerNodeSelectorPatch(selector map[string]string) ([]kusttypes.Patch, error) {
+	return render(
+		cluster.Resources,
+		"patches/ha-controller-node-selector.yaml",
+		map[string]any{
+			"NODE_SELECTOR": selector,
+		})
+}
+
 func ClusterApiTLSPatch(apiSecretName, clientSecretName string) ([]kusttypes.Patch, error) {
 	return render(
 		cluster.Resources,

--- a/pkg/resources/cluster/controller/controller-deployment.yaml
+++ b/pkg/resources/cluster/controller/controller-deployment.yaml
@@ -84,3 +84,7 @@ spec:
           operator: "Exists"
           effect: "NoExecute"
           tolerationSeconds: 30
+        - effect: NoSchedule
+          key: drbd.linbit.com/lost-quorum
+        - effect: NoSchedule
+          key: drbd.linbit.com/force-io-error

--- a/pkg/resources/cluster/csi/csi-controller-deployment.yaml
+++ b/pkg/resources/cluster/csi/csi-controller-deployment.yaml
@@ -209,6 +209,11 @@ spec:
             capabilities:
               drop:
                 - ALL
+      tolerations:
+        - effect: NoSchedule
+          key: drbd.linbit.com/lost-quorum
+        - effect: NoSchedule
+          key: drbd.linbit.com/force-io-error
       volumes:
         - name: socket-dir
           emptyDir: {}

--- a/pkg/resources/cluster/csi/csi-node-daemon-set.yaml
+++ b/pkg/resources/cluster/csi/csi-node-daemon-set.yaml
@@ -116,6 +116,11 @@ spec:
               mountPath: /csi
           args:
             - '--csi-address=/csi/csi.sock'
+      tolerations:
+        - effect: NoSchedule
+          key: drbd.linbit.com/lost-quorum
+        - effect: NoSchedule
+          key: drbd.linbit.com/force-io-error
       volumes:
         - name: device-dir
           hostPath:

--- a/pkg/resources/cluster/ha-controller/daemonset.yaml
+++ b/pkg/resources/cluster/ha-controller/daemonset.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ha-controller
+  labels:
+    app.kubernetes.io/component: ha-controller
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ha-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: ha-controller
+    spec:
+      serviceAccountName: ha-controller
+      containers:
+        - name: ha-controller
+          args:
+            - /agent
+            - --v=1
+          securityContext:
+            privileged: true
+            readOnlyRootFilesystem: true
+          image: ha-controller
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          startupProbe:
+            httpGet:
+              port: 8000
+              path: /healthz
+          livenessProbe:
+            httpGet:
+              port: 8000
+              path: /healthz
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+        - effect: NoSchedule
+          key: drbd.linbit.com/lost-quorum
+        - effect: NoSchedule
+          key: drbd.linbit.com/force-io-error

--- a/pkg/resources/cluster/ha-controller/kustomization.yaml
+++ b/pkg/resources/cluster/ha-controller/kustomization.yaml
@@ -1,0 +1,4 @@
+---
+resources:
+  - rbac.yaml
+  - daemonset.yaml

--- a/pkg/resources/cluster/ha-controller/rbac.yaml
+++ b/pkg/resources/cluster/ha-controller/rbac.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ha-controller
+  labels:
+    app.kubernetes.io/component: ha-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ha-controller
+  labels:
+    app.kubernetes.io/component: ha-controller
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ha-controller
+  labels:
+    app.kubernetes.io/component: ha-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ha-controller
+subjects:
+  - kind: ServiceAccount
+    name: ha-controller

--- a/pkg/resources/cluster/patches/ha-controller-node-selector.yaml
+++ b/pkg/resources/cluster/patches/ha-controller-node-selector.yaml
@@ -1,0 +1,15 @@
+---
+- target:
+    group: apps
+    version: v1
+    kind: DaemonSet
+    name: ha-controller
+  patch: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: ha-controller
+    spec:
+      template:
+        spec:
+          nodeSelector: $NODE_SELECTOR

--- a/pkg/resources/cluster/resources.go
+++ b/pkg/resources/cluster/resources.go
@@ -2,5 +2,5 @@ package cluster
 
 import "embed"
 
-//go:embed satellite-common controller csi satellite patches client-cert
+//go:embed satellite-common controller csi satellite patches client-cert ha-controller
 var Resources embed.FS

--- a/pkg/resources/satellite/pod/node-pod.yaml
+++ b/pkg/resources/satellite/pod/node-pod.yaml
@@ -140,3 +140,7 @@ spec:
       effect: NoSchedule
     - key: node.kubernetes.io/unschedulable
       effect: NoSchedule
+    - effect: NoSchedule
+      key: drbd.linbit.com/lost-quorum
+    - effect: NoSchedule
+      key: drbd.linbit.com/force-io-error


### PR DESCRIPTION
We configure DRBD with "suspend-io" by default, so we should include a way for people to "unstuck" their resources. The HA Controller can do that and also improve fail-over times in case of node failures.