### PR TITLE
fix operator caches not using a proper cache key

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Operator caches not being index by a comparable key, leading to cache misses and a memory leak.
+
 ## [v2.8.0] - 2025-02-13
 
 ### Added

--- a/pkg/linstorhelper/client.go
+++ b/pkg/linstorhelper/client.go
@@ -44,7 +44,7 @@ var (
 // Client(s) pointing to the same URL will share a cache.
 func PerClusterNodeCache(timeout time.Duration) lapi.Option {
 	return func(c *lapi.Client) error {
-		cache, _ := nodeCaches.LoadOrStore(c.BaseURL(), &lapicache.NodeCache{Timeout: timeout})
+		cache, _ := nodeCaches.LoadOrStore(c.BaseURL().String(), &lapicache.NodeCache{Timeout: timeout})
 		return lapicache.WithCaches(cache.(*lapicache.NodeCache))(c)
 	}
 }
@@ -54,7 +54,7 @@ func PerClusterNodeCache(timeout time.Duration) lapi.Option {
 // Client(s) pointing to the same URL will share a rate limiter.
 func PerClusterRateLimiter(r rate.Limit, b int) lapi.Option {
 	return func(c *lapi.Client) error {
-		limiter, _ := rateLimiters.LoadOrStore(c.BaseURL(), rate.NewLimiter(r, b))
+		limiter, _ := rateLimiters.LoadOrStore(c.BaseURL().String(), rate.NewLimiter(r, b))
 		return lapi.Limiter(limiter.(*rate.Limiter))(c)
 	}
 }


### PR DESCRIPTION
The Operator maintains caches on a per-controller-connection basis. At least that was the intention of f241cc150929.

However, it turned out that at the point when the caches get created, the URL was still not set, which was eventually fixed in 400e48482ac5.

There, we introduced another bug, as we used the raw return value as cache key. That, however is of type *url.URL, so equality was checked on the pointer, not on the pointed to URL. This caused every invocation to create a new cache entry, slowly filling the cache map with ever more entries, while not actually caching anything.

To fix this, use the string represenation of the URL as cache key, as that has all the equality semantics we care about. Also add a test to ensure caches are actually working as expected.

Fixes #781 