### PR TITLE
stork: fix scheduler deployment

### DIFF
--- a/charts/piraeus/templates/stork-deployment.yaml
+++ b/charts/piraeus/templates/stork-deployment.yaml
@@ -274,7 +274,6 @@ spec:
       containers:
         - command:
             - /usr/local/bin/kube-scheduler
-            - --address=0.0.0.0
             {{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.Version }}
             - --config=/etc/kubernetes/stork-config.yaml
             {{- else }}


### PR DESCRIPTION
--address is not a valid argument to the scheduler since kubernetes 1.23. It's also just setting a default setting, so there is no need to explicitly set this argument.