### PR TITLE
use consistent tolerations for all "daemon" pods

### DIFF
--- a/pkg/resources/cluster/csi/csi-node-daemon-set.yaml
+++ b/pkg/resources/cluster/csi/csi-node-daemon-set.yaml
@@ -117,10 +117,14 @@ spec:
           args:
             - '--csi-address=/csi/csi.sock'
       tolerations:
-        - effect: NoSchedule
-          key: drbd.linbit.com/lost-quorum
-        - effect: NoSchedule
-          key: drbd.linbit.com/force-io-error
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+        - key: drbd.linbit.com/lost-quorum
+          effect: NoSchedule
+        - key: drbd.linbit.com/force-io-error
+          effect: NoSchedule
       volumes:
         - name: device-dir
           hostPath:

--- a/pkg/resources/satellite/pod/node-pod.yaml
+++ b/pkg/resources/satellite/pod/node-pod.yaml
@@ -156,6 +156,10 @@ spec:
       emptyDir: { }
   restartPolicy: Always
   tolerations:
+    - key: node-role.kubernetes.io/master
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/control-plane
+      effect: NoSchedule
     - key: node.kubernetes.io/not-ready
       effect: NoExecute
     - key: node.kubernetes.io/unreachable
@@ -166,7 +170,7 @@ spec:
       effect: NoSchedule
     - key: node.kubernetes.io/unschedulable
       effect: NoSchedule
-    - effect: NoSchedule
-      key: drbd.linbit.com/lost-quorum
-    - effect: NoSchedule
-      key: drbd.linbit.com/force-io-error
+    - key: drbd.linbit.com/lost-quorum
+      effect: NoSchedule
+    - key: drbd.linbit.com/force-io-error
+      effect: NoSchedule


### PR DESCRIPTION
Use the same tolerations for all 3 kinds of daemon pods:

* Satellite
* CSI Node
* HA Controller

These tolerations allow running on control plane nodes, and also tolerate the HA Controller managed taints.

The satellite pods also include the tolerations for node pressure events, they are included in the normal daemon set pods automatically, but the satellite is a custom pods.