### PR TITLE
Add Debian support

### DIFF
--- a/charts/piraeus/templates/config.yaml
+++ b/charts/piraeus/templates/config.yaml
@@ -54,3 +54,7 @@ data:
             image: drbd9-focal
           - osImage: Ubuntu 22\.04
             image: drbd9-jammy
+          - osImage: Debian GNU/Linux 11 (bullseye)
+            image: drbd9-bullseye
+          - osImage: Debian GNU/Linux 10 (buster)
+            image: drbd9-buster

--- a/charts/piraeus/templates/config.yaml
+++ b/charts/piraeus/templates/config.yaml
@@ -54,7 +54,7 @@ data:
             image: drbd9-focal
           - osImage: Ubuntu 22\.04
             image: drbd9-jammy
-          - osImage: Debian GNU/Linux 11 (bullseye)
+          - osImage: Debian GNU/Linux 11
             image: drbd9-bullseye
-          - osImage: Debian GNU/Linux 10 (buster)
+          - osImage: Debian GNU/Linux 10
             image: drbd9-buster

--- a/config/manager/default_images.yaml
+++ b/config/manager/default_images.yaml
@@ -48,3 +48,7 @@ components:
         image: drbd9-focal
       - osImage: Ubuntu 22\.04
         image: drbd9-jammy
+      - osImage: Debian GNU/Linux 11 (bullseye)
+        image: drbd9-bullseye
+      - osImage: Debian GNU/Linux 10 (buster)
+        image: drbd9-buster

--- a/config/manager/default_images.yaml
+++ b/config/manager/default_images.yaml
@@ -48,7 +48,7 @@ components:
         image: drbd9-focal
       - osImage: Ubuntu 22\.04
         image: drbd9-jammy
-      - osImage: Debian GNU/Linux 11 (bullseye)
+      - osImage: Debian GNU/Linux 11
         image: drbd9-bullseye
-      - osImage: Debian GNU/Linux 10 (buster)
+      - osImage: Debian GNU/Linux 10
         image: drbd9-buster

--- a/pkg/resources/satellite/patches/precompiled-module.yaml
+++ b/pkg/resources/satellite/patches/precompiled-module.yaml
@@ -12,11 +12,16 @@
       volumes:
       - name: usr-src
         $patch: delete
+      - name: usr-lib
+        $patch: delete
       initContainers:
       - name: drbd-module-loader
         volumeMounts:
         - name: usr-src
           mountPath: /usr/src
+          $patch: delete
+        - name: usr-lib
+          mountPath: /usr/lib
           $patch: delete
         env:
         - name: LB_HOW

--- a/pkg/resources/satellite/pod/node-pod.yaml
+++ b/pkg/resources/satellite/pod/node-pod.yaml
@@ -29,6 +29,9 @@ spec:
         - mountPath: /usr/src
           name: usr-src
           readOnly: true
+        - mountPath: /usr/lib
+          name: usr-lib
+          readOnly: true
     - name: drbd-shutdown-guard
       image: drbd-shutdown-guard
       securityContext:
@@ -103,6 +106,10 @@ spec:
     - name: usr-src
       hostPath:
         path: /usr/src
+        type: Directory
+    - name: usr-lib
+      hostPath:
+        path: /usr/lib
         type: Directory
     - name: dev
       hostPath:


### PR DESCRIPTION
This adds drbd-driver/module-loader support for Debian 10 & Debian 11.
/usr/lib has to be mounted in the loader container, as Debian symlinks a lot of kernel header stuff e.g. Makefile scripts back into /usr/lib.

This depends on https://github.com/piraeusdatastore/piraeus/pull/138