### PR TITLE
v1: switch to common logr.Logger implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.19
 require (
 	github.com/BurntSushi/toml v1.2.1
 	github.com/LINBIT/golinstor v0.46.1
+	github.com/go-logr/logr v1.2.3
 	github.com/linbit/k8s-await-election v0.3.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.63.0
-	github.com/sirupsen/logrus v1.9.0
 	gopkg.in/ini.v1 v1.67.0
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
@@ -25,7 +25,6 @@ require (
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -257,7 +257,6 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
-github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -409,7 +408,6 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/controller/linstorcontroller/common.go
+++ b/pkg/controller/linstorcontroller/common.go
@@ -1,9 +1,6 @@
 package linstorcontroller
 
 import (
-	"os"
-
-	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -13,16 +10,6 @@ const (
 	// requeue reconciliation after connectionRetrySeconds
 	connectionRetrySeconds = 10
 )
-
-func init() {
-	logrus.SetFormatter(&logrus.TextFormatter{})
-	logrus.SetOutput(os.Stdout)
-	logrus.SetLevel(logrus.DebugLevel)
-}
-
-var log = logrus.WithFields(logrus.Fields{
-	"controller": "LinstorController",
-})
 
 // Add creates a new LinstorController Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.

--- a/pkg/controller/linstorcsidriver/linstorcsidriver_controller_test.go
+++ b/pkg/controller/linstorcsidriver/linstorcsidriver_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -110,7 +111,7 @@ func TestReconcileLinstorCSIDriver_Reconcile(t *testing.T) {
 			// Create controller fake client.
 			controllerClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(testcase.initialResources...).Build()
 
-			reconciler := ReconcileLinstorCSIDriver{controllerClient, scheme.Scheme}
+			reconciler := ReconcileLinstorCSIDriver{client: controllerClient, scheme: scheme.Scheme, log: logr.Discard()}
 
 			_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo", Namespace: "bar"}})
 			if testcase.withError {

--- a/pkg/controller/linstorsatelliteset/common.go
+++ b/pkg/controller/linstorsatelliteset/common.go
@@ -1,10 +1,6 @@
 package linstorsatelliteset
 
 import (
-	"os"
-
-	"github.com/sirupsen/logrus"
-
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -20,16 +16,6 @@ const (
 	// requeue reconciliation after connectionRetrySeconds
 	connectionRetrySeconds = 10
 )
-
-func init() {
-	logrus.SetFormatter(&logrus.TextFormatter{})
-	logrus.SetOutput(os.Stdout)
-	logrus.SetLevel(logrus.DebugLevel)
-}
-
-var log = logrus.WithFields(logrus.Fields{
-	"controller": "LinstorSatelliteSet",
-})
 
 // Add creates a new LinstorSatelliteSet Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.

--- a/pkg/linstor/client/log.go
+++ b/pkg/linstor/client/log.go
@@ -1,0 +1,36 @@
+package client
+
+import (
+	"fmt"
+
+	lapi "github.com/LINBIT/golinstor/client"
+	"github.com/go-logr/logr"
+
+	. "github.com/piraeusdatastore/piraeus-operator/pkg/logconsts"
+)
+
+type logrAdapter struct {
+	logr.Logger
+}
+
+var _ lapi.LeveledLogger = &logrAdapter{}
+
+func Logr(l logr.Logger) lapi.Option {
+	return lapi.Log(&logrAdapter{Logger: l})
+}
+
+func (l *logrAdapter) Errorf(s string, i ...interface{}) {
+	l.Logger.Error(fmt.Errorf(s, i...), "error occurred")
+}
+
+func (l *logrAdapter) Warnf(s string, i ...interface{}) {
+	l.Logger.V(0).Info(fmt.Sprintf(s, i...))
+}
+
+func (l *logrAdapter) Infof(s string, i ...interface{}) {
+	l.Logger.V(INFO).Info(fmt.Sprintf(s, i...))
+}
+
+func (l *logrAdapter) Debugf(s string, i ...interface{}) {
+	l.Logger.V(DEBUG).Info(fmt.Sprintf(s, i...))
+}

--- a/pkg/logconsts/log.go
+++ b/pkg/logconsts/log.go
@@ -1,0 +1,6 @@
+package logconsts
+
+const (
+	INFO  = 1
+	DEBUG = 2
+)


### PR DESCRIPTION
The Operator had the option to set the logging verbosity for the operator-sdk controlled logs, but because we used logrus instead of the configured logr instance, we did not get to control the verbosity of our own logs.

This commit switches all logging to using a logr.Logger instance, inherited from the configured by operator-sdk. Since we configure development mode by default we should not see any change in log verbosity, but if users want to turn down the verbosity, they now can.