### PR TITLE
ci: run basic tests for promised lower compat version

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,3 +33,13 @@ jobs:
       - uses: actions/setup-python@v5
       - name: Run pre-commit checks on changes files
         uses: pre-commit/action@v3.0.1
+  compat-tests:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+      - name: Run compat test
+        run: |
+          make compat-test

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,10 @@ endif
 # Image URL to use all building/pushing image targets
 IMG ?= quay.io/piraeusdatastore/piraeus-operator:v$(VERSION)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.28
+ENVTEST_K8S_VERSION = 1.29
+# ENVTEST_K8S_COMPAT_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary for
+# checking compatibility with older kubernetes versions.
+ENVTEST_K8S_COMPAT_VERSION = 1.20
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -111,6 +114,10 @@ vet: ## Run go vet against code.
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
+
+.PHONY: compat-test
+compat-test: manifests generate fmt vet envtest ## Run tests.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_COMPAT_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./...
 
 ##@ Build
 

--- a/internal/controller/linstorsatellite_test.go
+++ b/internal/controller/linstorsatellite_test.go
@@ -92,7 +92,7 @@ var _ = Describe("LinstorSatelliteReconciler", func() {
 				Spec: piraeusiov1.LinstorSatelliteSpec{
 					InternalTLS: &piraeusiov1.TLSConfigWithHandshakeDaemon{},
 				},
-			}, client.Apply, client.FieldOwner("test"))
+			}, client.Apply, client.FieldOwner("test"), client.ForceOwnership)
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func(g Gomega) {
@@ -112,7 +112,7 @@ var _ = Describe("LinstorSatelliteReconciler", func() {
 						TLSHandshakeDaemon: true,
 					},
 				},
-			}, client.Apply, client.FieldOwner("test"))
+			}, client.Apply, client.FieldOwner("test"), client.ForceOwnership)
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func(g Gomega) {
@@ -138,7 +138,7 @@ var _ = Describe("LinstorSatelliteReconciler", func() {
 						},
 					},
 				},
-			}, client.Apply, client.FieldOwner("test"))
+			}, client.Apply, client.FieldOwner("test"), client.ForceOwnership)
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func(g Gomega) {
@@ -164,7 +164,7 @@ var _ = Describe("LinstorSatelliteReconciler", func() {
 						},
 					},
 				},
-			}, client.Apply, client.FieldOwner("test"))
+			}, client.Apply, client.FieldOwner("test"), client.ForceOwnership)
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func(g Gomega) {
@@ -183,7 +183,7 @@ var _ = Describe("LinstorSatelliteReconciler", func() {
 				err := k8sClient.Patch(ctx, &piraeusiov1.LinstorSatellite{
 					TypeMeta:   TypeMeta,
 					ObjectMeta: metav1.ObjectMeta{Name: ExampleNodeName, Finalizers: []string{"piraeus.io/test"}},
-				}, client.Apply, client.FieldOwner("test"))
+				}, client.Apply, client.FieldOwner("test"), client.ForceOwnership)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -191,7 +191,7 @@ var _ = Describe("LinstorSatelliteReconciler", func() {
 				err := k8sClient.Patch(ctx, &piraeusiov1.LinstorSatellite{
 					TypeMeta:   TypeMeta,
 					ObjectMeta: metav1.ObjectMeta{Name: ExampleNodeName},
-				}, client.Apply, client.FieldOwner("test"))
+				}, client.Apply, client.FieldOwner("test"), client.ForceOwnership)
 				Expect(err).NotTo(HaveOccurred())
 			})
 

--- a/pkg/resources/cluster/patches/api-tls.yaml
+++ b/pkg/resources/cluster/patches/api-tls.yaml
@@ -87,3 +87,4 @@
       ports:
         - port: 3371
           name: secure-api
+          protocol: TCP


### PR DESCRIPTION
We try to support older kubernetes versions: to ensure that they actually work, we run our normal tests against the oldest kubernetes version we support.

This already managed to unearth some issues with certain patches being applied.