### PR TITLE
satellite: change default monitoring address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change default monitoring address for DRBD Reactor to support systems with IPv6 completely disabled.
+
 ## [v2.3.0] - 2023-12-05
 
 ### Added

--- a/pkg/resources/satellite/pod/node-config.yaml
+++ b/pkg/resources/satellite/pod/node-config.yaml
@@ -18,4 +18,4 @@ data:
   prometheus.toml: |
     [[prometheus]]
     enums = true
-    address = "[::]:9942"
+    address = ":9942"


### PR DESCRIPTION
The default monitoring address assumed a working IPv6 stack. This was not necessarily the same as working IPv6, as the address still worked for IPv4 traffic. It did not work if users disabled IPv6 completely on the kernel command line.

With DRBD Reactor 1.4.0, there is a new special address format inspired by Go, where Reactor will first try binding to IPv6 and fall back to IPv4 in case of errors.

So use this new address format by default.