### PR TITLE
satellite: ensure DRBD 9 is loaded

### DIFF
--- a/pkg/resources/satellite/satellite/daemonset.yaml
+++ b/pkg/resources/satellite/satellite/daemonset.yaml
@@ -25,6 +25,8 @@ spec:
           env:
             - name: LB_FAIL_IF_USERMODE_HELPER_NOT_DISABLED
               value: "yes"
+            - name: LB_DRBD_MIN_LOADED_VERSION
+              value: "9"
             - name: LB_SELINUX_AS
               value: "modules_object_t"
           securityContext:


### PR DESCRIPTION
The upcoming DRBD images will all support checking the currently loaded DRBD version.

On some systems (Ubuntu or Oracle), it can happen quite easily that users load DRBD 8 on boot. This than causes obscure issues, such as the HA Controller complaining about missing "--json" flag on drbdsetup, or LINSTOR no support DRBD Layers.

With this change, the issue should be made more obvious.