### PR TITLE
Disable operator metrics reporting by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade to operator-sdk 1.29
 - Upgrade to kubebuilder v4 layout
 
+### Removed
+
+- Disable operator metrics by default. This removes a dependency on an external container.
+
 ## [v2.1.1] - 2023-05-24
 
 ### Added

--- a/charts/piraeus/templates/deployment.yaml
+++ b/charts/piraeus/templates/deployment.yaml
@@ -20,7 +20,11 @@ spec:
       containers:
       - args:
           - --health-probe-bind-address=:8081
+        {{- if .Values.kubeRbacProxy.enabled }}
           - --metrics-bind-address=127.0.0.1:8080
+        {{- else }}
+          - --metrics-bind-address=0
+        {{- end }}
         {{- range $opt, $val := .Values.operator.options }}
           - --{{ $opt | kebabcase }}={{ $val }}
         {{- end }}
@@ -60,6 +64,7 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
+      {{- if .Values.kubeRbacProxy.enabled }}
       - args:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8080/
@@ -82,6 +87,7 @@ spec:
         volumeMounts:
           - mountPath: /etc/tls
             name: cert
+      {{- end }}
       securityContext:
         runAsNonRoot: true
       serviceAccountName: {{ include "piraeus-operator.serviceAccountName" . }}

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -28,6 +28,7 @@ operator:
     #   memory: 128Mi
 
 kubeRbacProxy:
+  enabled: false
   image:
     repository: gcr.io/kubebuilder/kube-rbac-proxy
     pullPolicy: IfNotPresent

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -23,10 +23,10 @@ resources:
 - ../webhook
 - ../certmanager
 
-patchesStrategicMerge:
-- manager_auth_proxy_patch.yaml
-- manager_webhook_patch.yaml
-- webhookcainjection_patch.yaml
+patches:
+- path: manager_webhook_patch.yaml
+- path: webhookcainjection_patch.yaml
+# - path: manager_auth_proxy_patch.yaml
 
 replacements:
 - source:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,6 +31,7 @@ spec:
         - /manager
         args:
         - --leader-elect
+        - --metrics-bind-address=0
         - --namespace=$(NAMESPACE)
         - --image-config-map-name=$(IMAGE_CONFIG_MAP_NAME)
         image: controller:latest


### PR DESCRIPTION
The Operator metrics are not generally useful without additional metrics. They also depend on an external container.

In order to streamline air-gapped deployments, remove this feature from the default deployment.