### PR TITLE
ci: group go mod updates by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
       - WanzenBug
     schedule:
       interval: "weekly"
+    groups:
+      gomod:
+        patterns:
+          - "*" # Include all go mod update in one PR
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
This reduced the noise of pull requests when updates are available.