### PR TITLE
satellite: restart terminated pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - A crash caused by insufficient permissions on the LINSTOR Controller.
+- Satellite will now restart if the Pods terminated for unexpected reasons.
 
 ## [v2.1.1] - 2023-05-24
 


### PR DESCRIPTION
We expect satellite to be recreated when they shut down for any reason, as long as they are still on a matching node.

This was not always the case, as the Pod could get into a terminated state, which even "restartPolicy: Always" did not cover. This may happen when the Pod is shut down forcefully during node shutdown.

This patch modifies the PodPatcher to also consider the phase of the old Pod when deciding if a delete+create operation is necessary.