### PR TITLE
Update external-snapshotter to v6.3.3

### DIFF
--- a/charts/piraeus/templates/config.yaml
+++ b/charts/piraeus/templates/config.yaml
@@ -78,7 +78,7 @@ data:
         tag: v3.6.2
         image: csi-provisioner
       csi-snapshotter:
-        tag: v6.3.2
+        tag: v6.3.3
         image: csi-snapshotter
       csi-resizer:
         tag: v1.9.2

--- a/config/manager/0_sig_storage_images.yaml
+++ b/config/manager/0_sig_storage_images.yaml
@@ -11,7 +11,7 @@ components:
     tag: v3.6.2
     image: csi-provisioner
   csi-snapshotter:
-    tag: v6.3.2
+    tag: v6.3.3
     image: csi-snapshotter
   csi-resizer:
     tag: v1.9.2


### PR DESCRIPTION
New external-snapshotter version contains an important fix to replaces the update calls for VolumeSnapshot and VolumeSnapshotContent with JSON patch calls. Addresses the "object has been modified" issue we see a lot in the snapshot-controller/snapshotter. See https://github.com/kubernetes-csi/external-snapshotter/pull/974.