### PR TITLE
Satellite daemonset fixes

### DIFF
--- a/pkg/resources/satellite/satellite/daemonset.yaml
+++ b/pkg/resources/satellite/satellite/daemonset.yaml
@@ -69,6 +69,10 @@ spec:
           env:
             - name: JAVA_OPTS
               value: -Djdk.tls.acknowledgeCloseNotify=true
+            - name: LB_FORCE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           securityContext:
             readOnlyRootFilesystem: true
             privileged: true

--- a/pkg/resources/satellite/satellite/daemonset.yaml
+++ b/pkg/resources/satellite/satellite/daemonset.yaml
@@ -176,6 +176,10 @@ spec:
           emptyDir: { }
       restartPolicy: Always
       tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
         - key: drbd.linbit.com/lost-quorum
           effect: NoSchedule
         - key: drbd.linbit.com/force-io-error


### PR DESCRIPTION
* Also on control-plane nodes: this is to stay compatible with existing deployments.
* Force `uname -n` to return the "root" node name. This requires the change in https://github.com/piraeusdatastore/piraeus/pull/172 with a longer explanation on why and how.