### PR TITLE
satellite: remove /usr/lib mount

### DIFF
--- a/pkg/resources/satellite/patches/precompiled-module.yaml
+++ b/pkg/resources/satellite/patches/precompiled-module.yaml
@@ -12,16 +12,11 @@
       volumes:
       - name: usr-src
         $patch: delete
-      - name: usr-lib
-        $patch: delete
       initContainers:
       - name: drbd-module-loader
         volumeMounts:
         - name: usr-src
           mountPath: /usr/src
-          $patch: delete
-        - name: usr-lib
-          mountPath: /usr/lib
           $patch: delete
         env:
         - name: LB_HOW

--- a/pkg/resources/satellite/pod/node-pod.yaml
+++ b/pkg/resources/satellite/pod/node-pod.yaml
@@ -29,9 +29,6 @@ spec:
         - mountPath: /usr/src
           name: usr-src
           readOnly: true
-        - mountPath: /usr/lib
-          name: usr-lib
-          readOnly: true
     - name: drbd-shutdown-guard
       image: drbd-shutdown-guard
       securityContext:
@@ -106,10 +103,6 @@ spec:
     - name: usr-src
       hostPath:
         path: /usr/src
-        type: Directory
-    - name: usr-lib
-      hostPath:
-        path: /usr/lib
         type: Directory
     - name: dev
       hostPath:


### PR DESCRIPTION
In bd29628, we started bind mounting /usr/lib, as our debian images required it to find the necessary scripts to build DRBD.

A better way to resolve this issue is to include those scripts directly in the container images. This means we can remove the /usr/lib mount, which led to some "franken"-container scenarios.

Depends on: https://github.com/piraeusdatastore/piraeus/pull/145
See also: https://github.com/piraeusdatastore/piraeus-operator/pull/444 and https://github.com/piraeusdatastore/piraeus-operator/issues/427
