### PR TITLE
allow users to specify multiple URLs for external controllers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Automatically set the LINSTOR Satellite image version when using an external LINSTOR Controller.
 
 ### Changed
+
 - Disable debug logging by default for the Operator.
+- Allow specifying multiple controller URLs for external LINSTOR clusters.
 
 ## [v2.7.1] - 2024-11-25
 

--- a/pkg/linstorhelper/client_test.go
+++ b/pkg/linstorhelper/client_test.go
@@ -81,7 +81,7 @@ func TestNewClientForCluster(t *testing.T) {
 				URL: "http://other-cluster.example.com:3370",
 			},
 			expectedOptions: []lapi.Option{
-				lapi.BaseURL(&url.URL{Scheme: "http", Host: "other-cluster.example.com:3370"}),
+				lapi.Controllers([]string{"http://other-cluster.example.com:3370"}),
 				lapi.UserAgent(vars.OperatorName + "/" + vars.Version),
 			},
 		},
@@ -99,10 +99,23 @@ func TestNewClientForCluster(t *testing.T) {
 			},
 			existingSecret: "client-secret",
 			expectedOptions: []lapi.Option{
-				lapi.BaseURL(&url.URL{Scheme: "https", Host: "other-cluster.example.com:3371"}),
+				lapi.Controllers([]string{"https://other-cluster.example.com:3371"}),
 				lapi.HTTPClient(&http.Client{Transport: &http.Transport{
 					TLSClientConfig: tlsConfig,
 				}}),
+				lapi.UserAgent(vars.OperatorName + "/" + vars.Version),
+			},
+		},
+		{
+			name: "cluster-external-controller-with-multiple-urls",
+			externalRef: &piraeusv1.LinstorExternalControllerRef{
+				URL: "http://other-cluster.example.com:3370,http://another-cluster.example.com:3370",
+			},
+			expectedOptions: []lapi.Option{
+				lapi.Controllers([]string{
+					"http://other-cluster.example.com:3370",
+					"http://another-cluster.example.com:3370",
+				}),
 				lapi.UserAgent(vars.OperatorName + "/" + vars.Version),
 			},
 		},


### PR DESCRIPTION
When a user has a HA LINSTOR Controller managed by drbd-reactor, they generally do not have a single service IP. Instead, the user usually specified all possible controller IPs.

golinstor already supports this when using the "Controllers()" option, so make use of this here. LINSTOR CSI does not need to be updated, as this already works there.