### PR TITLE
how-to: run on MicroK8s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ability to skip deploying the LINSTOR Controller by setting `LinstorCluster.spec.externalController`.
 
+### Changed
+
+- Fix an issue where the CSI node driver would use the CSI socket not through the expected path in the container.
+
 ## [v2.0.1] - 2023-03-08
 
 ### Added

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -13,6 +13,7 @@ These guides show you how to configure a specific aspect or achieve a specific t
 
 * [How to Load DRBD on OpenShift](./openshift.md)
 * [How to Load DRBD on Talos Linux](./talos.md)
+* [How to Configure Piraeus Datastore on MicroK8s](./microk8s.md)
 
 ## Configuration
 

--- a/docs/how-to/microk8s.md
+++ b/docs/how-to/microk8s.md
@@ -1,0 +1,43 @@
+# How to Configure Piraeus Datastore on MicroK8s
+
+This guide shows you how to configure Piraeus Datastore when using [MicroK8s](https://microk8s.io/).
+
+To complete this guide, you should be familiar with:
+
+* editing `LinstorCluster` resources.
+
+## Configure the CSI Driver
+
+MicroK8s is distributed as a [Snap](https://ubuntu.com/core/services/guide/snaps-intro). Because Snaps store their state
+in a separate directory (`/var/snap`) the LINSTOR CSI Driver needs to be updated to use a new path for mounting volumes.
+
+To change the LINSTOR CSI Driver, so that it uses the MicroK8s state paths, apply the following `LinstorCluster`:
+
+```yaml
+apiVersion: piraeus.io/v1
+kind: LinstorCluster
+metadata:
+  name: linstorcluster
+spec:
+  patches:
+    - target:
+        name: linstor-csi-node
+        kind: DaemonSet
+      patch: |
+        apiVersion: apps/v1
+        kind: DaemonSet
+        metadata:
+          name: linstor-csi-node
+        spec:
+          template:
+            spec:
+              containers:
+              - name: linstor-csi
+                volumeMounts:
+                - mountPath: /var/lib/kubelet
+                  name: publish-dir
+                  $patch: delete
+                - mountPath: /var/snap/microk8s/common/var/lib/kubelet
+                  name: publish-dir
+                  mountPropagation: Bidirectional
+```

--- a/pkg/resources/cluster/csi/csi-node-daemon-set.yaml
+++ b/pkg/resources/cluster/csi/csi-node-daemon-set.yaml
@@ -38,7 +38,7 @@ spec:
         - name: linstor-csi
           image: linstor-csi
           args:
-            - --csi-endpoint=unix://$(CSI_ENDPOINT)
+            - --csi-endpoint=unix:///csi/csi.sock
             - --node=$(KUBE_NODE_NAME)
             - --property-namespace=Aux/topology
             - --label-by-storage-pool=false
@@ -51,8 +51,6 @@ spec:
               add:
                 - SYS_ADMIN
           env:
-            - name: CSI_ENDPOINT
-              value: /var/lib/kubelet/plugins/linstor.csi.linbit.com/csi.sock
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
MicroK8s needs slightly modified mount paths for the CSI node containers.

During testing it also revealed an issue in the way we pass the csi socket to the linstor-csi plugin: instead of using the explicit mount location it used a path for the csi socket that only worked by accident. To fix it, we now use the explicit socket mount location.