### PR TITLE
extras: monitoring fixes

### DIFF
--- a/config/extras/monitoring/kustomization.yaml
+++ b/config/extras/monitoring/kustomization.yaml
@@ -5,11 +5,12 @@ resources:
   - linstor-satellite-monitor.yaml
   - alerts.yaml
 
+namespace: piraeus-datastore
+
 generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:
   - name: piraeus-datastore-dashboard
-    namespace: prometheus
     options:
       labels:
         grafana_dashboard: "1"


### PR DESCRIPTION
Use the same default namespace to deploy monitoring resources as the main operator deployment.

Also, do not force the grafana dashboard into a different namespace: the grafana container will watch all namespaces by default.