### PR TITLE
use persistent host directory for satellite logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a backup of current DB state if needed.
 - Apply global rate limit to LINSTOR API, defaulting to 100 qps.
 
+### Changed
+
+- Store LINSTOR Satellite logs on the host.
+
 ### Fixed
 
 - Fixed a bug where `LinstorSatellite` resources would be not be cleaned up when the satellite is already gone.

--- a/pkg/resources/satellite/pod/node-pod.yaml
+++ b/pkg/resources/satellite/pod/node-pod.yaml
@@ -143,6 +143,10 @@ spec:
       hostPath:
         path: /run/dbus/system_bus_socket
         type: Socket
+    - name: var-log-linstor-satellite
+      hostPath:
+        path: /var/log/linstor-satellite
+        type: DirectoryOrCreate
     - name: satellite-config
       configMap:
         name: satellite-config
@@ -151,8 +155,6 @@ spec:
       configMap:
         name: reactor-config
         defaultMode: 0440
-    - name: var-log-linstor-satellite
-      emptyDir: { }
     - name: tmp
       emptyDir: { }
     - name: run-lock


### PR DESCRIPTION
A satellite Pod may be restarted for any number of reasons. We would like access to logs of the satellite even after a restart, so we need a persistent directory on the host to store our logs.