### PR TITLE
[v1] chart: fix CSI values

### DIFF
--- a/charts/piraeus/templates/operator-csi-driver.yaml
+++ b/charts/piraeus/templates/operator-csi-driver.yaml
@@ -45,7 +45,7 @@ spec:
   priorityClassName: {{ .Values.priorityClassName | default "" | quote }}
   controllerReplicas: {{ .Values.csi.controllerReplicas }}
 {{- if .Values.csi.controllerStrategy }}
-  controllerStrategy: {{ .Values.csi.controllerStrategy }}
+  controllerStrategy: {{ .Values.csi.controllerStrategy | toJson}}
 {{- end }}
   controllerEndpoint: {{ template "controller.endpoint" . }}
   nodeAffinity: {{ .Values.csi.nodeAffinity | toJson }}
@@ -61,10 +61,10 @@ spec:
   logLevel: {{ .Values.csi.logLevel | quote }}
   {{- end }}
   {{- if .Values.csi.controllerSidecars }}
-  controllerSidecars: {{ .Values.csi.controllerSidecars | toJson }}
+  sidecars: {{ .Values.csi.controllerSidecars | toJson }}
   {{- end }}
   {{- if .Values.csi.controllerExtraVolumes }}
-  controllerExtraVolumes: {{ .Values.csi.controllerExtraVolumes | toJson }}
+  extraVolumes: {{ .Values.csi.controllerExtraVolumes | toJson }}
   {{- end }}
   {{- if .Values.csi.nodeSidecars }}
   nodeSidecars: {{ .Values.csi.nodeSidecars | toJson }}


### PR DESCRIPTION
Some chart values where not applied correctly, either using the wrong names or wrong filters that lead to errors.

While the names used originally in the CR where much clearer, we don't want to introduce a breaking change, so we keep them as is.

We also don't change the helm names, as they are much more descriptive, at the cost of some potential minor confusion. This should be fine, as nobody noticed this issue until now, and probably never will.