### PR TITLE
Implement rate limiter for LINSTOR API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - LINSTOR Controller deployment now runs DB migrations as a separate init container, creating
   a backup of current DB state if needed.
+- Apply global rate limit to LINSTOR API, defaulting to 100 qps.
 
 ### Fixed
 

--- a/controllers/linstorcluster_controller.go
+++ b/controllers/linstorcluster_controller.go
@@ -26,6 +26,7 @@ import (
 
 	lapi "github.com/LINBIT/golinstor/client"
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"golang.org/x/time/rate"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	netwv1 "k8s.io/api/networking/v1"
@@ -71,6 +72,7 @@ type LinstorClusterReconciler struct {
 	Namespace          string
 	PullSecret         string
 	ImageConfigMapName string
+	LinstorApiLimiter  *rate.Limiter
 	Kustomizer         *resources.Kustomizer
 }
 
@@ -608,6 +610,7 @@ func (r *LinstorClusterReconciler) reconcileClusterState(ctx context.Context, lc
 		clientSecret,
 		lcluster.Spec.ExternalController,
 		linstorhelper.Logr(log.FromContext(ctx)),
+		lapi.Limiter(r.LinstorApiLimiter),
 	)
 	if err != nil || lc == nil {
 		conds.AddError(conditions.Available, err)

--- a/controllers/linstorsatellite_controller.go
+++ b/controllers/linstorsatellite_controller.go
@@ -27,6 +27,7 @@ import (
 	lclient "github.com/LINBIT/golinstor/client"
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/go-logr/logr"
+	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -65,6 +66,7 @@ type LinstorSatelliteReconciler struct {
 	Scheme             *runtime.Scheme
 	Namespace          string
 	ImageConfigMapName string
+	LinstorApiLimiter  *rate.Limiter
 	Kustomizer         *resources.Kustomizer
 	log                logr.Logger
 }
@@ -287,6 +289,7 @@ func (r *LinstorSatelliteReconciler) reconcileLinstorSatelliteState(ctx context.
 		lsatellite.Spec.ClusterRef.ClientSecretName,
 		lsatellite.Spec.ClusterRef.ExternalController,
 		linstorhelper.Logr(log.FromContext(ctx)),
+		lclient.Limiter(r.LinstorApiLimiter),
 	)
 	if err != nil || lc == nil {
 		conds.AddError(conditions.Available, err)
@@ -488,6 +491,7 @@ func (r *LinstorSatelliteReconciler) deleteSatellite(ctx context.Context, lsatel
 		lsatellite.Spec.ClusterRef.ClientSecretName,
 		lsatellite.Spec.ClusterRef.ExternalController,
 		linstorhelper.Logr(log.FromContext(ctx)),
+		lclient.Limiter(r.LinstorApiLimiter),
 	)
 	if err != nil {
 		return err

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -125,11 +125,14 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
+	unlimiter := rate.NewLimiter(rate.Inf, 0)
+
 	err = (&controllers.LinstorClusterReconciler{
 		Client:             k8sManager.GetClient(),
 		Scheme:             k8sManager.GetScheme(),
 		Namespace:          Namespace,
 		ImageConfigMapName: ImageConfigMapName,
+		LinstorApiLimiter:  unlimiter,
 	}).SetupWithManager(k8sManager, opts)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -138,6 +141,7 @@ var _ = BeforeSuite(func() {
 		Scheme:             k8sManager.GetScheme(),
 		Namespace:          Namespace,
 		ImageConfigMapName: ImageConfigMapName,
+		LinstorApiLimiter:  unlimiter,
 	}).SetupWithManager(k8sManager, opts)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/piraeusdatastore/piraeus-operator/v2
 go 1.19
 
 require (
-	github.com/LINBIT/golinstor v0.47.0
+	github.com/LINBIT/golinstor v0.48.0
 	github.com/cert-manager/cert-manager v1.11.0
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/go-logr/logr v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/LINBIT/golinstor v0.47.0 h1:XaCjJUhxEqjutkdPGJgBW6UIXfMRVuCvm+4XVDu5voI=
 github.com/LINBIT/golinstor v0.47.0/go.mod h1:2DKFPzzhj3mhs4DUNAx3PPGDYCQXYE36sRUJyWfAA/0=
+github.com/LINBIT/golinstor v0.48.0 h1:JhXBQkGdDAA/ycKXHUuz2NYWFvVXYZE/w7AskCagOsw=
+github.com/LINBIT/golinstor v0.48.0/go.mod h1:2DKFPzzhj3mhs4DUNAx3PPGDYCQXYE36sRUJyWfAA/0=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=

--- a/pkg/linstorhelper/client.go
+++ b/pkg/linstorhelper/client.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	piraeusv1 "github.com/piraeusdatastore/piraeus-operator/v2/api/v1"
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/vars"
 )
 
 // Client is a LINSTOR client with convenience functions.
@@ -78,7 +79,7 @@ func NewClientForCluster(ctx context.Context, cl client.Client, namespace, clust
 		}))
 	}
 
-	options = append(options, lapi.BaseURL(clientUrl))
+	options = append(options, lapi.BaseURL(clientUrl), lapi.UserAgent(vars.OperatorName+"/"+vars.Version))
 
 	c, err := lapi.NewClient(options...)
 	if err != nil {

--- a/pkg/linstorhelper/client_test.go
+++ b/pkg/linstorhelper/client_test.go
@@ -26,6 +26,7 @@ import (
 
 	piraeusv1 "github.com/piraeusdatastore/piraeus-operator/v2/api/v1"
 	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/linstorhelper"
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/vars"
 )
 
 func TestNewClientForCluster(t *testing.T) {
@@ -74,7 +75,10 @@ func TestNewClientForCluster(t *testing.T) {
 			externalRef: &piraeusv1.LinstorExternalControllerRef{
 				URL: "http://other-cluster.example.com:3370",
 			},
-			expectedOptions: []lapi.Option{lapi.BaseURL(&url.URL{Scheme: "http", Host: "other-cluster.example.com:3370"})},
+			expectedOptions: []lapi.Option{
+				lapi.BaseURL(&url.URL{Scheme: "http", Host: "other-cluster.example.com:3370"}),
+				lapi.UserAgent(vars.OperatorName + "/" + vars.Version),
+			},
 		},
 		{
 			name: "cluster-external-controller-with-tls",
@@ -94,6 +98,7 @@ func TestNewClientForCluster(t *testing.T) {
 				lapi.HTTPClient(&http.Client{Transport: &http.Transport{
 					TLSClientConfig: tlsConfig,
 				}}),
+				lapi.UserAgent(vars.OperatorName + "/" + vars.Version),
 			},
 		},
 		{
@@ -132,7 +137,10 @@ func TestNewClientForCluster(t *testing.T) {
 					},
 				},
 			},
-			expectedOptions: []lapi.Option{lapi.BaseURL(&url.URL{Scheme: "http", Host: "test-cluster-service.test.svc:3370"})},
+			expectedOptions: []lapi.Option{
+				lapi.BaseURL(&url.URL{Scheme: "http", Host: "test-cluster-service.test.svc:3370"}),
+				lapi.UserAgent(vars.OperatorName + "/" + vars.Version),
+			},
 		},
 		{
 			name: "cluster-with-service-with-port-tls",
@@ -163,6 +171,7 @@ func TestNewClientForCluster(t *testing.T) {
 			expectedOptions: []lapi.Option{
 				lapi.BaseURL(&url.URL{Scheme: "https", Host: "test-cluster-service.test.svc:3371"}),
 				lapi.HTTPClient(&http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}),
+				lapi.UserAgent(vars.OperatorName + "/" + vars.Version),
 			},
 		},
 	}


### PR DESCRIPTION
LINSTOR may get overloaded on large clusters once the operator starts up. To combat this, we implement a global rate limit for the LINSTOR API, defaulting to 100 qps.

While at it, also set a user agent identifying the operator.