### PR TITLE
monitoring: add alert or all resources outdated

### DIFF
--- a/config/extras/monitoring/alerts.yaml
+++ b/config/extras/monitoring/alerts.yaml
@@ -107,3 +107,10 @@ spec:
           expr: drbd_device_state{drbd_device_state="Inconsistent"} and delta(drbd_peerdevice_outofsync_bytes[5m]) >= 0
           labels:
             severity: warn
+        - alert: drbdResourceWithNoUpToDateReplicas
+          annotations:
+            description: |
+              DRBD resource "{{ $labels.name }}" has no UpToDate replicas.
+          expr: sum by (name) (drbd_device_state{drbd_device_state="UpToDate"}) == 0
+          labels:
+            severity: critical


### PR DESCRIPTION
There have been reports of situations in which DRBD devices are all Outdated. This then requires manual intervention, as DRBD can never sync itself up again. So add a specific alert for that.