### PR TITLE
automatically try to guess tag for satellites

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Automatically set the LINSTOR Satellite image version when using an external LINSTOR Controller.
+
 ## [v2.7.1] - 2024-11-25
 
 ### Changed

--- a/internal/controller/linstorcluster_controller.go
+++ b/internal/controller/linstorcluster_controller.go
@@ -763,14 +763,13 @@ func (r *LinstorClusterReconciler) reconcileClusterState(ctx context.Context, lc
 		ctx,
 		r.Client,
 		r.Namespace,
-		lcluster.Name,
-		clientSecret,
-		caRef,
-		lcluster.Spec.ExternalController,
-		append(
-			slices.Clone(r.LinstorClientOpts),
-			linstorhelper.Logr(log.FromContext(ctx)),
-		)...,
+		&piraeusiov1.ClusterReference{
+			Name:               lcluster.Name,
+			ClientSecretName:   clientSecret,
+			CAReference:        caRef,
+			ExternalController: lcluster.Spec.ExternalController,
+		},
+		r.LinstorClientOpts...,
 	)
 	if err != nil || lc == nil {
 		conds.AddError(conditions.Available, err)

--- a/internal/controller/linstornodeconnection_controller.go
+++ b/internal/controller/linstornodeconnection_controller.go
@@ -125,14 +125,8 @@ func (r *LinstorNodeConnectionReconciler) reconcileAll(ctx context.Context, conn
 			ctx,
 			r.Client,
 			r.Namespace,
-			view.ClusterRef.Name,
-			view.ClusterRef.ClientSecretName,
-			view.ClusterRef.CAReference,
-			view.ClusterRef.ExternalController,
-			append(
-				slices.Clone(r.LinstorClientOpts),
-				linstorhelper.Logr(log.FromContext(ctx)),
-			)...,
+			&view.ClusterRef,
+			r.LinstorClientOpts...,
 		)
 		if err != nil {
 			return err

--- a/pkg/imageversions/dynamic.go
+++ b/pkg/imageversions/dynamic.go
@@ -3,11 +3,14 @@ package imageversions
 import (
 	"context"
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 
+	lclient "github.com/LINBIT/golinstor/client"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/yaml"
 )
 
@@ -19,19 +22,39 @@ func FromConfigMap(ctx context.Context, client client.Client, name types.Namespa
 	}
 
 	var cfgs []*Config
-	for name, content := range cfg.Data {
+	for _, name := range slices.Sorted(maps.Keys(cfg.Data)) {
 		var config Config
-		err = yaml.Unmarshal([]byte(content), &config)
+		err = yaml.Unmarshal([]byte(cfg.Data[name]), &config)
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode image configuration: %w", err)
 		}
-		config.source = name
 		cfgs = append(cfgs, &config)
 	}
 
-	sort.Slice(cfgs, func(i, j int) bool {
-		return cfgs[i].source < cfgs[j].source
-	})
-
 	return cfgs, nil
+}
+
+// SetFromExternalCluster sets the LINSTOR Satellite image tag to the version of the LINSTOR Controller.
+//
+// The Configs will be updated so that the first entry containing a LINSTOR Satellite image is updated.
+// Returns an error is the LINSTOR Controller could not be reached, or no LINSTOR Satellite image was found.
+func SetFromExternalCluster(ctx context.Context, client lclient.Client, configs Configs) error {
+	version, err := client.Controller.GetVersion(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch controller version: %w", err)
+	}
+
+	newTag := "v" + version.Version
+	logger := log.FromContext(ctx)
+
+	for name, config := range configs {
+		if v, ok := config.Components["linstor-satellite"]; ok {
+			logger.WithValues("configName", name, "oldTag", v.Tag, "newTag", newTag).Info("updating image version based on external cluster")
+			v.Tag = newTag
+			config.Components["linstor-satellite"] = v
+			return nil
+		}
+	}
+
+	return fmt.Errorf("no linstor-satellite component found in configs")
 }

--- a/pkg/imageversions/dynamic_test.go
+++ b/pkg/imageversions/dynamic_test.go
@@ -1,0 +1,252 @@
+package imageversions_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	lclient "github.com/LINBIT/golinstor/client"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/imageversions"
+)
+
+func TestFromConfigMap(t *testing.T) {
+	fakeclient := fake.NewFakeClient(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "image-config",
+			Namespace: "test",
+		},
+		Data: map[string]string{
+			"0_image.yaml": `
+base: example.com/base
+components:
+  linstor-satellite:
+    image: satellite-image
+    tag: v1.2.3
+  other-image:
+    image: other
+    tag: v0.1.2
+`,
+			"1_image.yaml": `
+base: example.com/extra
+components:
+  linstor-controller:
+    image: controller-image
+    tag: v2.0.0
+  other-image:
+    image: another
+    tag: v2.1.0
+  multi:
+    image: fallback
+    tag: v10.11.12
+    match:
+      - image: abcd
+        osImage: efgh
+        precompiled: true
+      - image: "1234"
+        osImage: "9876"
+`,
+		},
+	})
+
+	actual, err := imageversions.FromConfigMap(context.Background(), fakeclient, types.NamespacedName{Namespace: "test", Name: "image-config"})
+	assert.NoError(t, err)
+	assert.Equal(t, imageversions.Configs{
+		{
+			Base: "example.com/base",
+			Components: map[string]imageversions.ComponentConfig{
+				"linstor-satellite": {
+					Image: "satellite-image",
+					Tag:   "v1.2.3",
+				},
+				"other-image": {
+					Image: "other",
+					Tag:   "v0.1.2",
+				},
+			},
+		},
+		{
+			Base: "example.com/extra",
+			Components: map[string]imageversions.ComponentConfig{
+				"linstor-controller": {
+					Image: "controller-image",
+					Tag:   "v2.0.0",
+				},
+				"other-image": {
+					Image: "another",
+					Tag:   "v2.1.0",
+				},
+				"multi": {
+					Image: "fallback",
+					Tag:   "v10.11.12",
+					Match: []imageversions.OsMatch{
+						{Image: "abcd", OsImage: "efgh", Precompiled: true},
+						{Image: "1234", OsImage: "9876", Precompiled: false},
+					},
+				},
+			},
+		},
+	}, actual)
+}
+
+func TestSetFromExternalCluster(t *testing.T) {
+	configs := imageversions.Configs{
+		{
+			Base: "example.com/base",
+			Components: map[string]imageversions.ComponentConfig{
+				"linstor-satellite": {
+					Image: "satellite-image",
+					Tag:   "v1.2.3",
+				},
+				"linstor-controller": {
+					Image: "controller-image",
+					Tag:   "v2.0.0",
+				},
+			},
+		},
+		{
+			Base: "example.com/extra",
+			Components: map[string]imageversions.ComponentConfig{
+				"linstor-satellite": {
+					Image: "other-satellite-image",
+					Tag:   "other-tag",
+				},
+				"linstor-controller": {
+					Image: "other-controller-image",
+					Tag:   "v2.0.0-other",
+				},
+			},
+		},
+	}
+
+	err := imageversions.SetFromExternalCluster(context.Background(), lclient.Client{
+		Controller: &FakeVersionReporter{
+			Error: fmt.Errorf("error"),
+		},
+	}, configs)
+	assert.Error(t, err)
+
+	err = imageversions.SetFromExternalCluster(context.Background(), lclient.Client{
+		Controller: &FakeVersionReporter{
+			ControllerVersion: lclient.ControllerVersion{Version: "10.11.12"},
+		},
+	}, configs)
+	assert.NoError(t, err)
+	assert.Equal(t, imageversions.Configs{
+		{
+			Base: "example.com/base",
+			Components: map[string]imageversions.ComponentConfig{
+				"linstor-satellite": {
+					Image: "satellite-image",
+					Tag:   "v10.11.12",
+				},
+				"linstor-controller": {
+					Image: "controller-image",
+					Tag:   "v2.0.0",
+				},
+			},
+		},
+		{
+			Base: "example.com/extra",
+			Components: map[string]imageversions.ComponentConfig{
+				"linstor-satellite": {
+					Image: "other-satellite-image",
+					Tag:   "other-tag",
+				},
+				"linstor-controller": {
+					Image: "other-controller-image",
+					Tag:   "v2.0.0-other",
+				},
+			},
+		},
+	}, configs)
+}
+
+type FakeVersionReporter struct {
+	lclient.ControllerVersion
+	Error error
+}
+
+var _ lclient.ControllerProvider = &FakeVersionReporter{}
+
+func (f *FakeVersionReporter) GetVersion(ctx context.Context, opts ...*lclient.ListOpts) (lclient.ControllerVersion, error) {
+	return f.ControllerVersion, f.Error
+}
+
+func (f *FakeVersionReporter) GetConfig(ctx context.Context, opts ...*lclient.ListOpts) (lclient.ControllerConfig, error) {
+	panic("unimplemented")
+}
+
+func (f *FakeVersionReporter) Modify(ctx context.Context, props lclient.GenericPropsModify) error {
+	panic("unimplemented")
+}
+
+func (f *FakeVersionReporter) GetProps(ctx context.Context, opts ...*lclient.ListOpts) (lclient.ControllerProps, error) {
+	panic("unimplemented")
+}
+
+func (f *FakeVersionReporter) DeleteProp(ctx context.Context, prop string) error {
+	panic("unimplemented")
+}
+
+func (f *FakeVersionReporter) GetErrorReports(ctx context.Context, opts ...*lclient.ListOpts) ([]lclient.ErrorReport, error) {
+	panic("unimplemented")
+}
+
+func (f *FakeVersionReporter) DeleteErrorReports(ctx context.Context, del lclient.ErrorReportDelete) error {
+	panic("unimplemented")
+}
+
+func (f *FakeVersionReporter) GetErrorReportsSince(ctx context.Context, since time.Time, opts ...*lclient.ListOpts) ([]lclient.ErrorReport, error) {
+	panic("unimplemented")
+}
+
+func (f *FakeVersionReporter) GetErrorReport(ctx context.Context, id string, opts ...*lclient.ListOpts) (lclient.ErrorReport, error) {
+	panic("unimplemented")
+}
+
+func (f *FakeVersionReporter) CreateSOSReport(ctx context.Context, opts ...*lclient.ListOpts) error {
+	panic("unimplemented")
+}
+
+func (f *FakeVersionReporter) DownloadSOSReport(ctx context.Context, opts ...*lclient.ListOpts) error {
+	panic("unimplemented")
+}
+
+func (f *FakeVersionReporter) GetSatelliteConfig(ctx context.Context, node string) (lclient.SatelliteConfig, error) {
+	panic("unimplemented")
+}
+
+func (f *FakeVersionReporter) ModifySatelliteConfig(ctx context.Context, node string, cfg lclient.SatelliteConfig) error {
+	panic("unimplemented")
+}
+
+func (f *FakeVersionReporter) GetPropsInfos(ctx context.Context, opts ...*lclient.ListOpts) ([]lclient.PropsInfo, error) {
+	panic("unimplemented")
+}
+
+func (f *FakeVersionReporter) GetPropsInfosAll(ctx context.Context, opts ...*lclient.ListOpts) ([]lclient.PropsInfo, error) {
+	panic("unimplemented")
+}
+
+func (f *FakeVersionReporter) GetExternalFiles(ctx context.Context, opts ...*lclient.ListOpts) ([]lclient.ExternalFile, error) {
+	panic("unimplemented")
+}
+
+func (f *FakeVersionReporter) GetExternalFile(ctx context.Context, name string) (lclient.ExternalFile, error) {
+	panic("unimplemented")
+}
+
+func (f *FakeVersionReporter) ModifyExternalFile(ctx context.Context, name string, file lclient.ExternalFile) error {
+	panic("unimplemented")
+}
+
+func (f *FakeVersionReporter) DeleteExternalFile(ctx context.Context, name string) error {
+	panic("unimplemented")
+}

--- a/pkg/imageversions/versions.go
+++ b/pkg/imageversions/versions.go
@@ -13,7 +13,6 @@ type Configs []*Config
 
 // Config represents a default image mapping used by the operator.
 type Config struct {
-	source     string
 	Base       string                     `yaml:"base"`
 	Components map[string]ComponentConfig `yaml:"components"`
 }

--- a/pkg/linstorhelper/log.go
+++ b/pkg/linstorhelper/log.go
@@ -13,10 +13,6 @@ type logrAdapter struct {
 
 var _ lapi.LeveledLogger = &logrAdapter{}
 
-func Logr(l logr.Logger) lapi.Option {
-	return lapi.Log(&logrAdapter{Logger: l})
-}
-
 func (l *logrAdapter) Errorf(s string, i ...interface{}) {
 	l.Logger.Error(fmt.Errorf(s, i...), "error occurred")
 }


### PR DESCRIPTION
When using an external LINSTOR Controller, the Satellite version might not match the default version we configure with the Operator. Make the Operator smart enough to handle the "happy path" of the users having a properly released LINSTOR Controller version.

To do this, we try to modify the first image configuration that tries to set the linstor-satellite image tag. This should always be the one we shipped with the Operator. Any config applied by the user would still take precedence.