### PR TITLE
Add info about kernel module config to talos docs

### DIFF
--- a/docs/how-to/talos.md
+++ b/docs/how-to/talos.md
@@ -24,6 +24,8 @@ machine:
   kernel:
     modules:
       - name: drbd
+        parameters:
+          - usermode_helper=disabled
       - name: drbd_transport_tcp
 ```
 **NOTE**: Replace `v1.3.6` with the Talos version running.
@@ -33,6 +35,12 @@ Validate `drbd` module is loaded:
 $ talosctl -n <NODE_IP> read /proc/modules
 drbd_transport_tcp 28672 - - Live 0xffffffffc046c000 (O)
 drbd 643072 - - Live 0xffffffffc03b9000 (O)
+```
+
+Validate `drbd` module parameter `usermode_helper` is set to `disabled`:
+```shell
+$ talosctl -n <NODE_IP> read /sys/module/drbd/parameters/usermode_helper
+disabled
 ```
 
 ## Configure the DRBD Module Loader

--- a/docs/how-to/talos.md
+++ b/docs/how-to/talos.md
@@ -20,14 +20,19 @@ This can be achieved by updating the machine config:
 machine:
   install:
     extensions:
-      - image: ghcr.io/siderolabs/drbd:9.2.0-v1.3.5
+      - image: ghcr.io/siderolabs/drbd:9.2.0-v1.3.6
+  kernel:
+    modules:
+      - name: drbd
+      - name: drbd_transport_tcp
 ```
-**NOTE**: Replace `v1.3.5` with the Talos version running.
+**NOTE**: Replace `v1.3.6` with the Talos version running.
 
 Validate `drbd` module is loaded:
 ```shell
 $ talosctl -n <NODE_IP> read /proc/modules
-drbd 643072 - - Live 0xffffffffc0010000 (O)
+drbd_transport_tcp 28672 - - Live 0xffffffffc046c000 (O)
+drbd 643072 - - Live 0xffffffffc03b9000 (O)
 ```
 
 ## Configure the DRBD Module Loader


### PR DESCRIPTION
Adds [`KernelConfig`](https://www.talos.dev/v1.3/reference/configuration/#kernelconfig) info to the Talos docs.

Without it, `talosctl -n <NODE_IP> read /proc/modules` won't return anything and the linstor controller will report DRBD to be unsupported:
```
Unsupported resource layers:
 <node-name>:
  DRBD: DRBD version has to be >= 9. Current DRBD version: 0.0.0
```

> source: https://github.com/siderolabs/talos/pull/6426/files#diff-1a8257ae3f3e1367538a005610365d7fe5895c5833f1b802d4a88b9d3433c597R126-R129
