### PR TITLE
add default priority class name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Default PriorityClasses for all components
+
 ## [v2.5.0] - 2024-04-03
 
 ### Added

--- a/charts/piraeus/templates/deployment.yaml
+++ b/charts/piraeus/templates/deployment.yaml
@@ -92,6 +92,7 @@ spec:
         runAsNonRoot: true
       serviceAccountName: {{ include "piraeus-operator.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10
+      priorityClassName: {{ .Values.priorityClassName | default "system-cluster-critical" }}
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
       volumes:

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -93,6 +93,8 @@ tolerations:
     effect: NoSchedule
 affinity: { }
 
+priorityClassName: ""
+
 podDisruptionBudget:
   enabled: true
   minAvailable: 1

--- a/config/gencert/gencert.yaml
+++ b/config/gencert/gencert.yaml
@@ -64,6 +64,7 @@ spec:
               cpu: 5m
               memory: 32Mi
       serviceAccountName: gencert
+      priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 10
       tolerations:
         - key: drbd.linbit.com/lost-quorum

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -71,6 +71,7 @@ spec:
             memory: 64Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
+      priorityClassName: system-cluster-critical
       tolerations:
         - key: drbd.linbit.com/lost-quorum
           effect: NoSchedule

--- a/pkg/resources/cluster/controller/controller-deployment.yaml
+++ b/pkg/resources/cluster/controller/controller-deployment.yaml
@@ -102,6 +102,7 @@ spec:
               name: tmp
       enableServiceLinks: false
       serviceAccountName: linstor-controller
+      priorityClassName: system-node-critical
       volumes:
         - name: etc-linstor
           configMap:

--- a/pkg/resources/cluster/csi-controller/csi-controller-deployment.yaml
+++ b/pkg/resources/cluster/csi-controller/csi-controller-deployment.yaml
@@ -18,6 +18,7 @@ spec:
     spec:
       enableServiceLinks: false
       serviceAccountName: linstor-csi-controller
+      priorityClassName: system-node-critical
       initContainers:
         - name: linstor-wait-api-online
           image: linstor-csi

--- a/pkg/resources/cluster/csi-node/csi-node-daemon-set.yaml
+++ b/pkg/resources/cluster/csi-node/csi-node-daemon-set.yaml
@@ -19,6 +19,7 @@ spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
       serviceAccountName: linstor-csi-node
+      priorityClassName: system-node-critical
       initContainers:
         - name: linstor-wait-node-online
           image: linstor-csi

--- a/pkg/resources/cluster/ha-controller/daemonset.yaml
+++ b/pkg/resources/cluster/ha-controller/daemonset.yaml
@@ -15,6 +15,7 @@ spec:
         app.kubernetes.io/component: ha-controller
     spec:
       serviceAccountName: ha-controller
+      priorityClassName: system-cluster-critical
       containers:
         - name: ha-controller
           args:

--- a/pkg/resources/satellite/satellite/daemonset.yaml
+++ b/pkg/resources/satellite/satellite/daemonset.yaml
@@ -19,6 +19,7 @@ spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
       serviceAccountName: satellite
+      priorityClassName: system-node-critical
       initContainers:
         - name: drbd-module-loader
           image: drbd-module-loader


### PR DESCRIPTION
Priority Classes are used by Kubernetes to control preemption of Pods in resource starvation scenarios. Since Piraeus Datastore is most likely an important part of the cluster, and is needed for other Pods to be scheduled, assign it the system-{node,cluster}-critical priority class.

Fixes #654 