### PR TITLE
added image packing scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,3 +102,27 @@ deploy/piraeus:
 	mkdir -p "$@"
 	helm template -n default piraeus-op charts/piraeus --set stork.schedulerTag=v1.18.0 --set operator.controller.masterPassphrase=changemeplease --output-dir deploy >/dev/null
 	deploy/create-kustomization.bash
+
+list-images:
+	./list_images.sh
+
+pull-images:
+	./list_images.sh | xargs -tI % docker pull %
+
+save-images: pull-images
+	rm -vf ./piraeus_images.tgz
+	docker save $$( ./list_images.sh ) \
+	| gzip > ./piraeus_images.tgz
+	ls -lh ./piraeus_images.tgz
+
+list-images.cn:
+	./list_images.sh ./charts/piraeus/values.cn.yaml
+
+pull-images.cn:
+	./list_images.sh ./charts/piraeus/values.cn.yaml | xargs -tI % docker pull %
+
+save-images.cn: pull-images.cn
+	rm -vf ./piraeus_images.tgz
+	docker save $$( ./list_images.sh ./charts/piraeus/values.cn.yaml ) \
+	| gzip > ./piraeus_images.tgz
+	ls -lh ./piraeus_images.tgz

--- a/list_images.sh
+++ b/list_images.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+values_file=${1:-./charts/piraeus/values.yaml}
+[ ! -f "$values_file" ] && echo Cannot find file $values_file &&  exit 1
+
+# check if yq is installed
+if ! yq -V > /dev/null; then
+    echo Must Install yq to handle yaml files
+    exit 1
+fi
+
+# print etcd image
+cat "$values_file" | yq e '.etcd.image | (.repository, .tag)' | sed 'N;s/\n/:/'
+
+# print scheduler image
+sched_img=$( cat "$values_file" | yq e .stork.schedulerImage )
+sched_tag=$( cat "$values_file" | yq e .stork.schedulerTag )
+if [ -z "$sched_tag" ]; then
+    sched_tag=$(kubectl version -o yaml 2>/dev/null | yq .serverVersion.gitVersion)
+fi
+[ -z "$sched_tag" ] || echo "${sched_img}:${sched_tag}"
+
+# print other images
+for i in .stork.storkImage \
+         .csi.pluginImage \
+         .csi.csiAttacherImage \
+         .csi.csiLivenessProbeImage \
+         .csi.csiNodeDriverRegistrarImage \
+         .csi.csiProvisionerImage \
+         .csi.csiSnapshotterImage \
+         .csi.csiResizerImage \
+         .operator.image \
+         .operator.controller.controllerImage \
+         .operator.satelliteSet.satelliteImage \
+         .operator.satelliteSet.monitoringImage \
+         .operator.satelliteSet.kernelModuleInjectionImage \
+         .haController.image \
+         ; do
+    cat "$values_file" | yq e $i
+done | sort -u


### PR DESCRIPTION
Add a script to download and tar all the images for air-gapped deployment. The core script is list_images.sh which reads image URLs from chart values.yaml. It also makes a best effort to determine the kube-scheduler version from the `kubectl version` output:

```yaml
#print scheduler image
sched_img=$( cat "$values_file" | yq e .stork.schedulerImage )
sched_tag=$( cat "$values_file" | yq e .stork.schedulerTag )
if [ -z "$sched_tag" ]; then
    sched_tag=$(kubectl version -o yaml 2>/dev/null | yq .serverVersion.gitVersion)
fi
[ -z "$sched_tag" ] || echo "${sched_img}:${sched_tag}"
```