### PR TITLE
add wildcard properties to satellite spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support wildcard patterns when referencing property values from node labels and annotations.
+
 ## [v2.5.2] - 2024-07-17
 
 ### Added

--- a/docs/reference/linstorsatelliteconfiguration.md
+++ b/docs/reference/linstorsatelliteconfiguration.md
@@ -62,6 +62,10 @@ The property value can either be set directly using `value`, or inherited from t
 `valueFrom`. Metadata fields are specified using the same syntax as the [Downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api)
 for Pods.
 
+A special case is using `valueFrom` with a reference path ending in a `*` character. This copies all keys and values
+that match the given pattern. The property name must contain the special `$1` string, which gets replaced by the part of
+the key matching the `*` character.
+
 In addition, setting `optional` to true means the property is only applied if the value is not empty. This is useful
 in case the property value should be inherited from the node's metadata
 
@@ -74,6 +78,8 @@ This examples sets three Properties on every satellite:
 * `AutoplaceTarget` (if set to `no`, will exclude the node from LINSTOR's Autoplacer) takes the value from the
   `piraeus.io/autoplace` annotation of the Kubernetes Node. If a node has no `piraeus.io/autoplace` annotation, the
   property will not be set.
+* `Aux/role/$1` copies all "node-role.kubernetes.io/*" label keys and values. For example, a worker node with the
+  `node-role.kubernetes.io/worker: "true"` label will have the `Aux/role/worker` set to `"true"`.
 
 ```yaml
 apiVersion: piraeus.io/v1
@@ -91,6 +97,9 @@ spec:
       valueFrom:
         nodeFieldRef: metadata.annotations['piraeus.io/autoplace']
       optional: yes
+    - name: Aux/role/$1
+      valueFrom:
+        nodeFieldRef: metadata.labels['node-role.kubernetes.io/*']
 ```
 
 ### `.spec.storagePools`

--- a/pkg/utils/property_resolution_test.go
+++ b/pkg/utils/property_resolution_test.go
@@ -17,8 +17,11 @@ func TestResolveNodeProperties(t *testing.T) {
 	fakeNode := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				"label1": "labelval1",
-				"label2": "labelval2",
+				"label1":                                "labelval1",
+				"label2":                                "labelval2",
+				"node-role.kubernetes.io/control-plane": "cp",
+				"node-role.kubernetes.io/worker":        "w",
+				"node-role.kubernetes.io/test":          "",
 			},
 			Annotations: map[string]string{
 				"annotation1": "annotationval1",
@@ -57,6 +60,12 @@ func TestResolveNodeProperties(t *testing.T) {
 				NodeFieldRef: "metadata.annotations['annotation2']",
 			},
 		},
+		piraeusiov1.LinstorNodeProperty{
+			Name: "role/$1",
+			ValueFrom: &piraeusiov1.LinstorNodePropertyValueFrom{
+				NodeFieldRef: "metadata.labels['node-role.kubernetes.io/*']",
+			},
+		},
 	)
 
 	assert.NoError(t, err)
@@ -65,6 +74,9 @@ func TestResolveNodeProperties(t *testing.T) {
 		"prop2":                     "labelval1",
 		"non-existing-non-optional": "",
 		"prop3":                     "annotationval2",
+		"role/control-plane":        "cp",
+		"role/worker":               "w",
+		"role/test":                 "",
 	}, result)
 }
 


### PR DESCRIPTION
When setting properties inherited from the Kubernetes Node, it might be useful to copy all labels/annotations matching a specific prefix. To implement this, extend the existing "nodeFieldRef" syntax by allowing the key to contain a "*" character.

When a "\*" character is used, it acts like in a glob pattern, matching all keys on the referenced object. The property name has to contain a "$1", which gets replaced by whatever was matched by the "*".