### PR TITLE
Fix dashboard for scrape duration

### DIFF
--- a/config/extras/monitoring/linstor-satellite-monitor.yaml
+++ b/config/extras/monitoring/linstor-satellite-monitor.yaml
@@ -14,6 +14,10 @@ spec:
           sourceLabels:
             - __meta_kubernetes_pod_node_name
           targetLabel: node
+        - action: replace
+          sourceLabels:
+            - __meta_kubernetes_pod_label_app_kubernetes_io_component
+          targetLabel: job
   selector:
     matchLabels:
       app.kubernetes.io/component: linstor-satellite

--- a/config/extras/monitoring/piraeus-dashboard.json
+++ b/config/extras/monitoring/piraeus-dashboard.json
@@ -1328,7 +1328,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avg_over_time(scrape_duration_seconds{job=\"linstor-node\", node=~\"$node\"}[$__rate_interval])",
+          "expr": "avg_over_time(scrape_duration_seconds{job=\"linstor-satellite\", node=~\"$node\"}[$__rate_interval])",
           "legendFormat": "{{node}}",
           "refId": "A"
         }


### PR DESCRIPTION
The scrape duration shows no data currently. This PR fixes this by using a predictable job name.