### PR TITLE
ci: fix loading of old envtest assets

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -31,6 +31,12 @@ jobs:
         with:
           go-version: '1.22'
       - uses: actions/setup-python@v5
+      - name: Cache envtest assets
+        uses: actions/cache@v4
+        with:
+          key: envtest-base
+          path: |
+            bin/k8s
       - name: Run pre-commit checks on changes files
         uses: pre-commit/action@v3.0.1
   compat-tests:
@@ -40,6 +46,12 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.22'
+      - name: Cache envtest assets
+        uses: actions/cache@v4
+        with:
+          key: envtest-compat
+          path: |
+            bin/k8s
       - name: Run compat test
         run: |
           make compat-test

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 
 .PHONY: compat-test
 compat-test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_COMPAT_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./...
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use --use-deprecated-gcs $(ENVTEST_K8S_COMPAT_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./...
 
 ##@ Build
 


### PR DESCRIPTION
envtest is moving away from GCS buckets for storage and removed the 1.20 assets from the replacement. Get back the original assets by enabling the deprecated GCS bucket on the setup-envtest binary when installing for compat tests.

Also, cache the binaries in CI to be at least a bit more independant from the external sources.