### PR TITLE
CSI: bind /run/mount from host to support _netdev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated LINSTOR CSI to 1.0.0, mounting the `/run/mount` directory from the host to enable the `_netdev` mount option.
+
 ### Fixed
 
 - HA Controller deployment requires additional rules to run on OpenShift.

--- a/config/manager/default_images.yaml
+++ b/config/manager/default_images.yaml
@@ -14,7 +14,7 @@ components:
     tag: v1.20.3
     image: piraeus-server
   linstor-csi:
-    tag: v0.22.1
+    tag: v1.0.0
     image: piraeus-csi
   drbd-reactor:
     tag: v1.0.0

--- a/pkg/resources/cluster/csi/csi-node-daemon-set.yaml
+++ b/pkg/resources/cluster/csi/csi-node-daemon-set.yaml
@@ -78,6 +78,8 @@ spec:
               mountPropagation: Bidirectional
             - name: device-dir
               mountPath: /dev
+            - name: run-mount
+              mountPath: /run/mount
         - name: csi-node-driver-registrar
           image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
           args:
@@ -138,3 +140,7 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins/linstor.csi.linbit.com
             type: DirectoryOrCreate
+        - name: run-mount
+          hostPath:
+            path: /run/mount
+            type: Directory


### PR DESCRIPTION
The _netdev mount option is used by systemd to determine when to unmount a path during system shutdown: with the _netdev option set, this happens before the networking stack is unconfigured.

Since we default to using "suspend-io", we want to explicitly set the _netdev option for all our mounts. Otherwise, systemd might get stuck during shutdown while trying to unmount the CSI-created volume mounts.

The _netdev option is a user-space option only, persistet by the "mount" command in /run/mount/utab. So for systemd to pick up the option, we need to bind that directory to the linstor-csi container.