### PR TITLE
Introducing `piraeus.io/evacuate` Taint for Node Draining Support

### DIFF
--- a/hack/crd-charts-copy.sh
+++ b/hack/crd-charts-copy.sh
@@ -1,5 +1,13 @@
 #!/bin/sh -e
 
 echo ' {{ if .Values.installCRDs }}'
-find ./config/crd/bases -type f | sort | xargs --no-run-if-empty cat
+
+# Find and sort the files
+files=$(find ./config/crd/bases -type f | sort)
+
+# Check if files are empty
+if [ -n "$files" ]; then
+    cat $files
+fi
+
 echo '{{ end }}'

--- a/internal/controller/linstorsatellite_controller.go
+++ b/internal/controller/linstorsatellite_controller.go
@@ -446,6 +446,9 @@ func (r *LinstorSatelliteReconciler) evacuateNode(ctx context.Context, lc *linst
 
 	findMatchingEvacuatedResource := func(nodeRes lclient.ResourceWithVolumes) *lclient.ResourceWithVolumes {
 		for _, evacuatedRes := range evacuatedResources {
+			if utils.IsDisklessResource(evacuatedRes) {
+				continue
+			}
 			if nodeRes.Name == evacuatedRes.Name && evacuatedRes.Props[NodeEvacuationProp] == node.Name {
 				return &evacuatedRes
 			}
@@ -527,6 +530,9 @@ func (r *LinstorSatelliteReconciler) undoNodeEvacuation(ctx context.Context, lc 
 	})
 
 	for _, resource := range res {
+		if resource.State == nil || resource.State.InUse == nil {
+			continue
+		}
 		// If an evacuated resource is in use, it means we can delete the original resource.
 		// We also update the resource properties to remove the NodeEvacuationProp
 		// as we've just deleted the original resource it was pointing to.

--- a/pkg/utils/node_evacuation.go
+++ b/pkg/utils/node_evacuation.go
@@ -1,0 +1,32 @@
+package utils
+
+import lclient "github.com/LINBIT/golinstor/client"
+
+func IsUpToDateResource(res lclient.ResourceWithVolumes) bool {
+	for _, volume := range res.Volumes {
+		if volume.State.DiskState != "UpToDate" {
+			return false
+		}
+	}
+	return true
+}
+
+func IsDisklessResource(res lclient.ResourceWithVolumes) bool {
+	// Skip Diskless pools
+	for _, volume := range res.Volumes {
+		if volume.State.DiskState != "Diskless" && volume.State.DiskState != "TieBreaker" {
+			return false
+		}
+	}
+	return true
+}
+
+func IsTieBreakerResource(res lclient.ResourceWithVolumes) bool {
+	// Skip Diskless pools
+	for _, volume := range res.Volumes {
+		if volume.State.DiskState == "TieBreaker" {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
I'm pleased to share my first contribution, focused on enhancing node draining in Linstor/Piraeus clusters. Feedback welcome on areas that could be further improved / optimised or things I might have overlooked.

**Note**: This PR is not yet complete. While the core functionality is in place, documentation should be added once the initial review is done and any suggested changes are incorporated.

### Summary:
This pull request introduces a new annotation, `linstor.linbit.com/prepare-for-removal`, for Kubernetes nodes. When a node is annotated with this label, the `LinstorSatelliteReconciler` prepares the node for draining by auto placing additional replicas for all its resources.

The new annotation serves a crucial role in scenarios where a resource does not already have replicas. By creating additional replicas, it ensures that data remains available even when the original node is offline and allows the workload to be migrated in cases where `allowRemoteVolumeAccess: false` is defined. This feature is also particularly useful as Piraeus currently lacks (please correct me if i'm wrong) an auto-healing functionality to maintain the replica count automatically in case a node is lost.

The annotation provides a simple and declarative way to prepare nodes for maintenance or decommissioning while enhancing data availability. 

### Required Components:
For this feature to fully function and allow Kubernetes to reschedule the workload to a new node, the Persistent Volume (PV) needs to be updated. This is handled by the `linstor-affinity-controller`, which must be installed on the cluster. The controller updates the PV to enable the Pod to move to a new node, complementing the node draining and undo-draining functionalities introduced by this pull request.

### Changes:

1. **New Annotation**: 
   - `linstor.linbit.com/prepare-for-removal`: When added to a node, it triggers the `prepareNodeForDraining` method. When removed it will trigger the `undoNodeDrainingPreparation` method to reverse the changes.

2. **`prepareNodeForDraining` Method**: 
   - Fetches the list of resources on the annotated node.
   - Autoplaces an additional replica for each resource.
   - Updates node properties to mark it for removal and disable new resource placements.

3. **`undoNodeDrainingPreparation` Method**: 
   - Counterpart to `prepareNodeForDraining`.
   - Deletes either the newest replica or the one on the annotated node, depending on which resource is currently in use.
   - Removes the node properties set during the preparation for draining.

### Additional Information:
- The current implementation necessitates an extra API call and logic to ascertain the location of the newly-created replica. This is because the `lc.Resources.Autoplace` method does not return this specific metadata. As per the [Swagger documentation for the Linstor API](https://app.swaggerhub.com/apis-docs/Linstor/Linstor/1.10.0#/developers/resourceAutoplace), the `obj_refs` field could potentially contain the required information. To streamline this process, the [Golinstor library](https://github.com/LINBIT/golinstor) would need to be updated to accommodate these changes.