### PR TITLE
satellite: set up ports in container spec

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -16,15 +16,11 @@ repos:
           - --multi
       - id: check-added-large-files
   - repo: https://github.com/Bahjat/pre-commit-golang
-    rev: v1.0.2
+    rev: v1.0.5
     hooks:
       - id: gofumpt
         types: [go]
         exclude: ".*/zz_generated.*\\.go$"
-      - id: golangci-lint
-        types: [go]
-        args:
-          - --new-from-rev=HEAD
   - repo: local
     hooks:
       - id: generate-deep-copy
@@ -32,6 +28,12 @@ repos:
         language: system
         pass_filenames: false
         entry: make manifests
+      - id: golangci-lint
+        name: Run golangci-lint
+        types: [go]
+        language: system
+        pass_filenames: false
+        entry: golangci-lint run --new-from-rev=HEAD
       - id: run-tests
         name: Run go tests
         language: system

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix Operator caches not being index by a comparable key, leading to cache misses and a memory leak.
+- Fix missing `ports:` section on LINSTOR Satellites, need for certain network mesh solutions.
 
 ## [v2.8.0] - 2025-02-13
 

--- a/pkg/resources/satellite/patches/internal-tls.yaml
+++ b/pkg/resources/satellite/patches/internal-tls.yaml
@@ -23,6 +23,13 @@
               emptyDir: { }
           containers:
             - name: linstor-satellite
+              ports:
+                - containerPort: 3366
+                  protocol: TCP
+                  $patch: delete
+                - containerPort: 3367
+                  name: linstor
+                  protocol: TCP
               volumeMounts:
                 - name: internal-tls
                   mountPath: /etc/linstor/ssl-pem

--- a/pkg/resources/satellite/satellite/daemonset.yaml
+++ b/pkg/resources/satellite/satellite/daemonset.yaml
@@ -105,6 +105,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+          ports:
+            - containerPort: 3366
+              name: linstor
+              protocol: TCP
+          startupProbe:
+            tcpSocket:
+              port: linstor
+          livenessProbe:
+            tcpSocket:
+              port: linstor
           securityContext:
             readOnlyRootFilesystem: true
             privileged: true


### PR DESCRIPTION
Ports are used by certain network mesh solutions to determine connectivity.

Also includes a fix for the pre-commit setup with new golangci-lint.

Fixes #793 