### PR TITLE
Ensure user-defined patches are applied last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug where `LinstorSatellite` resources would be not be cleaned up when the satellite is already gone.
 - Fixed a bug where the LINSTOR Controller would never report readiness when TLS is enabled.
+- Fixed order in which patches are applied. Always apply user patches last.
 
 ## [v2.1.0] - 2023-04-24
 

--- a/controllers/linstorcluster_controller.go
+++ b/controllers/linstorcluster_controller.go
@@ -566,7 +566,7 @@ func (r *LinstorClusterReconciler) kustomize(resources []string, lcluster *pirae
 		Labels:    r.kustomLabels(lcluster),
 		Resources: resources,
 		Images:    imgs,
-		Patches:   append(append(utils.MakeKustPatches(lcluster.Spec.Patches...), saPatch...), patches...),
+		Patches:   append(append(patches, saPatch...), utils.MakeKustPatches(lcluster.Spec.Patches...)...),
 	}
 
 	return r.Kustomizer.Kustomize(k)

--- a/controllers/linstorsatellite_controller.go
+++ b/controllers/linstorsatellite_controller.go
@@ -274,7 +274,7 @@ func (r *LinstorSatelliteReconciler) kustomizeNodeResources(ctx context.Context,
 		Resources:    resourceDirs,
 		Images:       imgs,
 		Replacements: SatelliteNameReplacements,
-		Patches:      append(utils.MakeKustPatches(lsatellite.Spec.Patches...), patches...),
+		Patches:      append(patches, utils.MakeKustPatches(lsatellite.Spec.Patches...)...),
 	}
 
 	return r.Kustomizer.Kustomize(k)


### PR DESCRIPTION
User defined patches may break our own patches if they are applied first. For example, they may delete a resource which we also want to patch.

By applying user patches after our own, we can ensure that our own resources are in a consistent state: users using user-patches are on their own anyways.