### PR TITLE
Release 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v2.3.0] - 2023-12-05
 
 ### Added
 
@@ -779,4 +779,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v2.1.0]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.0.1...v2.1.0
 [v2.1.1]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.1.0...v2.1.1
 [v2.2.0]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.1.1...v2.2.0
-[Unreleased]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.2.0...HEAD
+[v2.3.0]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.2.0...v2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [v2.3.0] - 2023-12-05
 
 ### Added
@@ -780,3 +782,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v2.1.1]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.1.0...v2.1.1
 [v2.2.0]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.1.1...v2.2.0
 [v2.3.0]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.2.0...v2.3.0
+[Unreleased]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.3.0...HEAD

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PROJECT_NAME ?= piraeus-operator
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 2.0.0
+VERSION ?= 2.3.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ to fix issues or new software versions until a stable upgrade path to v2 is avai
 To deploy Piraeus Operator v2 from this repository, simply run:
 
 ```
-$ kubectl apply --server-side -k "https://github.com/piraeusdatastore/piraeus-operator//config/default?ref=v2"
+$ kubectl apply --server-side -k "https://github.com/piraeusdatastore/piraeus-operator//config/default?ref=v2.3.0"
 # Verify the operator is running:
 $ kubectl wait pod --for=condition=Ready -n piraeus-datastore -l app.kubernetes.io/component=piraeus-operator
 pod/piraeus-operator-controller-manager-dd898f48c-bhbtv condition met

--- a/charts/piraeus/Chart.yaml
+++ b/charts/piraeus/Chart.yaml
@@ -3,8 +3,8 @@ name: piraeus
 description: |
   The Piraeus Operator manages software defined storage clusters using LINSTOR in Kubernetes.
 type: application
-version: 2.2.0-dev
-appVersion: "v2"
+version: 2.3.0
+appVersion: "v2.3.0"
 maintainers:
   - name: Piraeus Datastore
     url: https://piraeus.io

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,7 +12,7 @@ labels:
 images:
 - name: controller
   newName: quay.io/piraeusdatastore/piraeus-operator
-  newTag: v2
+  newTag: v2.3.0
 
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,7 +12,7 @@ labels:
 images:
 - name: controller
   newName: quay.io/piraeusdatastore/piraeus-operator
-  newTag: v2.3.0
+  newTag: v2
 
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus

--- a/docs/tutorial/get-started.md
+++ b/docs/tutorial/get-started.md
@@ -15,7 +15,7 @@ All resources needed to run Piraeus Operator are included in a single Kustomizat
 Install Piraeus Operator by running:
 
 ```bash
-$ kubectl apply --server-side -k "https://github.com/piraeusdatastore/piraeus-operator//config/default?ref=v2"
+$ kubectl apply --server-side -k "https://github.com/piraeusdatastore/piraeus-operator//config/default?ref=v2.3.0"
 namespace/piraeus-datastore configured
 ...
 ```

--- a/hack/make-release.sh
+++ b/hack/make-release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 YQ="${YQ:-yq}"
 KUSTOMIZE="${KUSTOMIZE:-kustomize}"
@@ -41,31 +41,28 @@ popd
 
 # replace deployment instructions in docs
 for FILE in ./README.md ./docs/tutorial/get-started.md ; do
-	sed -e "s/ref=v2/ref=v$VERSION/" -i "$FILE"
+	sed -e "s/ref=v[0-9\.]\+/ref=v$VERSION/" -i "$FILE"
 done
+
+# replace version in Makefile
+sed -e "s/^VERSION ?=.*/VERSION ?= $VERSION/" -i Makefile
 
 # replace chart version+appVersion
 $YQ ".version = \"$VERSION\"" -i charts/piraeus/Chart.yaml
 $YQ ".appVersion = \"v$VERSION\"" -i charts/piraeus/Chart.yaml
 
-# commit as current release + tag
+# commit as current release
+# We don't do git tag v$(VERSION) here, as the commit will change once its merged in github
 git commit -aevm "Release v$VERSION" --signoff
 
-# We don't do git tag v$(VERSION) here, as the commit will change once its merged in github
 # add "Unreleased" section at top + create comparison link against current master
 sed "s/^## \[v$VERSION\]/## [Unreleased]\n\n## [v$VERSION]/" -i CHANGELOG.md
 echo "[Unreleased]: https://github.com/piraeusdatastore/piraeus-operator/compare/v$VERSION...HEAD" >> CHANGELOG.md
 
+# Reset image version for kustomize
 pushd config/default
 $KUSTOMIZE edit set image controller="$IMG:v2"
 popd
-
-$YQ ".version = \"$VERSION-dev\"" -i charts/piraeus/Chart.yaml
-$YQ ".appVersion = \"v2\"" -i charts/piraeus/Chart.yaml
-
-for FILE in ./README.md ./docs/tutorial/get-started.md ; do
-	sed -e "s/ref=v$VERSION/ref=v2/" -i "$FILE"
-done
 
 # commit begin of new dev cycle
 git commit -aevm "Prepare next dev cycle" --signoff


### PR DESCRIPTION
Apart from the release commits, this also changes the way release script so that the instructions on the main branch always point to the latest released version. This should help users when deploying using the default instructions.