### PR TITLE
operator: skip registration for pending controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Skip registration of non-running Controller Pods.
+
 ## [v1.10.3] - 2023-04-24
 
 ### Changed

--- a/pkg/controller/linstorcontroller/linstorcontroller_controller.go
+++ b/pkg/controller/linstorcontroller/linstorcontroller_controller.go
@@ -361,6 +361,10 @@ func (r *ReconcileLinstorController) reconcileControllers(ctx context.Context, c
 	log.V(DEBUG).Info("register controller pods in LINSTOR")
 
 	for _, pod := range ourPods.Items {
+		if pod.Status.Phase != corev1.PodRunning || pod.Status.PodIP == "" {
+			continue
+		}
+
 		log.V(DEBUG).Info("register controller pod", "pod", pod.Name)
 		_, err := linstorClient.GetNodeOrCreate(ctx, lapi.Node{
 			Name: pod.Name,


### PR DESCRIPTION
If the controller is pending, it does not have an assigned IP. We now skip any non-running controller containers, as there is nothing to register.

Fixes #456 