### PR TITLE
Select IP families for LINSTOR Satellite connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Option to select IP Family to use for LINSTOR control traffic.
 
+### Changed
+
+- Reconciliation of a Satellites network interfaces now also deletes unneeded interfaces.
+
 ## [v2.6.0] - 2024-09-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Option to select IP Family to use for LINSTOR control traffic.
+
 ## [v2.6.0] - 2024-09-04
 
 ### Added

--- a/api/v1/ipfamilies.go
+++ b/api/v1/ipfamilies.go
@@ -1,0 +1,7 @@
+package v1
+
+import corev1 "k8s.io/api/core/v1"
+
+// IPFamily represents the IP Family (IPv4 or IPv6).
+// +kubebuilder:validation:Enum:=IPv4;IPv6
+type IPFamily corev1.IPFamily

--- a/api/v1/linstorsatellite_types.go
+++ b/api/v1/linstorsatellite_types.go
@@ -55,6 +55,13 @@ type LinstorSatelliteSpec struct {
 	// + Without "nullable" the k8s API does not accept patches with 'internalTLS: {}', which seems to be a bug.
 	// +nullable
 	InternalTLS *TLSConfigWithHandshakeDaemon `json:"internalTLS,omitempty"`
+
+	// IPFamilies configures the IP Family (IPv4 or IPv6) to use to connect to the LINSTOR Satellite.
+	//
+	// If set, the control traffic between LINSTOR Controller and Satellite will use only the given IP Family.
+	// If not set, the Operator will configure all families found in the Satellites Pods' Status.
+	// +kubebuilder:validation:Optional
+	IPFamilies []IPFamily `json:"ipFamilies,omitempty"`
 }
 
 // LinstorSatelliteStatus defines the observed state of LinstorSatellite

