### PR TITLE
extras: fix satellite offline alert

### DIFF
--- a/config/extras/monitoring/alerts.yaml
+++ b/config/extras/monitoring/alerts.yaml
@@ -33,9 +33,9 @@ spec:
         - alert: linstorSatelliteNotOnline
           annotations:
             description: |
-              LINSTOR Satellite "{{ $labels.hostname }}" is not ONLINE.
+              LINSTOR Satellite "{{ $labels.node }}" is not ONLINE.
               Check that the Satellite is running and reachable from the LINSTOR Controller.
-          expr: linstor_node_state{nodetype="SATELLITE"} != 2
+          expr: linstor_node_state{nodetype="SATELLITE"} != 2 and on (node) up{job=~".*/linstor-satellite"}
           labels:
             severity: critical
         - alert: linstorStoragePoolErrors

--- a/config/extras/monitoring/alerts.yaml
+++ b/config/extras/monitoring/alerts.yaml
@@ -58,7 +58,7 @@ spec:
           annotations:
             description: |
               DRBD Reactor on "{{ $labels.node }}" is not reachable.
-          expr: up{job="piraeus-datastore/linstor-satellite"} == 0
+          expr: up{job=".*/linstor-satellite"} == 0
           labels:
             severity: critical
         - alert: drbdConnectionNotConnected


### PR DESCRIPTION
The description used the wrong label, so the alert description showed an empty satellite name. In addition, ensure the alert only fires if the Node+Pod is actually running, otherwise there is no point in this alert. If the Pod has trouble starting, it should hopefully create a general alert.