### PR TITLE
generate webhook cert without cert-manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Disable operator metrics by default. This removes a dependency on an external container.
+- Dependency on cert-manager for initial deployment.
 
 ## [v2.1.1] - 2023-05-24
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,13 @@ ARG VERSION=devel
 ARG TARGETARCH
 ARG TARGETOS
 RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "-X github.com/piraeusdatastore/piraeus-operator/v2/pkg/vars.Version=$VERSION" -o manager ./cmd
+RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "-X github.com/piraeusdatastore/piraeus-operator/v2/pkg/vars.Version=$VERSION" -o gencert ./cmd/gencert
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/manager /workspace/gencert /
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/README.md
+++ b/README.md
@@ -22,20 +22,13 @@ to fix issues or new software versions until a stable upgrade path to v2 is avai
 
 ## Usage
 
-To deploy Piraeus Operator v2, first make sure to deploy [cert-manager](https://cert-manager.io)
-
-```
-$ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.0/cert-manager.yaml
-```
-
-Then, deploy the Operator from this repository:
+To deploy Piraeus Operator v2 from this repository, simply run:
 
 ```
 $ kubectl apply --server-side -k "https://github.com/piraeusdatastore/piraeus-operator//config/default?ref=v2"
 # Verify the operator is running:
-$ kubectl get pods -n piraeus-datastore
-NAME                                                 READY   STATUS    RESTARTS   AGE
-piraeus-operator-piraeus-operator-748c57bb8d-65cvw   2/2     Running   0          55s
+$ kubectl wait pod --for=condition=Ready -n piraeus-datastore -l app.kubernetes.io/component=piraeus-operator
+pod/piraeus-operator-controller-manager-dd898f48c-bhbtv condition met
 ```
 
 Now you can create a basic storage cluster by applying the `LinstorCluster` resource.
@@ -50,10 +43,7 @@ spec: {}
 EOF
 ```
 
-## Configuration
-
-We are currently working on improving our documentation. Additional tutorials and explanation will be
-added soon.
+## Documentation
 
 ### [Tutorials](./docs/tutorial)
 
@@ -67,6 +57,10 @@ How-To Guides show you how to configure a specific aspect or achieve a specific 
 
 The API Reference for the Piraeus Operator. Contains documentation of the LINSTOR related resources that the user can
 modify or observe.
+
+### [Understanding Piraeus Datastore](./docs/explanation)
+
+These documents explain how Piraeus Datastore works, and why it works the way it does.
 
 ## Missing features
 

--- a/cmd/gencert/gencert.go
+++ b/cmd/gencert/gencert.go
@@ -1,0 +1,282 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"crypto/x509"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/go-logr/logr"
+	v1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/cert"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/vars"
+)
+
+var (
+	scheme   = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("setup")
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+}
+
+func main() {
+	var enableLeaderElection bool
+	var probeAddr string
+	var namespace string
+	var webhookConfigurationName string
+	var webhookServiceName string
+	var webhookTlsSecretName string
+	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
+		"Enable leader election for controller manager. "+
+			"Enabling this will ensure there is only one active instance.")
+	flag.StringVar(&namespace, "namespace", os.Getenv("NAMESPACE"), "The namespace to create resources in.")
+	flag.StringVar(&webhookConfigurationName, "webhook-configuration-name", os.Getenv("WEBHOOK_CONFIGURATION_NAME"), "The name of the ValidatingWebhookConfiguration.")
+	flag.StringVar(&webhookServiceName, "webhook-service-name", os.Getenv("WEBHOOK_SERVICE_NAME"), "The name of the service used to route the webhook.")
+	flag.StringVar(&webhookTlsSecretName, "webhook-tls-secret-name", os.Getenv("WEBHOOK_TLS_SECRET_NAME"), "The name of the tls-type secret used for serving the webhooks.")
+	opts := zap.Options{
+		Development: true,
+	}
+	opts.BindFlags(flag.CommandLine)
+	flag.Parse()
+
+	if namespace == "" {
+		setupLog.Info("No namespace specified, defaulting to operator namespace")
+		raw, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+		if err != nil {
+			setupLog.Error(err, "unable to detect operator namespace")
+			os.Exit(1)
+		}
+		namespace = string(raw)
+	}
+
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme:                 scheme,
+		HealthProbeBindAddress: probeAddr,
+		LeaderElection:         enableLeaderElection,
+		LeaderElectionID:       vars.GenCertLeaderElectionID,
+		Namespace:              namespace,
+		NewClient: func(cache cache.Cache, config *rest.Config, options client.Options, uncachedObjects ...client.Object) (client.Client, error) {
+			return client.New(config, options)
+		},
+	})
+	if err != nil {
+		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	err = mgr.Add(&GenCertRunner{
+		Client:                   mgr.GetClient(),
+		Logger:                   mgr.GetLogger(),
+		Namespace:                namespace,
+		WebhookConfigurationName: webhookConfigurationName,
+		WebhookServiceName:       webhookServiceName,
+		WebhookTlsSecretName:     webhookTlsSecretName,
+	})
+	if err != nil {
+		setupLog.Error(err, "unable to add gen cert runner")
+		os.Exit(1)
+	}
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up health check")
+		os.Exit(1)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up ready check")
+		os.Exit(1)
+	}
+
+	setupLog.Info("starting manager", "version", vars.Version)
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		setupLog.Error(err, "problem running manager")
+		os.Exit(1)
+	}
+}
+
+type GenCertRunner struct {
+	Client                   client.Client
+	Logger                   logr.Logger
+	Namespace                string
+	WebhookConfigurationName string
+	WebhookServiceName       string
+	WebhookTlsSecretName     string
+}
+
+func (g *GenCertRunner) NeedLeaderElection() bool {
+	return true
+}
+
+func (g *GenCertRunner) Start(ctx context.Context) error {
+	g.Logger.Info("starting cert renew")
+	for {
+		c, err := g.reconcile(ctx)
+		if err != nil {
+			return err
+		}
+
+		renewIn := NeedsRenewIn(c, g.dnsNames(), time.Now())
+		g.Logger.Info("sleeping until cert renewal", "renewIn", renewIn)
+		t := time.NewTimer(renewIn)
+
+		select {
+		case <-t.C:
+			// continue
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (g *GenCertRunner) reconcile(ctx context.Context) (*x509.Certificate, error) {
+	certBytes, keyBytes, err := g.getCert(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get initial cert: %w", err)
+	}
+
+	cs, err := cert.ParseCertsPEM(certBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse certificates: %w", err)
+	}
+
+	err = g.reconcileCertSecret(ctx, certBytes, keyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reconcile certificate secret: %w", err)
+	}
+
+	err = g.reconcileWebhookCA(ctx, certBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reconcile webhook ca config: %w", err)
+	}
+
+	return cs[0], nil
+}
+
+func (g *GenCertRunner) getCert(ctx context.Context) ([]byte, []byte, error) {
+	g.Logger.Info("checking for existing secret")
+	var secret corev1.Secret
+	err := g.Client.Get(ctx, types.NamespacedName{Name: g.WebhookTlsSecretName, Namespace: g.Namespace}, &secret)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, nil, err
+	}
+
+	if err == nil {
+		certs, _ := cert.ParseCertsPEM(secret.Data[corev1.TLSCertKey])
+		if len(certs) > 0 && NeedsRenewIn(certs[0], g.dnsNames(), time.Now()) > 0 {
+			g.Logger.Info("existing secret does not need to be renewed")
+			return secret.Data[corev1.TLSCertKey], secret.Data[corev1.TLSPrivateKeyKey], nil
+		}
+	}
+
+	g.Logger.Info("creating new self signed secret")
+	return cert.GenerateSelfSignedCertKey(g.dnsNames()[0], nil, g.dnsNames())
+}
+
+func (g *GenCertRunner) reconcileCertSecret(ctx context.Context, certBytes, keyBytes []byte) error {
+	g.Logger.Info("applying cert as secret")
+	secret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: corev1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      g.WebhookTlsSecretName,
+			Namespace: g.Namespace,
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       certBytes,
+			corev1.TLSPrivateKeyKey: keyBytes,
+		},
+	}
+
+	return g.Client.Patch(ctx, secret, client.Apply, client.ForceOwnership, client.FieldOwner(vars.FieldOwner))
+}
+
+func (g *GenCertRunner) reconcileWebhookCA(ctx context.Context, caBytes []byte) error {
+	g.Logger.Info("checking webhook configuration")
+	var webhookConfiguration v1.ValidatingWebhookConfiguration
+	err := g.Client.Get(ctx, types.NamespacedName{Name: g.WebhookConfigurationName}, &webhookConfiguration)
+	if err != nil {
+		return err
+	}
+
+	changed := false
+	for i := range webhookConfiguration.Webhooks {
+		whc := &webhookConfiguration.Webhooks[i].ClientConfig
+		if whc.Service == nil {
+			continue
+		}
+
+		if whc.Service.Name != g.WebhookServiceName || whc.Service.Namespace != g.Namespace {
+			continue
+		}
+
+		if string(whc.CABundle) != string(caBytes) {
+			changed = true
+			whc.CABundle = caBytes
+		}
+	}
+
+	if changed {
+		g.Logger.Info("applying changed webhook configuration")
+		return g.Client.Update(ctx, &webhookConfiguration)
+	}
+
+	return nil
+}
+
+func (g *GenCertRunner) dnsNames() []string {
+	return []string{
+		fmt.Sprintf("%s.%s.svc", g.WebhookServiceName, g.Namespace),
+		fmt.Sprintf("%s.%s.svc.cluster.local", g.WebhookServiceName, g.Namespace),
+	}
+}
+
+func NeedsRenewIn(c *x509.Certificate, expectedNames []string, now time.Time) time.Duration {
+	// There may be repeats in the cert, so we use a set to compare here
+	if !sets.NewString(c.DNSNames...).Equal(sets.NewString(expectedNames...)) {
+		return 0
+	}
+
+	if now.Before(c.NotBefore) {
+		return 0
+	}
+
+	// Renew two weeks before actually expiring. Our certificates are always valid for a year, so using a fixed offset
+	// should be good enough.
+	return c.NotAfter.Sub(now) - (14 * 24 * time.Hour)
+}

--- a/cmd/gencert/gencert_test.go
+++ b/cmd/gencert/gencert_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"crypto/x509"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	testNames = []string{
+		"piraeus-operator-webhook-service.piraeus-datastore.svc",
+		"piraeus-operator-webhook-service.piraeus-datastore.svc.cluster.local",
+	}
+	testCert = x509.Certificate{
+		DNSNames:  testNames,
+		NotAfter:  time.Date(2023, 6, 21, 13, 14, 15, 0, time.UTC),
+		NotBefore: time.Date(2022, 6, 21, 13, 14, 15, 0, time.UTC),
+	}
+)
+
+func TestNeedsRenewIn(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name          string
+		expectedNames []string
+		now           time.Time
+		expected      time.Duration
+	}{
+		{
+			name:          "all-valid",
+			expectedNames: testNames,
+			now:           time.Date(2023, 5, 21, 13, 14, 15, 0, time.UTC),
+			expected:      17 * 24 * time.Hour,
+		},
+		{
+			name:          "names-invalid",
+			expectedNames: append(testNames, "test2"),
+			now:           time.Date(2023, 5, 21, 13, 14, 15, 0, time.UTC),
+			expected:      0,
+		},
+		{
+			name:          "before-valid-date",
+			expectedNames: testNames,
+			now:           time.Date(2022, 6, 21, 13, 14, 14, 0, time.UTC),
+			expected:      0,
+		},
+		{
+			name:          "after-valid-date",
+			expectedNames: testNames,
+			now:           time.Date(2023, 6, 21, 13, 14, 15, 1, time.UTC),
+			expected:      -14*24*time.Hour - 1*time.Nanosecond,
+		},
+	}
+
+	for i := range testcases {
+		tcase := &testcases[i]
+		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := NeedsRenewIn(&testCert, tcase.expectedNames, tcase.now)
+			assert.Equal(t, tcase.expected, actual)
+		})
+	}
+}

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -21,90 +21,35 @@ resources:
 - ../rbac
 - ../manager
 - ../webhook
-- ../certmanager
+- ../gencert
 
 patches:
 - path: manager_webhook_patch.yaml
-- path: webhookcainjection_patch.yaml
-# - path: manager_auth_proxy_patch.yaml
 
 replacements:
 - source:
-    fieldPath: metadata.namespace
     kind: Service
     name: webhook-service
   targets:
   - fieldPaths:
-    - spec.dnsNames.0
-    options:
-      delimiter: .
-      index: 1
+    - spec.template.spec.containers.[name=gencert].env.[name=WEBHOOK_SERVICE_NAME].value
     select:
-      group: cert-manager.io
-      kind: Certificate
-      name: serving-cert
-      namespace: system
-      version: v1
-  - fieldPaths:
-    - spec.dnsNames.1
-    options:
-      delimiter: .
-      index: 1
-    select:
-      group: cert-manager.io
-      kind: Certificate
-      name: serving-cert
-      namespace: system
-      version: v1
+      kind: Deployment
+      name: gencert
 - source:
-    kind: Service
-    name: webhook-service
+    kind: ValidatingWebhookConfiguration
+    name: validating-webhook-configuration
   targets:
   - fieldPaths:
-    - spec.dnsNames.0
-    options:
-      delimiter: .
+    - spec.template.spec.containers.[name=gencert].env.[name=WEBHOOK_CONFIGURATION_NAME].value
     select:
-      group: cert-manager.io
-      kind: Certificate
-      name: serving-cert
-      namespace: system
-      version: v1
+      kind: Deployment
+      name: gencert
   - fieldPaths:
-    - spec.dnsNames.1
-    options:
-      delimiter: .
+    - rules.0.resourceNames.0
     select:
-      group: cert-manager.io
-      kind: Certificate
-      name: serving-cert
-      namespace: system
-      version: v1
-- source:
-    fieldPath: metadata.namespace
-    kind: Certificate
-    name: serving-cert
-  targets:
-  - fieldPaths:
-    - metadata.annotations.[cert-manager.io/inject-ca-from]
-    options:
-      delimiter: /
-    select:
-      kind: ValidatingWebhookConfiguration
-      name: validating-webhook-configuration
-- source:
-    fieldPath: metadata.name
-    kind: Certificate
-    name: serving-cert
-  targets:
-  - fieldPaths:
-    - metadata.annotations.[cert-manager.io/inject-ca-from]
-    options:
-      delimiter: /
-      index: 1
-    select:
-      kind: ValidatingWebhookConfiguration
-      name: validating-webhook-configuration
+      kind: ClusterRole
+      name: gencert
 - source:
     fieldPath: metadata.name
     kind: ConfigMap

--- a/config/gencert/gencert.yaml
+++ b/config/gencert/gencert.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gencert
+  labels:
+    app.kubernetes.io/component: piraeus-operator-gencert
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: piraeus-operator-gencert
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: gencert
+      labels:
+        app.kubernetes.io/component: piraeus-operator-gencert
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - command:
+            - /gencert
+          args:
+            - --leader-elect
+            - --namespace=$(NAMESPACE)
+            - --webhook-configuration-name=$(WEBHOOK_CONFIGURATION_NAME)
+            - --webhook-service-name=$(WEBHOOK_SERVICE_NAME)
+            - --webhook-tls-secret-name=$(WEBHOOK_TLS_SECRET_NAME)
+          image: controller:latest
+          name: gencert
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: WEBHOOK_CONFIGURATION_NAME
+              value: validating-webhook-configuration
+            - name: WEBHOOK_SERVICE_NAME
+              value: webhook-service
+            - name: WEBHOOK_TLS_SECRET_NAME
+              value: webhook-server-cert
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 50m
+              memory: 128Mi
+            requests:
+              cpu: 5m
+              memory: 32Mi
+      serviceAccountName: gencert
+      terminationGracePeriodSeconds: 10

--- a/config/gencert/kustomization.yaml
+++ b/config/gencert/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - gencert.yaml
+  - rbac.yaml

--- a/config/gencert/rbac.yaml
+++ b/config/gencert/rbac.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gencert
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gencert
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gencert
+subjects:
+  - kind: ServiceAccount
+    name: gencert
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gencert
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gencert
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gencert
+subjects:
+  - kind: ServiceAccount
+    name: gencert
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gencert
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    resourceNames:
+      - validating-webhook-configuration
+    verbs:
+      - get
+      - list
+      - watch
+      - update

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
-- auth_proxy_service.yaml
-- auth_proxy_role.yaml
-- auth_proxy_role_binding.yaml
-- auth_proxy_client_clusterrole.yaml
+#- auth_proxy_service.yaml
+#- auth_proxy_role.yaml
+#- auth_proxy_role_binding.yaml
+#- auth_proxy_client_clusterrole.yaml

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -9,3 +9,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
+- kind: ServiceAccount
+  name: gencert

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,3 +14,7 @@ How-To Guides show you how to configure a specific aspect or achieve a specific 
 
 The API Reference for the Piraeus Operator. Contains documentation of the LINSTOR related resources that the user can
 modify or observe.
+
+### [Understanding Piraeus Datastore](./explanation)
+
+These documents explain how Piraeus Datastore works, and why it works the way it does.

--- a/docs/explanation/README.md
+++ b/docs/explanation/README.md
@@ -1,0 +1,7 @@
+# Understanding Piraeus Datastore
+
+The following documents explain how Piraeus Datastore works, and why it works the way it does.
+
+### [Understanding Piraeus Datastore Components](./components.md)
+
+A short introduction for every component of Piraeus Datastore.

--- a/docs/explanation/components.md
+++ b/docs/explanation/components.md
@@ -1,0 +1,81 @@
+# Understanding Piraeus Datastore Components
+
+Piraeus Datastore consists of several different components. Each component runs as a separate Deployment, DaemonSet or
+plain Pod.
+
+All Pods are labelled according to their component. You can check the Pods running in your own cluster by
+running the following `kubectl` command:
+
+```
+$ kubectl get pods '-ocustom-columns=NAME:.metadata.name,COMPONENT:.metadata.labels.app\.kubernetes\.io/component'
+NAME                                                   COMPONENT
+ha-controller-vd82w                                    ha-controller
+k8s-10.test                                            linstor-satellite
+linstor-controller-6c8f8dc47-cm8hr                     linstor-controller
+linstor-csi-controller-59b9968b86-ftl76                linstor-csi-controller
+linstor-csi-node-hcmk9                                 linstor-csi-node
+piraeus-operator-controller-manager-6dcfcb4568-6jntp   piraeus-operator
+piraeus-operator-gencert-59449cb449-nzg6z              piraeus-operator-gencert
+```
+
+# `piraeus-operator`
+
+The Piraeus Operator creates and maintains the other components, except for the `piraeus-operator-gencert` component.
+
+Along with deploying the needed Kubernetes resources, it maintains the LINSTOR® Cluster state by:
+
+* Registering satellites
+* Creating storage pools
+* Maintaining node labels
+
+# `piraeus-operator-gencert`
+
+The "generate certificate" Pod creates and maintains the TLS key and certificate used by the Piraeus Operator.
+The TLS secret, named `webhook-server-cert`, is needed to start the Piraeus Operator Pod. In addition, this Pod
+keeps the `ValidatingWebhookConfiguration` for the Piraeus Operator up-to-date.
+
+The Piraeus Operator needs a TLS certificate to serve the validation endpoint for the custom resources it maintains.
+
+Historically, TLS certificates where created by `cert-manager`. This was removed to reduce the number of dependencies
+for deploying Piraeus Datastore.
+
+# `linstor-controller`
+
+The LINSTOR Controller is responsible for resource placement, resource configuration, and orchestration of any
+operational processes that require a view of the whole cluster. It maintains a database of all the configuration
+information for the whole cluster, stored as Kubernetes objects.
+
+The LINSTOR Controller connects to the LINSTOR Satellites and sends them instructions for achieving the desired cluster
+state.
+
+It provides an external API used by LINSTOR CSI and Piraeus Operator to change the cluster state.
+
+# `linstor-satellite`
+
+The LINSTOR Satellite service runs on each node. It acts as the local configuration agent for LINSTOR managed storage.
+It is stateless and receives all the information it needs from the LINSTOR Controller.
+
+Satellites are started as plain Pods, managed by the Piraeus Operator. Using plain Pods, we can guarantee a stable
+hostname for the Pod on every node, which is requirement of LINSTOR. It also enables having per-node configuration
+and customization of the Satellite Pods.
+
+# `linstor-csi-controller`
+
+The LINSTOR CSI Controller Pod creates, modifies and deletes volumes and snapshots. It translates the state of Kubernetes
+resources (`StorageClass`, `PersistentVolumeClaims`, `VolumeSnapshots`) into their equivalent in LINSTOR.
+
+# `linstor-csi-node`
+
+The LINSTOR CSI Node Pods execute mount and unmount operations. Mount and Unmount are initiated by kubelet before
+starting a Pod with a Piraeus volume.
+
+They are deployed as a DaemonSet on every node in the cluster by default. There needs to be a LINSTOR Satellite running
+on the same node as a CSI Node Pod.
+
+# `ha-controller`
+
+The Piraeus High Availability Controller will speed up the fail-over process for stateful workloads using Piraeus for
+storage.
+
+It is deployed on every node in the cluster and listens for DRBD® events to detect storage failures on other nodes. It
+evicts Pods when it detects that the storage on their node is inaccessible.

--- a/docs/tutorial/get-started.md
+++ b/docs/tutorial/get-started.md
@@ -4,11 +4,6 @@ Learn about the ways to get started with Piraeus Datastore by deploying Piraeus 
 
 ## Prerequisites
 
-* [Install `cert-manager`](https://cert-manager.io/docs/installation/). You can quickly install `cert-manager` by
-  applying its static manifests:
-  ```
-  kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
-  ```
 * [Install the Linux kernel headers on the hosts](./install-kernel-headers.md).
 * [Install `kubectl` version `>= 1.22`](https://kubernetes.io/docs/tasks/tools/)
 

--- a/pkg/vars/vars.go
+++ b/pkg/vars/vars.go
@@ -9,8 +9,9 @@ var (
 )
 
 const (
-	FieldOwner         = Domain + "/operator"
-	ApplyAnnotation    = Domain + "/last-applied"
-	ManagedByLabel     = Domain + "/managed-by"
-	SatelliteFinalizer = Domain + "/satellite-protection"
+	FieldOwner              = Domain + "/operator"
+	ApplyAnnotation         = Domain + "/last-applied"
+	ManagedByLabel          = Domain + "/managed-by"
+	SatelliteFinalizer      = Domain + "/satellite-protection"
+	GenCertLeaderElectionID = OperatorName + "-gencert"
 )


### PR DESCRIPTION
Having a dependency on cert-manager prevents Piraeus from working "out of the box". While the validation webhook is optional, it does improve the user experience, so we want to keep it.

The solution is to have our own self-contained provisioning service for the webhook. This is deployed by default and ensures we have a valid TLS secret and up-to-date validation webhook config.