--- a/api/v1/linstorsatelliteconfiguration_types.go
+++ b/api/v1/linstorsatelliteconfiguration_types.go
@@ -64,6 +64,13 @@ type LinstorSatelliteConfigurationSpec struct {
 	// +nullable
 	InternalTLS *TLSConfigWithHandshakeDaemon `json:"internalTLS,omitempty"`
 
+	// IPFamilies configures the IP Family (IPv4 or IPv6) to use to connect to the LINSTOR Satellite.
+	//
+	// If set, the control traffic between LINSTOR Controller and Satellite will use only the given IP Family.
+	// If not set, the Operator will configure all families found in the Satellites Pods' Status.
+	// +kubebuilder:validation:Optional
+	IPFamilies []IPFamily `json:"ipFamilies,omitempty"`
+
 	// Template to apply to Satellite Pods.
 	//
 	// The template is applied as a patch to the default resource, so it can be "sparse", not listing any

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -614,6 +614,11 @@ func (in *LinstorSatelliteConfigurationSpec) DeepCopyInto(out *LinstorSatelliteC
 		*out = new(TLSConfigWithHandshakeDaemon)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.IPFamilies != nil {
+		in, out := &in.IPFamilies, &out.IPFamilies
+		*out = make([]IPFamily, len(*in))
+		copy(*out, *in)
+	}
 	if in.PodTemplate != nil {
 		in, out := &in.PodTemplate, &out.PodTemplate
 		*out = make(json.RawMessage, len(*in))
@@ -714,6 +719,11 @@ func (in *LinstorSatelliteSpec) DeepCopyInto(out *LinstorSatelliteSpec) {
 		in, out := &in.InternalTLS, &out.InternalTLS
 		*out = new(TLSConfigWithHandshakeDaemon)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.IPFamilies != nil {
+		in, out := &in.IPFamilies, &out.IPFamilies
+		*out = make([]IPFamily, len(*in))
+		copy(*out, *in)
 	}
 }
 

--- a/charts/piraeus/templates/crds.yaml
+++ b/charts/piraeus/templates/crds.yaml
@@ -830,6 +830,19 @@ spec:
                       The daemon uses the TLS certificate and key to establish secure connections on behalf of DRBD.
                     type: boolean
                 type: object
+              ipFamilies:
+                description: |-
+                  IPFamilies configures the IP Family (IPv4 or IPv6) to use to connect to the LINSTOR Satellite.
+
+                  If set, the control traffic between LINSTOR Controller and Satellite will use only the given IP Family.
+                  If not set, the Operator will configure all families found in the Satellites Pods' Status.
+                items:
+                  description: IPFamily represents the IP Family (IPv4 or IPv6).
+                  enum:
+                  - IPv4
+                  - IPv6
+                  type: string
+                type: array
               nodeAffinity:
                 description: |-
                   NodeAffinity selects which LinstorSatellite resources this spec should be applied to.
@@ -1426,6 +1439,19 @@ spec:
                       The daemon uses the TLS certificate and key to establish secure connections on behalf of DRBD.
                     type: boolean
                 type: object
+              ipFamilies:
+                description: |-
+                  IPFamilies configures the IP Family (IPv4 or IPv6) to use to connect to the LINSTOR Satellite.
+
+                  If set, the control traffic between LINSTOR Controller and Satellite will use only the given IP Family.
+                  If not set, the Operator will configure all families found in the Satellites Pods' Status.
+                items:
+                  description: IPFamily represents the IP Family (IPv4 or IPv6).
+                  enum:
+                  - IPv4
+                  - IPv6
+                  type: string
+                type: array
               patches:
                 description: |-
                   Patches is a list of kustomize patches to apply.

--- a/config/crd/bases/piraeus.io_linstorsatelliteconfigurations.yaml
+++ b/config/crd/bases/piraeus.io_linstorsatelliteconfigurations.yaml
@@ -110,6 +110,19 @@ spec:
                       The daemon uses the TLS certificate and key to establish secure connections on behalf of DRBD.
                     type: boolean
                 type: object
+              ipFamilies:
+                description: |-
+                  IPFamilies configures the IP Family (IPv4 or IPv6) to use to connect to the LINSTOR Satellite.
+
+                  If set, the control traffic between LINSTOR Controller and Satellite will use only the given IP Family.
+                  If not set, the Operator will configure all families found in the Satellites Pods' Status.
+                items:
+                  description: IPFamily represents the IP Family (IPv4 or IPv6).
+                  enum:
+                  - IPv4
+                  - IPv6
+                  type: string
+                type: array
               nodeAffinity:
                 description: |-
                   NodeAffinity selects which LinstorSatellite resources this spec should be applied to.

--- a/config/crd/bases/piraeus.io_linstorsatellites.yaml
+++ b/config/crd/bases/piraeus.io_linstorsatellites.yaml
@@ -160,6 +160,19 @@ spec:
                       The daemon uses the TLS certificate and key to establish secure connections on behalf of DRBD.
                     type: boolean
                 type: object
+              ipFamilies:
+                description: |-
+                  IPFamilies configures the IP Family (IPv4 or IPv6) to use to connect to the LINSTOR Satellite.
+
+                  If set, the control traffic between LINSTOR Controller and Satellite will use only the given IP Family.
+                  If not set, the Operator will configure all families found in the Satellites Pods' Status.
+                items:
+                  description: IPFamily represents the IP Family (IPv4 or IPv6).
+                  enum:
+                  - IPv4
+                  - IPv6
+                  type: string
+                type: array
               patches:
                 description: |-
                   Patches is a list of kustomize patches to apply.

--- a/docs/reference/linstorsatelliteconfiguration.md
+++ b/docs/reference/linstorsatelliteconfiguration.md
@@ -259,6 +259,31 @@ spec:
       name: piraeus-root
 ```
 
+### `.spec.ipFamilies`
+
+Configures the IP Family (IPv4 or IPv6) to use to connect to the LINSTOR Satellite.
+
+If unset, the LINSTOR Controller will attempt to reach the LINSTOR Satellite via all recognized addresses in the
+Satellite Pods' Status.
+If set, the LINSTOR Controller will only attempt to reach the LINSTOR Satellite via all addresses matching the listed
+IP Families.
+
+Valid values are `IPv4` and `IPv6`.
+
+#### Example
+
+This example configures the LINSTOR Controller to only use IPv4, even in a dual stack cluster.
+
+```yaml
+apiVersion: piraeus.io/v1
+kind: LinstorSatelliteConfiguration
+metadata:
+  name: ipv4-only
+spec:
+  ipFamilies:
+  - IPv4
+```
+
 ### `.spec.podTemplate`
 
 Configures the Pod used to run the LINSTOR Satellite.

--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/internal/controller/linstorcluster_controller.go
+++ b/internal/controller/linstorcluster_controller.go
@@ -666,6 +666,14 @@ func (r *LinstorClusterReconciler) kustomizeLinstorSatellite(ctx context.Context
 		})
 	}
 
+	if cfg.Spec.IPFamilies != nil {
+		patches = append(patches, utils.JsonPatch{
+			Op:    utils.Add,
+			Path:  "/spec/ipFamilies",
+			Value: cfg.Spec.IPFamilies,
+		})
+	}
+
 	for j := range cfg.Spec.Properties {
 		patches = append(patches, utils.JsonPatch{
 			Op:    utils.Add,

--- a/pkg/merge/linstorsatelliteconfiguration.go
+++ b/pkg/merge/linstorsatelliteconfiguration.go
@@ -58,6 +58,10 @@ func SatelliteConfigurations(ctx context.Context, node *corev1.Node, configs ...
 		if cfg.Spec.InternalTLS != nil {
 			result.Spec.InternalTLS = cfg.Spec.InternalTLS
 		}
+
+		if cfg.Spec.IPFamilies != nil {
+			result.Spec.IPFamilies = cfg.Spec.IPFamilies
+		}
 	}
 
 	for _, v := range propsMap {

--- a/pkg/vars/vars.go
+++ b/pkg/vars/vars.go
@@ -17,6 +17,7 @@ var (
 const (
 	FieldOwner              = Domain + "/operator"
 	ApplyAnnotation         = Domain + "/last-applied"
+	NodeInterfaceAnnotation = Domain + "/configured-interfaces"
 	ManagedByLabel          = Domain + "/managed-by"
 	SatelliteNodeLabel      = Domain + "/linstor-satellite"
 	SatelliteFinalizer      = Domain + "/satellite-protection"


### PR DESCRIPTION
Some users reported running in a Cluster where Kubernetes assigns IPv6 addresses to the Satellite Pods, but those addresses are then not routable from the Controller Pod.
    
This leads to useless connection definitions, and in some cases to LINSTOR getting stuck trying to connect on the wrong network. While this is a misconfiguration on the Kubernetes side, as well as a bug on the LINSTOR side, we can still help these users by providing a way to filter the network interfaces we configure on the LINSTOR Satellites.
    
The option to set the "ipFamilies" on the Satellite Configuration is inspired by the option of the same name on the Kubernetes Service resources. When set, we filter the available addresses to only the specified IP family (IPv4 or IPv6). An empty list is the same as not setting any restrictions, keeping the existing behaviour.

In addition, ensure that interfaces once configured by the operator are also cleaned when they are no longer needed,
