### PR TITLE
Added selinux options

### DIFF
--- a/charts/piraeus/values.cn.yaml
+++ b/charts/piraeus/values.cn.yaml
@@ -115,7 +115,9 @@ operator:
     kernelModuleInjectionAdditionalSourceDirectory: ""
     kernelModuleInjectionResources: {}
     kernelModuleInjectionExtraVolumeMounts: []
-    additionalEnv: []
+    additionalEnv:
+    - name: LB_SELINUX_AS
+      value: "modules_object_t"
     dnsPolicy: ""
     sidecars: []
     extraVolumes: []

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -115,7 +115,9 @@ operator:
     kernelModuleInjectionAdditionalSourceDirectory: ""
     kernelModuleInjectionResources: {}
     kernelModuleInjectionExtraVolumeMounts: []
-    additionalEnv: []
+    additionalEnv:
+    - name: LB_SELINUX_AS
+      value: "modules_object_t"
     dnsPolicy: ""
     sidecars: []
     extraVolumes: []

--- a/deploy/piraeus/templates/operator-satelliteset.yaml
+++ b/deploy/piraeus/templates/operator-satelliteset.yaml
@@ -23,3 +23,4 @@ spec:
   kernelModuleInjectionMode: "Compile"
   kernelModuleInjectionImage: "quay.io/piraeusdatastore/drbd9-bionic:v9.1.15"
   kernelModuleInjectionResources: {}
+  additionalEnv: [{"name":"LB_SELINUX_AS","value":"modules_object_t"}]

--- a/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
+++ b/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
@@ -960,7 +960,8 @@ func newSatelliteDaemonSet(satelliteSet *piraeusv1.LinstorSatelliteSet, satellit
 							}, // Run linstor-satellite.
 							Env:             satelliteSet.Spec.AdditionalEnv,
 							ImagePullPolicy: satelliteSet.Spec.ImagePullPolicy,
-							SecurityContext: &corev1.SecurityContext{Privileged: &kubeSpec.Privileged},
+							SecurityContext: &corev1.SecurityContext{Privileged: &kubeSpec.Privileged,
+								SELinuxOptions: &corev1.SELinuxOptions{Level: kubeSpec.Level, Type: kubeSpec.Type}},
 							Ports: []corev1.ContainerPort{
 								{
 									HostPort:      satelliteSet.Spec.SslConfig.Port(),
@@ -1266,10 +1267,11 @@ func daemonSetWithDRBDKernelModuleInjection(ds *apps.DaemonSet, satelliteSet *pi
 			Name:            "kernel-module-injector",
 			Image:           satelliteSet.Spec.KernelModuleInjectionImage,
 			ImagePullPolicy: satelliteSet.Spec.ImagePullPolicy,
-			SecurityContext: &corev1.SecurityContext{Privileged: &kubeSpec.Privileged},
-			Env:             env,
-			VolumeMounts:    volumeMounts,
-			Resources:       satelliteSet.Spec.KernelModuleInjectionResources,
+			SecurityContext: &corev1.SecurityContext{Privileged: &kubeSpec.Privileged,
+				SELinuxOptions: &corev1.SELinuxOptions{Level: kubeSpec.Level, Type: kubeSpec.Type}},
+			Env:          env,
+			VolumeMounts: volumeMounts,
+			Resources:    satelliteSet.Spec.KernelModuleInjectionResources,
 		},
 	}
 

--- a/pkg/k8s/spec/const.go
+++ b/pkg/k8s/spec/const.go
@@ -100,11 +100,13 @@ var (
 	HostPathDirectoryType         = corev1.HostPathDirectory
 	HostPathDirectoryOrCreateType = corev1.HostPathDirectoryOrCreate
 	MountPropagationBidirectional = corev1.MountPropagationBidirectional
-	FileType = corev1.HostPathFile
+	FileType                      = corev1.HostPathFile
 )
 
 // Shared consts common to container security. These need to be vars, so they
 // are addressible.
 var (
 	Privileged = true
+	Level      = "s0"
+	Type       = "spc_t"
 )


### PR DESCRIPTION
Added SELinux options for enforced mode

Without this kernel module injector can't work with enforced SELinux mode.

Also, there is linked changes in drbd
https://lists.linbit.com/pipermail/drbd-dev/2023-May/007050.html