### PR TITLE
csi: enable metrics endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Configure Monitoring for CSI Components if monitoring is enabled.
+
 ### Fixed
 
 - A crash caused by insufficient permissions on the LINSTOR Controller.
+- Invalid use of "HTTP" protocol specification for prometheus monitoring, use "http" instead.
 
 ## [v1.10.5] - 2023-06-20
 

--- a/charts/piraeus/templates/operator-serviceaccount.yaml
+++ b/charts/piraeus/templates/operator-serviceaccount.yaml
@@ -98,6 +98,7 @@ rules:
       - monitoring.coreos.com
     resources:
       - servicemonitors
+      - podmonitors
     verbs:
       - get
       - watch

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/piraeusdatastore/piraeus-operator/pkg/apis"
 	"github.com/piraeusdatastore/piraeus-operator/pkg/controller"
 	"github.com/piraeusdatastore/piraeus-operator/pkg/controller/linstorcontroller"
+	"github.com/piraeusdatastore/piraeus-operator/pkg/controller/linstorcsidriver"
 	"github.com/piraeusdatastore/piraeus-operator/pkg/controller/linstorsatelliteset"
 	kubeSpec "github.com/piraeusdatastore/piraeus-operator/pkg/k8s/spec"
 )
@@ -71,6 +72,7 @@ func main() {
 
 	linstorcontroller.CreateMonitoring = createMonitoring
 	linstorsatelliteset.CreateMonitoring = createMonitoring
+	linstorcsidriver.CreateMonitoring = createMonitoring
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 

--- a/deploy/piraeus/templates/operator-serviceaccount.yaml
+++ b/deploy/piraeus/templates/operator-serviceaccount.yaml
@@ -214,6 +214,7 @@ rules:
       - monitoring.coreos.com
     resources:
       - servicemonitors
+      - podmonitors
     verbs:
       - get
       - watch

--- a/pkg/k8s/monitoring/monitoring.go
+++ b/pkg/k8s/monitoring/monitoring.go
@@ -31,7 +31,7 @@ func MonitorForService(service *corev1.Service) *monitoringv1.ServiceMonitor {
 		endpoints[i] = monitoringv1.Endpoint{
 			Port:     port.Name,
 			Interval: "30s",
-			Scheme:   string(corev1.URISchemeHTTP),
+			Scheme:   "http",
 		}
 	}
 


### PR DESCRIPTION
If monitoring is enabled, also enable metrics on the CSI sidecars and create the necessary pod monitor resource for automatic scraping by prometheus.

While at it, also fix an issue with an invalid protocol specification for existing monitoring resources.