### PR TITLE
deploy: add HA Controller taints to Operators' tolerations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * LINSTOR 1.25.0
   * DRBD Reactor 1.3.0
   * Latest CSI sidecars
+- Add a default toleration for the HA Controller taints to the operator.
 
 ## [v2.2.0] - 2023-08-31
 

--- a/charts/piraeus/templates/deployment.yaml
+++ b/charts/piraeus/templates/deployment.yaml
@@ -92,6 +92,8 @@ spec:
         runAsNonRoot: true
       serviceAccountName: {{ include "piraeus-operator.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
       volumes:
       - name: cert
         secret:

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -86,7 +86,11 @@ podSecurityContext: {}
 
 nodeSelector: { }
 
-tolerations: [ ]
+tolerations:
+  - key: drbd.linbit.com/lost-quorum
+    effect: NoSchedule
+  - key: drbd.linbit.com/force-io-error
+    effect: NoSchedule
 affinity: { }
 
 podDisruptionBudget:

--- a/config/gencert/gencert.yaml
+++ b/config/gencert/gencert.yaml
@@ -65,3 +65,8 @@ spec:
               memory: 32Mi
       serviceAccountName: gencert
       terminationGracePeriodSeconds: 10
+      tolerations:
+        - key: drbd.linbit.com/lost-quorum
+          effect: NoSchedule
+        - key: drbd.linbit.com/force-io-error
+          effect: NoSchedule

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -67,3 +67,8 @@ spec:
             memory: 64Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
+      tolerations:
+        - key: drbd.linbit.com/lost-quorum
+          effect: NoSchedule
+        - key: drbd.linbit.com/force-io-error
+          effect: NoSchedule


### PR DESCRIPTION
If the whole cluster reboots, it is very likely that all cluster nodes get tainted by the HA Controller. Because the Operator does not start, it can't get the satellites up and running, and we can never clear the taints.

The fix is to include the tolerations in the default deployment for the operator (and gencert, too).