### PR TITLE
satellite: rename generated Certificate resources

### DIFF
--- a/internal/controller/linstorsatellite_controller.go
+++ b/internal/controller/linstorsatellite_controller.go
@@ -629,14 +629,8 @@ var SatelliteNameReplacements = []kusttypes.ReplacementField{
 		},
 		Targets: []*kusttypes.TargetSelector{
 			{
-				// Sets the name of certificate to "<node-name>-tls"
-				Select:     &kusttypes.Selector{ResId: resid.NewResId(resid.NewGvk("cert-manager.io", "v1", "Certificate"), "tls")},
-				FieldPaths: []string{"metadata.name"},
-				Options:    &kusttypes.FieldOptions{Delimiter: "-", Index: -1},
-			},
-			{
 				// Sets the domain name of the issued certificate to "<node-name>"
-				Select:     &kusttypes.Selector{ResId: resid.NewResId(resid.NewGvk("cert-manager.io", "v1", "Certificate"), "tls")},
+				Select:     &kusttypes.Selector{ResId: resid.NewResId(resid.NewGvk("cert-manager.io", "v1", "Certificate"), "linstor-satellite")},
 				FieldPaths: []string{"spec.dnsNames.0"},
 			},
 		},

--- a/pkg/resources/satellite/patches/internal-tls-cert-manager.yaml
+++ b/pkg/resources/satellite/patches/internal-tls-cert-manager.yaml
@@ -3,12 +3,12 @@
     group: cert-manager.io
     version: v1
     kind: Certificate
-    name: tls
+    name: linstor-satellite
   patch: |
     apiVersion: cert-manager.io/v1
     kind: Certificate
     metadata:
-      name: tls
+      name: linstor-satellite
     spec:
       secretName: $LINSTOR_INTERNAL_TLS_SECRET_NAME
       issuerRef: $LINSTOR_INTERNAL_TLS_CERT_ISSUER

--- a/pkg/resources/satellite/satellite/cert-manager/certificate.yaml
+++ b/pkg/resources/satellite/satellite/cert-manager/certificate.yaml
@@ -2,7 +2,7 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: tls
+  name: linstor-satellite
 spec:
   issuerRef:
     name: FILLME


### PR DESCRIPTION
Since switching to the daemonset deployment method, generated Certificate resources had double-barreled names: `<node>-tls.<node>`.

With this commit, we switch to using `linstor-satellite.<node>` as name for the certificate: this matches the other satellite resource names more closely.

We do not change the name of the generated Secret resources, as those are also used when users do their certificate management manually, so the default names of `<node>-tls` are part of the public API, in a way.