### PR TITLE
Revert "csi: remove deprecated feature flag"

### DIFF
--- a/pkg/resources/cluster/csi/csi-controller-deployment.yaml
+++ b/pkg/resources/cluster/csi/csi-controller-deployment.yaml
@@ -107,6 +107,7 @@ spec:
             - '--csi-address=$(ADDRESS)'
             - '--timeout=1m'
             - '--default-fstype=ext4'
+            - '--feature-gates=Topology=true'
             - '--leader-election=true'
             - '--leader-election-namespace=$(NAMESPACE)'
             - '--enable-capacity'


### PR DESCRIPTION
This reverts commit 0b7273a337a7b2c2b621751ba54f98764e9cb134.

The commit mistakenly assumes that the topology feature gate is generally available and enabled by default. While it is marked "GA", it's still not enabled by default (leading to the question on why it's marked GA then).