### PR TITLE
Updated registry mirror for chinese users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,13 +36,15 @@ crds:
 	mv ./config/crd/bases/* ./charts/piraeus/crds
 
 helm-values:
-	cp ./charts/piraeus/values.yaml ./charts/piraeus/values.cn.yaml
-	sed 's|gcr.io/etcd-development/etcd|daocloud.io/piraeus/etcd|' -i ./charts/piraeus/values.cn.yaml
-	sed 's|docker.io/openstorage/stork|daocloud.io/piraeus/stork|' -i ./charts/piraeus/values.cn.yaml
-	sed 's|registry.k8s.io/kube-scheduler|daocloud.io/piraeus/kube-scheduler|' -i ./charts/piraeus/values.cn.yaml
-	sed 's|quay.io/piraeusdatastore|daocloud.io/piraeus|' -i ./charts/piraeus/values.cn.yaml
-	sed 's|registry.k8s.io/sig-storage|daocloud.io/piraeus|' -i ./charts/piraeus/values.cn.yaml
-	sed 's|quay.io/k8scsi|daocloud.io/piraeus|' -i ./charts/piraeus/values.cn.yaml
+	cat ./charts/piraeus/values.yaml \
+      | sed 's/docker.io/docker.m.daocloud.io/' \
+      | sed 's/quay.io/quay.m.daocloud.io/' \
+      | sed 's/registry.k8s.io/k8s-gcr.m.daocloud.io/' \
+      | sed 's/k8s.gcr.io/k8s-gcr.m.daocloud.io/' \
+      | sed 's/gcr.io/gcr.m.daocloud.io/' \
+      | sed 's/ghcr.io/gcr.m.daocloud.io/' \
+      | sed 's/bionic/centos7/' \
+      > ./charts/piraeus/values.cn.yaml  
 
 release:
 	# check that VERSION is set

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ helm-values:
       | sed 's/gcr.io/gcr.m.daocloud.io/' \
       | sed 's/ghcr.io/gcr.m.daocloud.io/' \
       | sed 's/bionic/centos7/' \
-      > ./charts/piraeus/values.cn.yaml  
+      > ./charts/piraeus/values.cn.yaml 
 
 release:
 	# check that VERSION is set

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ helm-values:
       | sed 's/gcr.io/gcr.m.daocloud.io/' \
       | sed 's/ghcr.io/gcr.m.daocloud.io/' \
       | sed 's/bionic/centos7/' \
-      > ./charts/piraeus/values.cn.yaml 
+      > ./charts/piraeus/values.cn.yaml
 
 release:
 	# check that VERSION is set

--- a/charts/piraeus/values.cn.yaml
+++ b/charts/piraeus/values.cn.yaml
@@ -10,12 +10,12 @@ etcd:
   replicas: 1 # How many instances of etcd will be added to the initial cluster.
   resources: {} # resource requirements for etcd containers
   image:
-    repository: daocloud.io/piraeus/etcd
+    repository: gcr.m.daocloud.io/etcd-development/etcd
     tag: v3.4.15
 stork:
   enabled: false
-  storkImage: daocloud.io/piraeus/stork:2.8.2
-  schedulerImage: daocloud.io/piraeus/kube-scheduler
+  storkImage: docker.m.daocloud.io/openstorage/stork:2.8.2
+  schedulerImage: k8s-gcr.m.daocloud.io/kube-scheduler
   schedulerTag: ""
   replicas: 1
   storkResources: {} # resources requirements for the stork plugin containers
@@ -23,13 +23,13 @@ stork:
   podsecuritycontext: {}
 csi:
   enabled: true
-  pluginImage: daocloud.io/piraeus/piraeus-csi:v0.22.1
-  csiAttacherImage: daocloud.io/piraeus/csi-attacher:v4.1.0
-  csiLivenessProbeImage: daocloud.io/piraeus/livenessprobe:v2.9.0
-  csiNodeDriverRegistrarImage: daocloud.io/piraeus/csi-node-driver-registrar:v2.7.0
-  csiProvisionerImage: daocloud.io/piraeus/csi-provisioner:v3.4.0
-  csiSnapshotterImage: daocloud.io/piraeus/csi-snapshotter:v6.2.1
-  csiResizerImage: daocloud.io/piraeus/csi-resizer:v1.7.0
+  pluginImage: quay.m.daocloud.io/piraeusdatastore/piraeus-csi:v0.22.1
+  csiAttacherImage: k8s-gcr.m.daocloud.io/sig-storage/csi-attacher:v4.1.0
+  csiLivenessProbeImage: k8s-gcr.m.daocloud.io/sig-storage/livenessprobe:v2.9.0
+  csiNodeDriverRegistrarImage: k8s-gcr.m.daocloud.io/sig-storage/csi-node-driver-registrar:v2.7.0
+  csiProvisionerImage: k8s-gcr.m.daocloud.io/sig-storage/csi-provisioner:v3.4.0
+  csiSnapshotterImage: k8s-gcr.m.daocloud.io/sig-storage/csi-snapshotter:v6.2.1
+  csiResizerImage: k8s-gcr.m.daocloud.io/sig-storage/csi-resizer:v1.7.0
   csiAttacherWorkerThreads: 10
   csiProvisionerWorkerThreads: 10
   csiSnapshotterWorkerThreads: 10
@@ -61,7 +61,7 @@ psp:
   unprivilegedRole: ""
 operator:
   replicas: 1 # <- number of replicas for the operator deployment
-  image: daocloud.io/piraeus/piraeus-operator:latest
+  image: quay.m.daocloud.io/piraeusdatastore/piraeus-operator:latest
   affinity: {}
   tolerations: []
   resources: {}
@@ -75,7 +75,7 @@ operator:
   extraVolumes: []
   controller:
     enabled: true
-    controllerImage: daocloud.io/piraeus/piraeus-server:v1.20.3
+    controllerImage: quay.m.daocloud.io/piraeusdatastore/piraeus-server:v1.20.3
     dbConnectionURL: ""
     luksSecret: ""
     dbCertSecret: ""
@@ -101,16 +101,16 @@ operator:
     customAnnotations: {}
   satelliteSet:
     enabled: true
-    satelliteImage: daocloud.io/piraeus/piraeus-server:v1.20.3
+    satelliteImage: quay.m.daocloud.io/piraeusdatastore/piraeus-server:v1.20.3
     storagePools: {}
     sslSecret: ""
     automaticStorageType: None
     affinity: {}
     tolerations: []
     resources: {}
-    monitoringImage: daocloud.io/piraeus/drbd-reactor:v1.0.0
+    monitoringImage: quay.m.daocloud.io/piraeusdatastore/drbd-reactor:v1.0.0
     monitoringBindAddress: ""
-    kernelModuleInjectionImage: daocloud.io/piraeus/drbd9-bionic:v9.1.13
+    kernelModuleInjectionImage: quay.m.daocloud.io/piraeusdatastore/drbd9-centos7:v9.1.13
     kernelModuleInjectionMode: Compile
     kernelModuleInjectionAdditionalSourceDirectory: ""
     kernelModuleInjectionResources: {}
@@ -122,7 +122,7 @@ operator:
     customAnnotations: {}
 haController:
   enabled: false
-  image: daocloud.io/piraeus/piraeus-ha-controller:v0.3.0
+  image: quay.m.daocloud.io/piraeusdatastore/piraeus-ha-controller:v0.3.0
   affinity: {}
   tolerations: []
   resources: {}


### PR DESCRIPTION
We are automatically syncing all images to `m.daocloud.io` registry (refreshing each day). 

The following script convert all registry addresses to those of daocloud mirror.  

```
cd piraeus-operator/charts/piraeus

cat values.yaml \
| sed 's/docker.io/docker.m.daocloud.io/' \
| sed 's/quay.io/quay.m.daocloud.io/' \
| sed 's/registry.k8s.io/k8s-gcr.m.daocloud.io/' \
| sed 's/k8s.gcr.io/k8s-gcr.m.daocloud.io/' \
| sed 's/gcr.io/gcr.m.daocloud.io/' \
| sed 's/ghcr.io/gcr.m.daocloud.io/' \
| sed 's/bionic/centos7/' \
> values.cn.yaml
```

PS: We also default the drbd loader image to `centos7` as it is more popular than `ubuntu` in China.