### PR TITLE
Updated LINSTOR

### DIFF
--- a/charts/piraeus/templates/config.yaml
+++ b/charts/piraeus/templates/config.yaml
@@ -17,13 +17,13 @@ data:
     #   quay.io/piraeusdatastore/piraeus-server:v1.24.2
     components:
       linstor-controller:
-        tag: v1.30.4
+        tag: v1.31.0
         image: piraeus-server
       linstor-satellite:
-        tag: v1.30.4
+        tag: v1.31.0
         image: piraeus-server
       linstor-csi:
-        tag: v1.7.0
+        tag: v1.7.1
         image: piraeus-csi
       drbd-reactor:
         tag: v1.8.0
@@ -38,7 +38,7 @@ data:
         tag: v0.11
         image: ktls-utils
       drbd-module-loader:
-        tag: v9.2.12
+        tag: v9.2.13
         # The special "match" attribute is used to select an image based on the node's reported OS.
         # The operator will first check the k8s node's ".status.nodeInfo.osImage" field, and compare it against the list
         # here. If one matches, that specific image name will be used instead of the fallback image.
@@ -89,7 +89,7 @@ data:
     base: registry.k8s.io/sig-storage
     components:
       csi-attacher:
-        tag: v4.8.0
+        tag: v4.8.1
         image: csi-attacher
       csi-livenessprobe:
         tag: v2.15.0
@@ -98,10 +98,10 @@ data:
         tag: v5.2.0
         image: csi-provisioner
       csi-snapshotter:
-        tag: v8.2.0
+        tag: v8.2.1
         image: csi-snapshotter
       csi-resizer:
-        tag: v1.13.1
+        tag: v1.13.2
         image: csi-resizer
       csi-external-health-monitor-controller:
         tag: v0.14.0

--- a/config/manager/0_piraeus_datastore_images.yaml
+++ b/config/manager/0_piraeus_datastore_images.yaml
@@ -8,13 +8,13 @@ base: quay.io/piraeusdatastore
 #   quay.io/piraeusdatastore/piraeus-server:v1.24.2
 components:
   linstor-controller:
-    tag: v1.30.4
+    tag: v1.31.0
     image: piraeus-server
   linstor-satellite:
-    tag: v1.30.4
+    tag: v1.31.0
     image: piraeus-server
   linstor-csi:
-    tag: v1.7.0
+    tag: v1.7.1
     image: piraeus-csi
   drbd-reactor:
     tag: v1.8.0
@@ -29,7 +29,7 @@ components:
     tag: v0.11
     image: ktls-utils
   drbd-module-loader:
-    tag: v9.2.12
+    tag: v9.2.13
     # The special "match" attribute is used to select an image based on the node's reported OS.
     # The operator will first check the k8s node's ".status.nodeInfo.osImage" field, and compare it against the list
     # here. If one matches, that specific image name will be used instead of the fallback image.

--- a/config/manager/0_sig_storage_images.yaml
+++ b/config/manager/0_sig_storage_images.yaml
@@ -2,7 +2,7 @@
 base: registry.k8s.io/sig-storage
 components:
   csi-attacher:
-    tag: v4.8.0
+    tag: v4.8.1
     image: csi-attacher
   csi-livenessprobe:
     tag: v2.15.0
@@ -11,10 +11,10 @@ components:
     tag: v5.2.0
     image: csi-provisioner
   csi-snapshotter:
-    tag: v8.2.0
+    tag: v8.2.1
     image: csi-snapshotter
   csi-resizer:
-    tag: v1.13.1
+    tag: v1.13.2
     image: csi-resizer
   csi-external-health-monitor-controller:
     tag: v0.14.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -39,6 +39,7 @@ spec:
         - --namespace=$(NAMESPACE)
         - --zap-devel=$(ZAP_DEVEL)
         - --image-config-map-name=$(IMAGE_CONFIG_MAP_NAME)
+        - --requeue-interval=$(REQUEUE_INTERVAL)
         image: controller:latest
         name: manager
         env:
@@ -50,6 +51,8 @@ spec:
             value: "false"
           - name: IMAGE_CONFIG_MAP_NAME
             value: image-config
+          - name: REQUEUE_INTERVAL
+            value: "1m"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Option to set the maximum time between reconciliations.
+
 ### Changed
 
 - Updated default properties applied on controller level to match LINSTOR release 1.31.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated default properties applied on controller level to match LINSTOR release 1.31.0
+- Updated images:
+    * LINSTOR 1.31.0
+    * LINSTOR CSI 1.7.1
+    * DRBD 9.2.13
+    * Latest CSI sidecars
+
 ### Fixed
 
 - Fix Operator caches not being index by a comparable key, leading to cache misses and a memory leak.

--- a/docs/upgrade/migration/README.md
+++ b/docs/upgrade/migration/README.md
@@ -57,6 +57,6 @@ This guide assumes:
     * `DrbdOptions/Net/rr-conflict: retry-connect`
     * `DrbdOptions/Resource/on-suspended-primary-outdated: force-secondary`
     * `DrbdOptions/Resource/on-no-data-accessible: suspend-io`
