### PR TITLE
satellite: ignore 404s when running finalizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a bug where `LinstorSatellite` resources would be not be cleaned up when the satellite is already gone.
+
 ## [v2.1.0] - 2023-04-24
 
 ### Added

--- a/controllers/linstorsatellite_controller.go
+++ b/controllers/linstorsatellite_controller.go
@@ -505,7 +505,7 @@ func (r *LinstorSatelliteReconciler) deleteSatellite(ctx context.Context, lsatel
 	}
 
 	ress, err := lc.Resources.GetResourceView(ctx, &lclient.ListOpts{Node: []string{lsatellite.Name}})
-	if err != nil {
+	if err != nil && err != lclient.NotFoundError {
 		return err
 	}
 


### PR DESCRIPTION
When removing satellites, we need to ignore 404 errors, as those usually indicate that the node is removed. In these cases we want to continue running the finalizer. We missed one instance where LINSTOR would return a 404 when the satellite is already deregistered.