### PR TITLE
docs: update upgrade instructions

### DIFF
--- a/docs/upgrade/migration/2-collect-information.md
+++ b/docs/upgrade/migration/2-collect-information.md
@@ -20,7 +20,7 @@ or directly from GitHub:
 
 ```
 $ curl --proto '=https' --tlsv1.2 -sSf \
-  https://raw.githubusercontent.com/piraeusdatastore/piraeus-operator/v2/docs/upgrade/migration/collect-operator-v1-information.sh \
+  https://piraeus.io/docs/v2/how-to/upgrade/collect-operator-v1-information.sh \
   | bash -s
 ```
 


### PR DESCRIPTION
The old script is now a symlink, which github does not automatically redirect to the right location. Use or own docs domain instead.