### PR TITLE
satellite: fix pod template not working

### DIFF
--- a/pkg/merge/linstorsatelliteconfiguration.go
+++ b/pkg/merge/linstorsatelliteconfiguration.go
@@ -86,7 +86,7 @@ func ConvertTemplateToPatch(podTemplate json.RawMessage) (*piraeusv1.Patch, erro
 	}
 
 	var u unstructured.Unstructured
-	err := json.Unmarshal(podTemplate, &u)
+	err := json.Unmarshal(podTemplate, &u.Object)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert podTemplate to unstructured: %w", err)
 	}

--- a/pkg/merge/linstorsatelliteconfiguration_test.go
+++ b/pkg/merge/linstorsatelliteconfiguration_test.go
@@ -2,6 +2,7 @@ package merge_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -96,6 +97,11 @@ var (
 			},
 		},
 	}
+	Config5 = piraeusv1.LinstorSatelliteConfiguration{
+		Spec: piraeusv1.LinstorSatelliteConfigurationSpec{
+			PodTemplate: json.RawMessage(`{"spec": {"hostNetwork": true}}`),
+		},
+	}
 )
 
 func TestMergeSatelliteConfigurations(t *testing.T) {
@@ -176,6 +182,18 @@ func TestMergeSatelliteConfigurations(t *testing.T) {
 					Patches:      Config4.Spec.Patches,
 					StoragePools: Config4.Spec.StoragePools,
 					Properties:   Config4.Spec.Properties,
+				},
+			},
+		},
+		{
+			name:    "patch-convert",
+			configs: []piraeusv1.LinstorSatelliteConfiguration{Config5},
+			result: &piraeusv1.LinstorSatelliteConfiguration{
+				Spec: piraeusv1.LinstorSatelliteConfigurationSpec{
+					Patches: []piraeusv1.Patch{{
+						Target: &piraeusv1.Selector{Name: "satellite", Kind: "Pod"},
+						Patch:  "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"name\":\"satellite\"},\"spec\":{\"hostNetwork\":true}}\n",
+					}},
 				},
 			},
 		},


### PR DESCRIPTION
Unstructured resource still expect the "kind:" to be set at the root. For our template, we omit the kind and force it to be "Pod" ourselves.

This caused the podTemplate to not work as expected, as during creation of the patch the decoding into a temporary Unstructured variable failed. To fix, we directly decode into the generic backing "map[string]any".

Also add a test, so this does not go unnoticed next time.