### PR TITLE
tests: fix comparison of linstor client objects

### DIFF
--- a/pkg/linstorhelper/client_test.go
+++ b/pkg/linstorhelper/client_test.go
@@ -192,9 +192,16 @@ func TestNewClientForCluster(t *testing.T) {
 				require.NoError(t, err)
 
 				// need to use go-cmp here, as that can handle the embedded x509.CertPool comparison.
-				diff := cmp.Diff(&linstorhelper.Client{Client: *expected}, actual, cmp.Exporter(func(r reflect.Type) bool {
-					return true
-				}))
+				diff := cmp.Diff(*expected, actual.Client,
+					// Compare all unexported fields, too
+					cmp.Exporter(func(r reflect.Type) bool {
+						return true
+					}),
+					// But ignore all logging
+					cmp.Comparer(func(a, b lapi.Logger) bool {
+						return true
+					}),
+				)
 				if diff != "" {
 					assert.Fail(t, diff)
 				}


### PR DESCRIPTION
To test our helper methods for constructing a client we do a deep compare of the client struct. This needs to include unexported fields, as we otherwise can't compare important fields such as the TLS certificates used.

This broke with recent enough go versions, as it would report the following differences:

```
	log: log.Logger{
		outMu:     {},
		out:       &os.File{file: &{pfd: {Sysfd: 2, isBlocking: 1, IsStream: true, ZeroReadIsEOF: true, ...}, name: "/dev/stderr", stdoutOrErr: true}},
-		prefix:    atomic.Pointer[string]{v: ⟪0xc0002ce070⟫},
+		prefix:    atomic.Pointer[string]{v: ⟪0xc0002ce060⟫},
		flag:      {},
		isDiscard: {},
	},
```

Because we don't care about the logging config, we just assume that any logger is equal.