-    * `DrbdOptions/auto-quorum: suspend-io`
+    * `DrbdOptions/Resource/on-no-quorum: suspend-io`
 *   Operator v2 also includes a [High-Availability Controller](https://github.com/piraeusdatastore/piraeus-ha-controller)
     deployment to prevent stuck nodes caused by suspended DRBD devices.

--- a/internal/controller/linstorcluster_controller.go
+++ b/internal/controller/linstorcluster_controller.go
@@ -70,6 +70,7 @@ type LinstorClusterReconciler struct {
 	Namespace          string
 	PullSecret         string
 	ImageConfigMapName string
+	RequeueInterval    time.Duration
 	LinstorClientOpts  []lapi.Option
 	Kustomizer         *resources.Kustomizer
 	APIVersion         *utils.APIVersion
@@ -136,11 +137,7 @@ func (r *LinstorClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return nil
 	})
 
-	result := ctrl.Result{
-		RequeueAfter: 1 * time.Minute,
-	}
-
-	return utils.AnyResult(result, applyErr, stateErr, condErr)
+	return utils.AnyResult(ctrl.Result{RequeueAfter: r.RequeueInterval}, applyErr, stateErr, condErr)
 }
 
 func (r *LinstorClusterReconciler) reconcileAppliedResource(ctx context.Context, lcluster *piraeusiov1.LinstorCluster) error {

--- a/internal/controller/linstornodeconnection_controller.go
+++ b/internal/controller/linstornodeconnection_controller.go
@@ -52,6 +52,7 @@ type LinstorNodeConnectionReconciler struct {
 	client.Client
 	Scheme            *runtime.Scheme
 	Namespace         string
+	RequeueInterval   time.Duration
 	LinstorClientOpts []lapi.Option
 }
 
@@ -105,11 +106,7 @@ func (r *LinstorNodeConnectionReconciler) Reconcile(ctx context.Context, req ctr
 		}
 	}
 
-	result := ctrl.Result{
-		RequeueAfter: 1 * time.Minute,
-	}
-
-	return utils.AnyResult(result, errs...)
+	return utils.AnyResult(ctrl.Result{RequeueAfter: r.RequeueInterval}, errs...)
 }
 
 func (r *LinstorNodeConnectionReconciler) reconcileAll(ctx context.Context, conns []piraeusiov1.LinstorNodeConnection, satellites []piraeusiov1.LinstorSatellite, nodes []corev1.Node) error {

--- a/internal/controller/linstorsatellite_controller.go
+++ b/internal/controller/linstorsatellite_controller.go
@@ -66,6 +66,7 @@ type LinstorSatelliteReconciler struct {
 	Scheme             *runtime.Scheme
 	Namespace          string
 	ImageConfigMapName string
+	RequeueInterval    time.Duration
 	LinstorClientOpts  []lapi.Option
 	Kustomizer         *resources.Kustomizer
 	log                logr.Logger
@@ -136,11 +137,7 @@ func (r *LinstorSatelliteReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return nil
 	})
 
-	result := ctrl.Result{
-		RequeueAfter: 1 * time.Minute,
-	}
-
-	return utils.AnyResult(result, applyErr, stateErr, deleteErr, condErr)
+	return utils.AnyResult(ctrl.Result{RequeueAfter: r.RequeueInterval}, applyErr, stateErr, deleteErr, condErr)
 }
 
 func (r *LinstorSatelliteReconciler) reconcileAppliedResource(ctx context.Context, lsatellite *piraeusiov1.LinstorSatellite, node *corev1.Node) error {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -135,6 +135,7 @@ var _ = BeforeSuite(func() {
 		Scheme:             k8sManager.GetScheme(),
 		Namespace:          Namespace,
 		ImageConfigMapName: ImageConfigMapName,
+		RequeueInterval:    DefaultCheckInterval,
 	}).SetupWithManager(k8sManager, opts)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -143,6 +144,7 @@ var _ = BeforeSuite(func() {
 		Scheme:             k8sManager.GetScheme(),
 		Namespace:          Namespace,
 		ImageConfigMapName: ImageConfigMapName,
+		RequeueInterval:    DefaultCheckInterval,
 	}).SetupWithManager(k8sManager, opts)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/vars/defaults.go
+++ b/pkg/vars/defaults.go
@@ -7,7 +7,7 @@ var DefaultControllerProperties = map[string]string{
 	linstor.NamespcDrbdNetOptions + "/rr-conflict":                        "retry-connect",
 	linstor.NamespcDrbdResourceOptions + "/on-suspended-primary-outdated": "force-secondary",
 	linstor.NamespcDrbdResourceOptions + "/on-no-data-accessible":         "suspend-io",
-	linstor.NamespcDrbdOptions + "/auto-quorum":                           "suspend-io",
+	linstor.NamespcDrbdResourceOptions + "/on-no-quorum":                  "suspend-io",
 	// The operator can do its own eviction when necessary
 	linstor.NamespcDrbdOptions + "/AutoEvictAllowEviction": "false",
 }


### PR DESCRIPTION
* LINSTOR 1.31.0 no longer supports the "auto-quorum" property. Instead, quorum is configured as usual for >2 replicas, we just have to set the right quorum loss behaviour.
* Allow overriding the default reconcile interval, which makes our tests more stable.