### PR TITLE
update image versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,8 @@ repos:
         language: system
         pass_filenames: false
         entry: make test
+      - id: sync-chart
+        name: Run make sync-chart
+        language: system
+        pass_filenames: false
+        entry: make sync-chart

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fix an issue where the CSI node driver would use the CSI socket not through the expected path in the container.
+- Updated images:
+  * LINSTOR 1.22.0
+  * DRBD 9.2.3
+  * DRBD Reactor 1.1.0
+  * HA Controller 1.1.3
 
 ## [v2.0.1] - 2023-03-08
 

--- a/Makefile
+++ b/Makefile
@@ -255,3 +255,7 @@ catalog-push: ## Push a catalog image.
 .PHONY: release
 release: $(YQ) $(KUSTOMIZE)
 	KUSTOMIZE=$(abspath $(KUSTOMIZE)) YQ=$(abspath $(YQ)) hack/make-release.sh $(VERSION)
+
+.PHONY: sync-chart
+sync-chart:
+	hack/copy-image-config-to-chart.sh

--- a/charts/piraeus/templates/config.yaml
+++ b/charts/piraeus/templates/config.yaml
@@ -1,3 +1,4 @@
+# DO NOT EDIT; Automatically created by hack/copy-image-config-to-chart.sh
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,28 +14,28 @@ data:
     base: quay.io/piraeusdatastore
     # "components" is a mapping of image placeholders to actual image names with tag.
     # For example, the image name "linstor-controller" in the kustomize-resources will be replaced by:
-    #   quay.io/piraeusdatastore/piraeus-server:v1.20.3
+    #   quay.io/piraeusdatastore/piraeus-server:v1.22.0
     components:
       linstor-controller:
-        tag: v1.20.3
+        tag: v1.22.0
         image: piraeus-server
       linstor-satellite:
-        tag: v1.20.3
+        tag: v1.22.0
         image: piraeus-server
       linstor-csi:
-        tag: v0.22.1
+        tag: v1.0.0
         image: piraeus-csi
       drbd-reactor:
-        tag: v1.0.0
+        tag: v1.1.0
         image: drbd-reactor
       ha-controller:
-        tag: v1.1.2
+        tag: v1.1.3
         image: piraeus-ha-controller
       drbd-shutdown-guard:
         tag: v1.0.0
         image: drbd-shutdown-guard
       drbd-module-loader:
-        tag: v9.2.2
+        tag: v9.2.3
         # The special "match" attribute is used to select an image based on the node's reported OS.
         # The operator will first check the k8s node's ".status.nodeInfo.osImage" field, and compare it against the list
         # here. If one matches, that specific image name will be used instead of the fallback image.
@@ -45,6 +46,8 @@ data:
           - osImage: CentOS Linux 8
             image: drbd9-centos8
           - osImage: AlmaLinux 8
+            image: drbd9-almalinux8
+          - osImage: Red Hat Enterprise Linux CoreOS
             image: drbd9-almalinux8
           - osImage: AlmaLinux 9
             image: drbd9-almalinux9

--- a/charts/piraeus/templates/deployment.yaml
+++ b/charts/piraeus/templates/deployment.yaml
@@ -60,9 +60,6 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
-        - mountPath: /etc/operator
-          name: operator-config
-          readOnly: true
       - args:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8080/
@@ -94,6 +91,3 @@ spec:
         secret:
           defaultMode: 420
           secretName: {{ include "piraeus-operator.certifcateName" . }}
-      - configMap:
-          name: {{ include "piraeus-operator.fullname" . }}-config
-        name: operator-config

--- a/config/manager/images.yaml
+++ b/config/manager/images.yaml
@@ -5,28 +5,28 @@
 base: quay.io/piraeusdatastore
 # "components" is a mapping of image placeholders to actual image names with tag.
 # For example, the image name "linstor-controller" in the kustomize-resources will be replaced by:
-#   quay.io/piraeusdatastore/piraeus-server:v1.20.3
+#   quay.io/piraeusdatastore/piraeus-server:v1.22.0
 components:
   linstor-controller:
-    tag: v1.20.3
+    tag: v1.22.0
     image: piraeus-server
   linstor-satellite:
-    tag: v1.20.3
+    tag: v1.22.0
     image: piraeus-server
   linstor-csi:
     tag: v1.0.0
     image: piraeus-csi
   drbd-reactor:
-    tag: v1.0.0
+    tag: v1.1.0
     image: drbd-reactor
   ha-controller:
+    tag: v1.1.3
     image: piraeus-ha-controller
-    tag: v1.1.2
   drbd-shutdown-guard:
-    image: drbd-shutdown-guard
     tag: v1.0.0
+    image: drbd-shutdown-guard
   drbd-module-loader:
-    tag: v9.2.2
+    tag: v9.2.3
     # The special "match" attribute is used to select an image based on the node's reported OS.
     # The operator will first check the k8s node's ".status.nodeInfo.osImage" field, and compare it against the list
     # here. If one matches, that specific image name will be used instead of the fallback image.

--- a/hack/copy-image-config-to-chart.sh
+++ b/hack/copy-image-config-to-chart.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+cat <<EOF > charts/piraeus/templates/config.yaml
+# DO NOT EDIT; Automatically created by hack/copy-image-config-to-chart.sh
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "piraeus-operator.fullname" . }}-image-config
+  labels:
+  {{- include "piraeus-operator.labels" . | nindent 4 }}
+data:
+  images.yaml: |
+EOF
+
+sed 's/^/    /' config/manager/images.yaml >> charts/piraeus/templates/config.yaml


### PR DESCRIPTION
Update images, and fix some issues related to updateing images:
* The image config from the chart is now updated automatically with `make sync-chart`, which is also added to `pre-commit`
* The chart deployment referenced the old operator config still. This was missed in 5f77f51, as reported in #460 