### PR TITLE
add client-side caching to LINSTOR client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.2
 
 require (
-	github.com/LINBIT/golinstor v0.51.0
+	github.com/LINBIT/golinstor v0.52.0
 	github.com/cert-manager/cert-manager v1.14.4
 	github.com/evanphx/json-patch v5.9.0+incompatible
 	github.com/go-logr/logr v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/LINBIT/golinstor v0.51.0 h1:XvfcQN3jg7b/s79wrpTe/jzfFDGSNZy2pjGG8SDtFRM=
-github.com/LINBIT/golinstor v0.51.0/go.mod h1:MCkHNdHxoGw4mnt8DGsSqWNF5ZGhYFy6Lr4tQLyVBs0=
+github.com/LINBIT/golinstor v0.52.0 h1:b+l26DJvLxGIYuvopLFJUoE7aywa6oCmCeL3jav3kKM=
+github.com/LINBIT/golinstor v0.52.0/go.mod h1:D811Eyjhoy6t1Tl36HTW4by0s6O5g0cVgV/t58oN+0g=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -130,14 +130,11 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	unlimiter := rate.NewLimiter(rate.Inf, 0)
-
 	err = (&controller.LinstorClusterReconciler{
 		Client:             k8sManager.GetClient(),
 		Scheme:             k8sManager.GetScheme(),
 		Namespace:          Namespace,
 		ImageConfigMapName: ImageConfigMapName,
-		LinstorApiLimiter:  unlimiter,
 	}).SetupWithManager(k8sManager, opts)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -146,7 +143,6 @@ var _ = BeforeSuite(func() {
 		Scheme:             k8sManager.GetScheme(),
 		Namespace:          Namespace,
 		ImageConfigMapName: ImageConfigMapName,
-		LinstorApiLimiter:  unlimiter,
 	}).SetupWithManager(k8sManager, opts)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
On every reconciliation we run a create some LINSTOR requests. Most of them are "read-only", to ensure the cluster is in the expected state. These requests often come in "batches", i.e. update the status of all nodes.
    
With a new feature of the golinstor client, we can cache these respones and only use a single request for _all_ nodes or _all_ storage pools. This drastically reduces the number of requests in clusters with many nodes, or clusters with fast-changing labels.
    
The cache resets on every "modification" made by the client, ensuring the cluster state is at least internally consistent.
    
One tricky part is that we actually create lots of new clients for every reconciliation. These should still share the same cache, provided they actually point at the same cluster. This is done by inserting a another level of indirection by creating the cache once per controller URL.
