### PR TITLE
Add `deletionPolicy` to Satellites

### DIFF
--- a/api/v1/deletion_policy.go
+++ b/api/v1/deletion_policy.go
@@ -1,0 +1,23 @@
+package v1
+
+// DeletionPolicy configures the way LinstorSatellite resources are deleted.
+//
+// A LinstorSatellite may be deleted because:
+// * It no longer matches the affinity and node selector of the LinstorCluster resource.
+// * The node it references has been removed from Kubernetes.
+// * It was manually deleted outside the Operator.
+//
+// A LinstorSatellite may store the last copy of a volume, in which case it is not desirable to unconditionally remove
+// the satellite from the cluster. For this reason, the following deletion policies exist:
+//
+// * DeletionPolicyEvacuate will start evacuation of the LINSTOR Satellite and wait until it completes before removing the LinstorSatellite object, comparable to the "linstor node evacuate" command.
+// * DeletionPolicyRetain will retain the LINSTOR Satellite, keeping it registered in LINSTOR, but removing associated Kubernetes resources.
+// * DeletionPolicyDelete will remove the LINSTOR Satellite from the LINSTOR Cluster without prior eviction, comparable to the "linstor node lost" command.
+// +kubebuilder:validation:Enum:=Evacuate;Retain;Delete
+type DeletionPolicy string
+
+const (
+	DeletionPolicyEvacuate DeletionPolicy = "Evacuate"
+	DeletionPolicyRetain   DeletionPolicy = "Retain"
+	DeletionPolicyDelete   DeletionPolicy = "Delete"
+)

--- a/api/v1/linstorsatellite_types.go
+++ b/api/v1/linstorsatellite_types.go
@@ -62,6 +62,10 @@ type LinstorSatelliteSpec struct {
 	// If not set, the Operator will configure all families found in the Satellites Pods' Status.
 	// +kubebuilder:validation:Optional
 	IPFamilies []IPFamily `json:"ipFamilies,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default:=Retain
+	DeletionPolicy DeletionPolicy `json:"deletionPolicy,omitempty"`
 }
 
 // LinstorSatelliteStatus defines the observed state of LinstorSatellite

--- a/api/v1/linstorsatelliteconfiguration_types.go
+++ b/api/v1/linstorsatelliteconfiguration_types.go
@@ -71,6 +71,9 @@ type LinstorSatelliteConfigurationSpec struct {
 	// +kubebuilder:validation:Optional
 	IPFamilies []IPFamily `json:"ipFamilies,omitempty"`
 
+	// +kubebuilder:validation:Optional
+	DeletionPolicy DeletionPolicy `json:"deletionPolicy,omitempty"`
+
 	// Template to apply to Satellite Pods.
 	//
 	// The template is applied as a patch to the default resource, so it can be "sparse", not listing any

--- a/charts/piraeus/templates/crds.yaml
+++ b/charts/piraeus/templates/crds.yaml
@@ -764,6 +764,26 @@ spec:
               All the LinstorSatelliteConfiguration resources with matching NodeSelector will
               be merged into a single LinstorSatelliteSpec.
             properties:
+              deletionPolicy:
+                description: |-
+                  DeletionPolicy configures the way LinstorSatellite resources are deleted.
+
+                  A LinstorSatellite may be deleted because:
+                  * It no longer matches the affinity and node selector of the LinstorCluster resource.
+                  * The node it references has been removed from Kubernetes.
+                  * It was manually deleted outside the Operator.
+
+                  A LinstorSatellite may store the last copy of a volume, in which case it is not desirable to unconditionally remove
+                  the satellite from the cluster. For this reason, the following deletion policies exist:
+
+                  * DeletionPolicyEvacuate will start evacuation of the LINSTOR Satellite and wait until it completes before removing the LinstorSatellite object, comparable to the "linstor node evacuate" command.
+                  * DeletionPolicyRetain will retain the LINSTOR Satellite, keeping it registered in LINSTOR, but removing associated Kubernetes resources.
+                  * DeletionPolicyDelete will remove the LINSTOR Satellite from the LINSTOR Cluster without prior eviction, comparable to the "linstor node lost" command.
+                enum:
+                - Evacuate
+                - Retain
+                - Delete
+                type: string
               internalTLS:
                 description: |-
                   InternalTLS configures secure communication for the LINSTOR Satellite.
@@ -1372,6 +1392,27 @@ spec:
                       satellite.
                     type: string
                 type: object
+              deletionPolicy:
+                default: Retain
+                description: |-
+                  DeletionPolicy configures the way LinstorSatellite resources are deleted.
+
+                  A LinstorSatellite may be deleted because:
+                  * It no longer matches the affinity and node selector of the LinstorCluster resource.
+                  * The node it references has been removed from Kubernetes.
+                  * It was manually deleted outside the Operator.
+
+                  A LinstorSatellite may store the last copy of a volume, in which case it is not desirable to unconditionally remove
+                  the satellite from the cluster. For this reason, the following deletion policies exist:
+
+                  * DeletionPolicyEvacuate will start evacuation of the LINSTOR Satellite and wait until it completes before removing the LinstorSatellite object, comparable to the "linstor node evacuate" command.
+                  * DeletionPolicyRetain will retain the LINSTOR Satellite, keeping it registered in LINSTOR, but removing associated Kubernetes resources.
+                  * DeletionPolicyDelete will remove the LINSTOR Satellite from the LINSTOR Cluster without prior eviction, comparable to the "linstor node lost" command.
+                enum:
+                - Evacuate
+                - Retain
+                - Delete
+                type: string
               internalTLS:
                 description: |-
                   InternalTLS configures secure communication for the LINSTOR Satellite.

--- a/config/crd/bases/piraeus.io_linstorsatelliteconfigurations.yaml
+++ b/config/crd/bases/piraeus.io_linstorsatelliteconfigurations.yaml
@@ -44,6 +44,26 @@ spec:
               All the LinstorSatelliteConfiguration resources with matching NodeSelector will
               be merged into a single LinstorSatelliteSpec.
             properties:
+              deletionPolicy:
+                description: |-
+                  DeletionPolicy configures the way LinstorSatellite resources are deleted.
+
+                  A LinstorSatellite may be deleted because:
+                  * It no longer matches the affinity and node selector of the LinstorCluster resource.
+                  * The node it references has been removed from Kubernetes.
+                  * It was manually deleted outside the Operator.
+
+                  A LinstorSatellite may store the last copy of a volume, in which case it is not desirable to unconditionally remove
+                  the satellite from the cluster. For this reason, the following deletion policies exist:
+
+                  * DeletionPolicyEvacuate will start evacuation of the LINSTOR Satellite and wait until it completes before removing the LinstorSatellite object, comparable to the "linstor node evacuate" command.
+                  * DeletionPolicyRetain will retain the LINSTOR Satellite, keeping it registered in LINSTOR, but removing associated Kubernetes resources.
+                  * DeletionPolicyDelete will remove the LINSTOR Satellite from the LINSTOR Cluster without prior eviction, comparable to the "linstor node lost" command.
+                enum:
+                - Evacuate
+                - Retain
+                - Delete
+                type: string
               internalTLS:
                 description: |-
                   InternalTLS configures secure communication for the LINSTOR Satellite.

--- a/config/crd/bases/piraeus.io_linstorsatellites.yaml
+++ b/config/crd/bases/piraeus.io_linstorsatellites.yaml
@@ -93,6 +93,27 @@ spec:
                       satellite.
                     type: string
                 type: object
+              deletionPolicy:
+                default: Retain
+                description: |-
+                  DeletionPolicy configures the way LinstorSatellite resources are deleted.
+
+                  A LinstorSatellite may be deleted because:
+                  * It no longer matches the affinity and node selector of the LinstorCluster resource.
+                  * The node it references has been removed from Kubernetes.
+                  * It was manually deleted outside the Operator.
+
+                  A LinstorSatellite may store the last copy of a volume, in which case it is not desirable to unconditionally remove
+                  the satellite from the cluster. For this reason, the following deletion policies exist:
+
+                  * DeletionPolicyEvacuate will start evacuation of the LINSTOR Satellite and wait until it completes before removing the LinstorSatellite object, comparable to the "linstor node evacuate" command.
+                  * DeletionPolicyRetain will retain the LINSTOR Satellite, keeping it registered in LINSTOR, but removing associated Kubernetes resources.
+                  * DeletionPolicyDelete will remove the LINSTOR Satellite from the LINSTOR Cluster without prior eviction, comparable to the "linstor node lost" command.
+                enum:
+                - Evacuate
+                - Retain
+                - Delete
+                type: string
               internalTLS:
                 description: |-
                   InternalTLS configures secure communication for the LINSTOR Satellite.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for different deletion policies on satellites.
+
+### Changed
+
+- Deletion of `LinstorSatellite` no longer causes a node evacuation by default. See [`spec.deletionPolicy`](./reference/linstorsatelliteconfiguration.md#specdeletionpolicy).
+
 ## [v2.8.1] - 2025-04-09
 
 ### Added

--- a/docs/reference/linstorsatellite.md
+++ b/docs/reference/linstorsatellite.md
@@ -35,6 +35,11 @@ Holds the properties which should be set on the node level. Inherited from match
 Configures a TLS secret used by the LINSTOR Satellite. Inherited from matching
 [`LinstorSatelliteConfiguration`](./linstorsatelliteconfiguration.md#specproperties) resources.
 
+### `.spec.deletionPolicy`
+
+Configures the deletion policy to use for LINSTOR Satellites. Inherited from matching
+[`LinstorSatelliteConfiguration`](./linstorsatelliteconfiguration.md#specdeletionpolicy) resources.
+
 ### `.spec.patches`
 
 Holds patches to apply to the Kubernetes resources. Inherited from matching

--- a/docs/reference/linstorsatelliteconfiguration.md
+++ b/docs/reference/linstorsatelliteconfiguration.md
@@ -262,6 +262,31 @@ spec:
       name: piraeus-root
 ```
 
+### `spec.deletionPolicy`
+
+Configure how Satellite removal is handled. Possible policies are:
+
+* `Retain`, the default policy if not set. This policy will cause the Satellite to remain registered in LINSTOR when
+   the LinstorSatellite resource is removed.
+* `Evacuate`. This policy will cause the Satellite to be evacuated, i.e. all deployed resources will be moved to a
+   replacement node. This requires spare capacity in the cluster. Deletion will only succeed if all resources have
+   been moved off the node.
+* `Delete`. This policy causes the Satellite to be forcefully removed from the Cluster. All Kubernetes resources will
+   be removed, and the node will be removed from LINSTOR without regard for replica integrity.
+
+#### Example
+
+This example sets the deletion policy of LINSTOR Satellites to `Evacuate`.
+
+```yaml
+apiVersion: piraeus.io/v1
+kind: LinstorSatelliteConfiguration
+metadata:
+  name: satellite-deletion-policy
+spec:
+ deletionPolicy: Evacuate
+```
+
 ### `.spec.ipFamilies`
 
 Configures the IP Family (IPv4 or IPv6) to use to connect to the LINSTOR Satellite.

--- a/docs/upgrade/README.md
+++ b/docs/upgrade/README.md
@@ -14,6 +14,27 @@ $ kubectl apply --server-side -k "https://github.com/piraeusdatastore/piraeus-op
 $ kubectl wait pod --for=condition=Ready -n piraeus-datastore --all
 ```
 
+# Upgrades from v2.8 to v2.9
+
+Generally, no special steps required.
+
+The default behaviour when deleting the `LinstorSatellite` resource has been changed. The Operator no longer causes
+the node to be evacuated by default. Instead, the LINSTOR Satellite is left unchanged. To restore the old behaviour,
+create the following resource:
+
+```yaml
+apiVersion: piraeus.io/v1
+kind: LinstorSatelliteConfiguration
+metadata:
+  name: satellite-deletion-policy
+spec:
+ deletionPolicy: Evacuate
+```
+
+# Upgrades from v2.7 to v2.8
+
+No special steps required.
+
 # Upgrades from v2.6 to v2.7
 
 Generally, no special steps required.

--- a/internal/controller/linstorcluster_controller.go
+++ b/internal/controller/linstorcluster_controller.go
@@ -671,6 +671,14 @@ func (r *LinstorClusterReconciler) kustomizeLinstorSatellite(ctx context.Context
 		})
 	}
 
+	if cfg.Spec.DeletionPolicy != "" {
+		patches = append(patches, utils.JsonPatch{
+			Op:    utils.Add,
+			Path:  "/spec/deletionPolicy",
+			Value: cfg.Spec.DeletionPolicy,
+		})
+	}
+
 	for j := range cfg.Spec.Properties {
 		patches = append(patches, utils.JsonPatch{
 			Op:    utils.Add,

--- a/internal/controller/linstorcluster_test.go
+++ b/internal/controller/linstorcluster_test.go
@@ -134,6 +134,7 @@ var _ = Describe("LinstorCluster controller", func() {
 						Patches: []piraeusiov1.Patch{
 							{Target: &piraeusiov1.Selector{Kind: "Pod"}, Patch: "pod-patch1"},
 						},
+						DeletionPolicy: piraeusiov1.DeletionPolicyEvacuate,
 					},
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -186,7 +187,8 @@ var _ = Describe("LinstorCluster controller", func() {
 						{Name: "pool1", LvmPool: &piraeusiov1.LinstorStoragePoolLvm{}},
 						{Name: "pool2", LvmThinPool: &piraeusiov1.LinstorStoragePoolLvmThin{VolumeGroup: "vg1", ThinPool: "thin1"}, Source: &piraeusiov1.LinstorStoragePoolSource{HostDevices: []string{"/dev/vdb"}}},
 					},
-					InternalTLS: &piraeusiov1.TLSConfigWithHandshakeDaemon{},
+					InternalTLS:    &piraeusiov1.TLSConfigWithHandshakeDaemon{},
+					DeletionPolicy: piraeusiov1.DeletionPolicyEvacuate,
 				}
 
 				specZoneB := &piraeusiov1.LinstorSatelliteSpec{
@@ -202,7 +204,8 @@ var _ = Describe("LinstorCluster controller", func() {
 						{Name: "pool1", LvmPool: &piraeusiov1.LinstorStoragePoolLvm{}},
 						{Name: "pool2", LvmThinPool: &piraeusiov1.LinstorStoragePoolLvmThin{}},
 					},
-					InternalTLS: &piraeusiov1.TLSConfigWithHandshakeDaemon{},
+					InternalTLS:    &piraeusiov1.TLSConfigWithHandshakeDaemon{},
+					DeletionPolicy: piraeusiov1.DeletionPolicyRetain,
 				}
 
 				Expect(&satNode1A.Spec).To(Equal(specZoneA))

--- a/internal/controller/linstorsatellite_controller.go
+++ b/internal/controller/linstorsatellite_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -30,7 +31,7 @@ import (
 	"golang.org/x/exp/slices"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -88,7 +89,7 @@ func (r *LinstorSatelliteReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	lsatellite := &piraeusiov1.LinstorSatellite{}
 	err := r.Get(ctx, req.NamespacedName, lsatellite)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
 
@@ -97,7 +98,7 @@ func (r *LinstorSatelliteReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	var node corev1.Node
 	err = r.Get(ctx, req.NamespacedName, &node)
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil && !k8serrors.IsNotFound(err) {
 		return ctrl.Result{}, err
 	}
 
@@ -117,9 +118,9 @@ func (r *LinstorSatelliteReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if lsatellite.GetDeletionTimestamp() != nil {
 		deleteErr = r.deleteSatellite(ctx, lsatellite)
 		if deleteErr != nil {
-			conds.AddError("EvacuationCompleted", deleteErr)
+			conds.AddError("DeletionCompleted", deleteErr)
 		} else {
-			conds.AddSuccess("EvacuationCompleted", "evacuation complete")
+			conds.AddSuccess("DeletionCompleted", fmt.Sprintf("deletion using '%s' policy complete", lsatellite.Spec.DeletionPolicy))
 		}
 	} else {
 		if controllerutil.AddFinalizer(lsatellite, vars.SatelliteFinalizer) {
@@ -144,6 +145,11 @@ func (r *LinstorSatelliteReconciler) reconcileAppliedResource(ctx context.Contex
 	resMap, err := r.kustomizeNodeResources(ctx, lsatellite, node)
 	if err != nil {
 		return err
+	}
+
+	if lsatellite.GetDeletionTimestamp() != nil && lsatellite.Spec.DeletionPolicy == piraeusiov1.DeletionPolicyDelete {
+		r.log.Info("Forcing deletion of Satellite resources because of deletion policy 'Delete'")
+		resMap = resmap.New()
 	}
 
 	for _, res := range resMap.Resources() {
@@ -535,28 +541,38 @@ func (r *LinstorSatelliteReconciler) deleteSatellite(ctx context.Context, lsatel
 		return r.Client.Update(ctx, lsatellite)
 	}
 
-	err = lc.Nodes.Evacuate(ctx, lsatellite.Name)
-	if err != nil && err != lapi.NotFoundError {
-		return err
-	}
-
-	ress, err := lc.Resources.GetResourceView(ctx, &lapi.ListOpts{Node: []string{lsatellite.Name}})
-	if err != nil && err != lapi.NotFoundError {
-		return err
-	}
-
-	if len(ress) > 0 {
-		resNames := make([]string, 0, len(ress))
-		for _, r := range ress {
-			resNames = append(resNames, r.Name)
+	switch lsatellite.Spec.DeletionPolicy {
+	case piraeusiov1.DeletionPolicyEvacuate:
+		err = lc.Nodes.Evacuate(ctx, lsatellite.Name)
+		if err != nil && !errors.Is(err, lapi.NotFoundError) {
+			return err
 		}
 
-		return fmt.Errorf("remaining resources: %s", strings.Join(resNames, ", "))
-	}
+		ress, err := lc.Resources.GetResourceView(ctx, &lapi.ListOpts{Node: []string{lsatellite.Name}})
+		if err != nil && !errors.Is(err, lapi.NotFoundError) {
+			return err
+		}
 
-	err = lc.Nodes.Delete(ctx, lsatellite.Name)
-	if err != nil && err != lapi.NotFoundError {
-		return err
+		if len(ress) > 0 {
+			resNames := make([]string, 0, len(ress))
+			for _, r := range ress {
+				resNames = append(resNames, r.Name)
+			}
+
+			return fmt.Errorf("remaining resources: %s", strings.Join(resNames, ", "))
+		}
+
+		err = lc.Nodes.Delete(ctx, lsatellite.Name)
+		if err != nil && !errors.Is(err, lapi.NotFoundError) {
+			return err
+		}
+	case piraeusiov1.DeletionPolicyDelete:
+		err := lc.Nodes.Lost(ctx, lsatellite.Name)
+		if err != nil && !errors.Is(err, lapi.NotFoundError) {
+			return err
+		}
+	case "", piraeusiov1.DeletionPolicyRetain:
+		r.log.Info("Nothing to do for deletion of satellite with 'Retain' deletion policy")
 	}
 
 	controllerutil.RemoveFinalizer(lsatellite, vars.SatelliteFinalizer)

--- a/internal/controller/linstorsatellite_controller.go
+++ b/internal/controller/linstorsatellite_controller.go
@@ -413,6 +413,13 @@ func (r *LinstorSatelliteReconciler) reconcileLinstorSatelliteState(ctx context.
 	if lnode.ConnectionStatus == "ONLINE" {
 		conds.AddSuccess(conditions.Available, "satellite online")
 
+		if slices.Contains(lnode.Flags, linstor.FlagEvacuate) || slices.Contains(lnode.Flags, linstor.FlagEvicted) {
+			err := lc.Nodes.Restore(ctx, lnode.Name, lapi.NodeRestore{})
+			if err != nil {
+				conds.AddError(conditions.Configured, err)
+			}
+		}
+
 		err := r.reconcileStoragePools(ctx, lc, lsatellite, node)
 		if err != nil {
 			conds.AddError(conditions.Configured, err)

--- a/internal/controller/linstorsatellite_test.go
+++ b/internal/controller/linstorsatellite_test.go
@@ -82,24 +82,17 @@ var _ = Describe("LinstorSatelliteReconciler", func() {
 		})
 
 		It("should select loader image, apply resources, setting finalizer and condition", func(ctx context.Context) {
+			Eventually(func() *metav1.Condition {
+				return GetSatelliteCondition(ctx, k8sClient, ExampleNodeName, string(conditions.Applied))
+			}).Should(HaveField("Status", metav1.ConditionTrue))
+
 			var satellite piraeusiov1.LinstorSatellite
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, types.NamespacedName{Name: ExampleNodeName}, &satellite)
-				if err != nil {
-					return false
-				}
-
-				condition := meta.FindStatusCondition(satellite.Status.Conditions, string(conditions.Applied))
-				if condition == nil || condition.ObservedGeneration != satellite.Generation {
-					return false
-				}
-				return condition.Status == metav1.ConditionTrue
-			}).Should(BeTrue())
-
+			err := k8sClient.Get(ctx, client.ObjectKey{Name: ExampleNodeName}, &satellite)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(satellite.Finalizers).To(ContainElement(vars.SatelliteFinalizer))
 
 			var ds appsv1.DaemonSet
-			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: Namespace, Name: "linstor-satellite." + ExampleNodeName}, &ds)
+			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: Namespace, Name: "linstor-satellite." + ExampleNodeName}, &ds)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ds.Spec.Template.Spec.InitContainers).To(HaveLen(3))
 			Expect(ds.Spec.Template.Spec.InitContainers[0].Image).To(ContainSubstring("quay.io/piraeusdatastore/drbd9-almalinux9:"))
@@ -274,6 +267,22 @@ var _ = Describe("LinstorSatelliteReconciler", func() {
 				}).Should(Succeed())
 			})
 
+			It("should restore an evacuated satellite", func(ctx context.Context) {
+				Eventually(func(g Gomega) {
+					_, err := linstorClient.Nodes.Get(ctx, ExampleNodeName)
+					g.Expect(err).NotTo(HaveOccurred())
+				}).Should(Succeed())
+
+				err := linstorClient.Nodes.Evacuate(ctx, ExampleNodeName)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func(g Gomega) {
+					node, err := linstorClient.Nodes.Get(ctx, ExampleNodeName)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(node.Flags).NotTo(ContainElement(linstor.FlagEvacuate))
+				}).Should(Succeed())
+			})
+
 			Context("with additional finalizer and resource", func() {
 				BeforeEach(func(ctx context.Context) {
 					err := k8sClient.Patch(ctx, &piraeusiov1.LinstorSatellite{
@@ -326,18 +335,7 @@ var _ = Describe("LinstorSatelliteReconciler", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					Eventually(func() *metav1.Condition {
-						var satellite piraeusiov1.LinstorSatellite
-						err := k8sClient.Get(ctx, types.NamespacedName{Name: ExampleNodeName}, &satellite)
-						if err != nil {
-							return nil
-						}
-
-						condition := meta.FindStatusCondition(satellite.Status.Conditions, "DeletionCompleted")
-						if condition == nil || condition.ObservedGeneration != satellite.Generation {
-							return nil
-						}
-
-						return condition
+						return GetSatelliteCondition(ctx, k8sClient, ExampleNodeName, "DeletionCompleted")
 					}).Should(HaveField("Status", metav1.ConditionTrue))
 
 					node, err := linstorClient.Nodes.Get(ctx, ExampleNodeName)
@@ -370,20 +368,8 @@ var _ = Describe("LinstorSatelliteReconciler", func() {
 
 					GinkgoWriter.Println("checking that Satellite status reports evacuation progress")
 					Eventually(func() *metav1.Condition {
-						var satellite piraeusiov1.LinstorSatellite
-						err := k8sClient.Get(ctx, types.NamespacedName{Name: ExampleNodeName}, &satellite)
-						if err != nil {
-							return nil
-						}
-
-						condition := meta.FindStatusCondition(satellite.Status.Conditions, "DeletionCompleted")
-						if condition == nil || condition.ObservedGeneration != satellite.Generation {
-							return nil
-						}
-
-						return condition
+						return GetSatelliteCondition(ctx, k8sClient, ExampleNodeName, "DeletionCompleted")
 					}).Should(And(
-						Not(BeNil()),
 						HaveField("Status", metav1.ConditionFalse),
 						HaveField("Message", ContainSubstring("resource1"))),
 					)
@@ -397,20 +383,9 @@ var _ = Describe("LinstorSatelliteReconciler", func() {
 						g.Expect(err).To(Equal(lapi.NotFoundError))
 					}).Should(Succeed())
 
-					Eventually(func() metav1.ConditionStatus {
-						var satellite piraeusiov1.LinstorSatellite
-						err := k8sClient.Get(ctx, types.NamespacedName{Name: ExampleNodeName}, &satellite)
-						if err != nil {
-							return metav1.ConditionUnknown
-						}
-
-						condition := meta.FindStatusCondition(satellite.Status.Conditions, "DeletionCompleted")
-						if condition == nil || condition.ObservedGeneration != satellite.Generation {
-							return metav1.ConditionUnknown
-						}
-
-						return condition.Status
-					}).Should(Equal(metav1.ConditionTrue))
+					Eventually(func() *metav1.Condition {
+						return GetSatelliteCondition(ctx, k8sClient, ExampleNodeName, "DeletionCompleted")
+					}).Should(HaveField("Status", metav1.ConditionTrue))
 				})
 
 				It("should respect DeletionPolicy=Delete", func(ctx context.Context) {
@@ -438,18 +413,7 @@ var _ = Describe("LinstorSatelliteReconciler", func() {
 					}).Should(Succeed())
 
 					Eventually(func() *metav1.Condition {
-						var satellite piraeusiov1.LinstorSatellite
-						err := k8sClient.Get(ctx, types.NamespacedName{Name: ExampleNodeName}, &satellite)
-						if err != nil {
-							return nil
-						}
-
-						condition := meta.FindStatusCondition(satellite.Status.Conditions, "DeletionCompleted")
-						if condition == nil || condition.ObservedGeneration != satellite.Generation {
-							return nil
-						}
-
-						return condition
+						return GetSatelliteCondition(ctx, k8sClient, ExampleNodeName, "DeletionCompleted")
 					}).Should(And(
 						Not(BeNil()),
 						HaveField("Status", metav1.ConditionFalse),
@@ -468,3 +432,18 @@ var _ = Describe("LinstorSatelliteReconciler", func() {
 		})
 	})
 })
+
+func GetSatelliteCondition(ctx context.Context, k8sClient client.Client, nodeName, ty string) *metav1.Condition {
+	var satellite piraeusiov1.LinstorSatellite
+	err := k8sClient.Get(ctx, types.NamespacedName{Name: ExampleNodeName}, &satellite)
+	if err != nil {
+		return nil
+	}
+
+	condition := meta.FindStatusCondition(satellite.Status.Conditions, ty)
+	if condition == nil || condition.ObservedGeneration != satellite.Generation {
+		return nil
+	}
+
+	return condition
+}

--- a/internal/controller/linstorsatellite_test.go
+++ b/internal/controller/linstorsatellite_test.go
@@ -3,7 +3,6 @@ package controller_test
 import (
 	"context"
 	"net"
-	"net/http/httptest"
 
 	linstor "github.com/LINBIT/golinstor"
 	lapi "github.com/LINBIT/golinstor/client"
@@ -17,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	piraeusiov1 "github.com/piraeusdatastore/piraeus-operator/v2/api/v1"
 	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/conditions"
@@ -32,10 +30,10 @@ var _ = Describe("LinstorSatelliteReconciler", func() {
 	Context("When creating LinstorSatellite resources", func() {
 		var clusterRef *piraeusiov1.ClusterReference
 		var satellite *piraeusiov1.LinstorSatellite
-		var linstorController *httptest.Server
+		var linstorController *fakelinstor.FakeLinstor
 
 		BeforeEach(func(ctx context.Context) {
-			linstorController = httptest.NewServer(fakelinstor.New())
+			linstorController = fakelinstor.New()
 
 			err := k8sClient.Create(ctx, &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Name: ExampleNodeName},
@@ -55,7 +53,7 @@ var _ = Describe("LinstorSatelliteReconciler", func() {
 					ClusterRef: piraeusiov1.ClusterReference{
 						Name: "example",
 						ExternalController: &piraeusiov1.LinstorExternalControllerRef{
-							URL: linstorController.URL,
+							URL: linstorController.Server.URL,
 						},
 					},
 				},
@@ -80,7 +78,7 @@ var _ = Describe("LinstorSatelliteReconciler", func() {
 			err = k8sClient.DeleteAllOf(ctx, &corev1.Node{})
 			Expect(err).NotTo(HaveOccurred())
 
-			linstorController.Close()
+			linstorController.Server.Close()
 		})
 
 		It("should select loader image, apply resources, setting finalizer and condition", func(ctx context.Context) {
@@ -314,25 +312,18 @@ var _ = Describe("LinstorSatelliteReconciler", func() {
 						}
 						g.Expect(err).NotTo(HaveOccurred())
 
-						controllerutil.RemoveFinalizer(&satellite, "piraeus.io/test")
+						satellite.ObjectMeta.Finalizers = []string{}
 						err = k8sClient.Update(ctx, &satellite)
+						g.Expect(err).NotTo(HaveOccurred())
+
+						err = k8sClient.Delete(ctx, &satellite)
 						g.Expect(err).NotTo(HaveOccurred())
 					}).Should(Succeed())
 				})
 
-				It("should evacuate the node after deleting the satellite", func(ctx context.Context) {
+				It("should respect DeletionPolicy=Retain (Default policy)", func(ctx context.Context) {
 					err := k8sClient.Delete(ctx, &piraeusiov1.LinstorSatellite{ObjectMeta: metav1.ObjectMeta{Name: ExampleNodeName}})
 					Expect(err).NotTo(HaveOccurred())
-
-					GinkgoWriter.Println("checking that Satellite is in evacuation")
-
-					Eventually(func(g Gomega) {
-						node, err := linstorClient.Nodes.Get(ctx, ExampleNodeName)
-						g.Expect(err).NotTo(HaveOccurred())
-						g.Expect(node.Flags).To(ContainElement(linstor.FlagEvacuate))
-					}).Should(Succeed())
-
-					GinkgoWriter.Println("checking that Satellite status reports evacuation progress")
 
 					Eventually(func() *metav1.Condition {
 						var satellite piraeusiov1.LinstorSatellite
@@ -341,7 +332,51 @@ var _ = Describe("LinstorSatelliteReconciler", func() {
 							return nil
 						}
 
-						condition := meta.FindStatusCondition(satellite.Status.Conditions, "EvacuationCompleted")
+						condition := meta.FindStatusCondition(satellite.Status.Conditions, "DeletionCompleted")
+						if condition == nil || condition.ObservedGeneration != satellite.Generation {
+							return nil
+						}
+
+						return condition
+					}).Should(HaveField("Status", metav1.ConditionTrue))
+
+					node, err := linstorClient.Nodes.Get(ctx, ExampleNodeName)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(node.ConnectionStatus).To(Equal("ONLINE"))
+
+					_, err = linstorClient.Resources.Get(ctx, "resource1", ExampleNodeName)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should respect DeletionPolicy=Evacuate", func(ctx context.Context) {
+					err := k8sClient.Patch(ctx, &piraeusiov1.LinstorSatellite{
+						TypeMeta:   TypeMeta,
+						ObjectMeta: metav1.ObjectMeta{Name: ExampleNodeName, Finalizers: []string{"piraeus.io/test"}},
+						Spec: piraeusiov1.LinstorSatelliteSpec{
+							DeletionPolicy: piraeusiov1.DeletionPolicyEvacuate,
+						},
+					}, client.Apply, client.FieldOwner("test"), client.ForceOwnership)
+					Expect(err).NotTo(HaveOccurred())
+
+					err = k8sClient.Delete(ctx, &piraeusiov1.LinstorSatellite{ObjectMeta: metav1.ObjectMeta{Name: ExampleNodeName}})
+					Expect(err).NotTo(HaveOccurred())
+
+					GinkgoWriter.Println("checking that Satellite is in evacuation")
+					Eventually(func(g Gomega) {
+						node, err := linstorClient.Nodes.Get(ctx, ExampleNodeName)
+						g.Expect(err).NotTo(HaveOccurred())
+						g.Expect(node.Flags).To(ContainElement(linstor.FlagEvacuate))
+					}).Should(Succeed())
+
+					GinkgoWriter.Println("checking that Satellite status reports evacuation progress")
+					Eventually(func() *metav1.Condition {
+						var satellite piraeusiov1.LinstorSatellite
+						err := k8sClient.Get(ctx, types.NamespacedName{Name: ExampleNodeName}, &satellite)
+						if err != nil {
+							return nil
+						}
+
+						condition := meta.FindStatusCondition(satellite.Status.Conditions, "DeletionCompleted")
 						if condition == nil || condition.ObservedGeneration != satellite.Generation {
 							return nil
 						}
@@ -354,7 +389,6 @@ var _ = Describe("LinstorSatelliteReconciler", func() {
 					)
 
 					GinkgoWriter.Println("by deleting resources, evacuation should complete")
-
 					err = linstorClient.ResourceDefinitions.Delete(ctx, "resource1")
 					Expect(err).NotTo(HaveOccurred())
 
@@ -370,13 +404,65 @@ var _ = Describe("LinstorSatelliteReconciler", func() {
 							return metav1.ConditionUnknown
 						}
 
-						condition := meta.FindStatusCondition(satellite.Status.Conditions, "EvacuationCompleted")
+						condition := meta.FindStatusCondition(satellite.Status.Conditions, "DeletionCompleted")
 						if condition == nil || condition.ObservedGeneration != satellite.Generation {
 							return metav1.ConditionUnknown
 						}
 
 						return condition.Status
 					}).Should(Equal(metav1.ConditionTrue))
+				})
+
+				It("should respect DeletionPolicy=Delete", func(ctx context.Context) {
+					err := k8sClient.Patch(ctx, &piraeusiov1.LinstorSatellite{
+						TypeMeta:   TypeMeta,
+						ObjectMeta: metav1.ObjectMeta{Name: ExampleNodeName, Finalizers: []string{"piraeus.io/test"}},
+						Spec: piraeusiov1.LinstorSatelliteSpec{
+							DeletionPolicy: piraeusiov1.DeletionPolicyDelete,
+						},
+					}, client.Apply, client.FieldOwner("test"), client.ForceOwnership)
+					Expect(err).NotTo(HaveOccurred())
+
+					err = k8sClient.Delete(ctx, &piraeusiov1.LinstorSatellite{ObjectMeta: metav1.ObjectMeta{Name: ExampleNodeName}})
+					Expect(err).NotTo(HaveOccurred())
+
+					GinkgoWriter.Println("checking that associated resources are deleted")
+					Eventually(func(g Gomega) {
+						var ds appsv1.DaemonSet
+						err := k8sClient.Get(ctx, types.NamespacedName{Namespace: Namespace, Name: "linstor-satellite." + ExampleNodeName}, &ds)
+						if errors.IsNotFound(err) {
+							return
+						}
+						g.Expect(err).NotTo(HaveOccurred())
+						g.Expect(ds.ObjectMeta.DeletionTimestamp).NotTo(BeNil())
+					}).Should(Succeed())
+
+					Eventually(func() *metav1.Condition {
+						var satellite piraeusiov1.LinstorSatellite
+						err := k8sClient.Get(ctx, types.NamespacedName{Name: ExampleNodeName}, &satellite)
+						if err != nil {
+							return nil
+						}
+
+						condition := meta.FindStatusCondition(satellite.Status.Conditions, "DeletionCompleted")
+						if condition == nil || condition.ObservedGeneration != satellite.Generation {
+							return nil
+						}
+
+						return condition
+					}).Should(And(
+						Not(BeNil()),
+						HaveField("Status", metav1.ConditionFalse),
+						HaveField("Message", ContainSubstring("node '%s' is not 'OFFLINE'", ExampleNodeName))),
+					)
+
+					linstorController.SetConnectionStatus(ExampleNodeName, "OFFLINE")
+
+					GinkgoWriter.Println("checking that Satellite is forcefully removed from LINSTOR")
+					Eventually(func() error {
+						_, err := linstorClient.Nodes.Get(ctx, ExampleNodeName)
+						return err
+					}).Should(Equal(lapi.NotFoundError))
 				})
 			})
 		})

--- a/pkg/fakelinstor/fakelinstor.go
+++ b/pkg/fakelinstor/fakelinstor.go
@@ -24,6 +24,7 @@ func New() *FakeLinstor {
 	mux.Handle("GET /v1/nodes/{node}", wrapHandler(f.getNode))
 	mux.Handle("DELETE /v1/nodes/{node}", wrapHandler(f.deleteNode))
 	mux.Handle("PUT /v1/nodes/{node}/evacuate", wrapHandler(f.evacuateNode))
+	mux.Handle("PUT /v1/nodes/{node}/restore", wrapHandler(f.restoreNode))
 	mux.Handle("DELETE /v1/nodes/{node}/lost", wrapHandler(f.lostNode))
 	mux.Handle("POST /v1/resource-definitions", wrapHandler(f.createResourceDefinition))
 	mux.Handle("DELETE /v1/resource-definitions/{rd}", wrapHandler(f.deleteResourceDefinition))
@@ -235,6 +236,24 @@ func (f *FakeLinstor) evacuateNode(r *http.Request) (any, error) {
 			if !slices.Contains(f.nodes[i].Flags, linstor.FlagEvacuate) {
 				f.nodes[i].Flags = append(f.nodes[i].Flags, linstor.FlagEvacuate)
 			}
+			return nil, nil
+		}
+	}
+
+	return nil, lapi.NotFoundError
+}
+
+func (f *FakeLinstor) restoreNode(r *http.Request) (any, error) {
+	node := r.PathValue("node")
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	for i := range f.nodes {
+		if f.nodes[i].Name == node {
+			f.nodes[i].Flags = slices.DeleteFunc(f.nodes[i].Flags, func(s string) bool {
+				return s == linstor.FlagEvacuate || s == linstor.FlagEvicted
+			})
 			return nil, nil
 		}
 	}

--- a/pkg/fakelinstor/fakelinstor.go
+++ b/pkg/fakelinstor/fakelinstor.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"sync"
 
 	linstor "github.com/LINBIT/golinstor"
@@ -14,31 +15,36 @@ import (
 	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/vars"
 )
 
-func New() http.Handler {
-	f := &fakeLinstor{}
+func New() *FakeLinstor {
+	f := &FakeLinstor{}
 
 	mux := http.NewServeMux()
-	mux.Handle("GET /v1/controller/version", WrapHandler(f.getVersion))
-	mux.Handle("POST /v1/nodes", WrapHandler(f.createNode))
-	mux.Handle("GET /v1/nodes/{node}", WrapHandler(f.getNode))
-	mux.Handle("DELETE /v1/nodes/{node}", WrapHandler(f.deleteNode))
-	mux.Handle("PUT /v1/nodes/{node}/evacuate", WrapHandler(f.evacuateNode))
-	mux.Handle("POST /v1/resource-definitions", WrapHandler(f.createResourceDefinition))
-	mux.Handle("DELETE /v1/resource-definitions/{rd}", WrapHandler(f.deleteResourceDefinition))
-	mux.Handle("POST /v1/resource-definitions/{rd}/resources/{node}", WrapHandler(f.createResource))
-	mux.Handle("GET /v1/view/resources", WrapHandler(f.viewResources))
+	mux.Handle("GET /v1/controller/version", wrapHandler(f.getVersion))
+	mux.Handle("POST /v1/nodes", wrapHandler(f.createNode))
+	mux.Handle("GET /v1/nodes/{node}", wrapHandler(f.getNode))
+	mux.Handle("DELETE /v1/nodes/{node}", wrapHandler(f.deleteNode))
+	mux.Handle("PUT /v1/nodes/{node}/evacuate", wrapHandler(f.evacuateNode))
+	mux.Handle("DELETE /v1/nodes/{node}/lost", wrapHandler(f.lostNode))
+	mux.Handle("POST /v1/resource-definitions", wrapHandler(f.createResourceDefinition))
+	mux.Handle("DELETE /v1/resource-definitions/{rd}", wrapHandler(f.deleteResourceDefinition))
+	mux.Handle("GET /v1/resource-definitions/{rd}/resources/{node}", wrapHandler(f.getResource))
+	mux.Handle("POST /v1/resource-definitions/{rd}/resources/{node}", wrapHandler(f.createResource))
+	mux.Handle("GET /v1/view/resources", wrapHandler(f.viewResources))
 
-	return mux
+	f.Server = httptest.NewServer(mux)
+	return f
 }
 
-type fakeLinstor struct {
+type FakeLinstor struct {
+	Server *httptest.Server
+
 	mu                  sync.Mutex
 	nodes               []lapi.Node
 	resources           []lapi.ResourceWithVolumes
 	resourceDefinitions []lapi.ResourceDefinition
 }
 
-func WrapHandler(f func(r *http.Request) (any, error)) http.Handler {
+func wrapHandler(f func(r *http.Request) (any, error)) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		data, err := f(r)
 		if err != nil {
@@ -56,7 +62,7 @@ func WrapHandler(f func(r *http.Request) (any, error)) http.Handler {
 	})
 }
 
-func (f *fakeLinstor) getVersion(r *http.Request) (any, error) {
+func (f *FakeLinstor) getVersion(r *http.Request) (any, error) {
 	return lapi.ControllerVersion{
 		Version:        vars.Version,
 		RestApiVersion: "fake-rest-api",
@@ -65,7 +71,7 @@ func (f *fakeLinstor) getVersion(r *http.Request) (any, error) {
 	}, nil
 }
 
-func (f *fakeLinstor) createNode(r *http.Request) (any, error) {
+func (f *FakeLinstor) createNode(r *http.Request) (any, error) {
 	defer r.Body.Close() //nolint:errcheck
 
 	var node lapi.Node
@@ -90,7 +96,7 @@ func (f *fakeLinstor) createNode(r *http.Request) (any, error) {
 	return nil, nil
 }
 
-func (f *fakeLinstor) getNode(r *http.Request) (any, error) {
+func (f *FakeLinstor) getNode(r *http.Request) (any, error) {
 	node := r.PathValue("node")
 
 	f.mu.Lock()
@@ -105,7 +111,7 @@ func (f *fakeLinstor) getNode(r *http.Request) (any, error) {
 	return nil, lapi.NotFoundError
 }
 
-func (f *fakeLinstor) deleteNode(r *http.Request) (any, error) {
+func (f *FakeLinstor) deleteNode(r *http.Request) (any, error) {
 	node := r.PathValue("node")
 
 	f.mu.Lock()
@@ -124,7 +130,7 @@ func (f *fakeLinstor) deleteNode(r *http.Request) (any, error) {
 	return nil, nil
 }
 
-func (f *fakeLinstor) createResourceDefinition(r *http.Request) (any, error) {
+func (f *FakeLinstor) createResourceDefinition(r *http.Request) (any, error) {
 	defer r.Body.Close() //nolint:errcheck
 
 	var rd lapi.ResourceDefinitionCreate
@@ -146,7 +152,23 @@ func (f *fakeLinstor) createResourceDefinition(r *http.Request) (any, error) {
 	return nil, nil
 }
 
-func (f *fakeLinstor) createResource(r *http.Request) (any, error) {
+func (f *FakeLinstor) getResource(r *http.Request) (any, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	resource := r.PathValue("rd")
+	node := r.PathValue("node")
+
+	for i := range f.resources {
+		if f.resources[i].NodeName == node && f.resources[i].Name == resource {
+			return f.resources[i], nil
+		}
+	}
+
+	return nil, lapi.NotFoundError
+}
+
+func (f *FakeLinstor) createResource(r *http.Request) (any, error) {
 	defer r.Body.Close() //nolint:errcheck
 
 	var rc lapi.ResourceCreate
@@ -186,7 +208,7 @@ func (f *fakeLinstor) createResource(r *http.Request) (any, error) {
 	return nil, nil
 }
 
-func (f *fakeLinstor) deleteResourceDefinition(r *http.Request) (any, error) {
+func (f *FakeLinstor) deleteResourceDefinition(r *http.Request) (any, error) {
 	rd := r.PathValue("rd")
 
 	f.mu.Lock()
@@ -202,7 +224,7 @@ func (f *fakeLinstor) deleteResourceDefinition(r *http.Request) (any, error) {
 	return nil, nil
 }
 
-func (f *fakeLinstor) evacuateNode(r *http.Request) (any, error) {
+func (f *FakeLinstor) evacuateNode(r *http.Request) (any, error) {
 	node := r.PathValue("node")
 
 	f.mu.Lock()
@@ -220,7 +242,31 @@ func (f *fakeLinstor) evacuateNode(r *http.Request) (any, error) {
 	return nil, lapi.NotFoundError
 }
 
-func (f *fakeLinstor) viewResources(r *http.Request) (any, error) {
+func (f *FakeLinstor) lostNode(r *http.Request) (any, error) {
+	node := r.PathValue("node")
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	for i := range f.nodes {
+		if f.nodes[i].Name == node {
+			if f.nodes[i].ConnectionStatus != "OFFLINE" {
+				return nil, fmt.Errorf("node '%s' is not 'OFFLINE'", node)
+			}
+		}
+	}
+
+	f.nodes = slices.DeleteFunc(f.nodes, func(n lapi.Node) bool {
+		return n.Name == node
+	})
+	f.resources = slices.DeleteFunc(f.resources, func(n lapi.ResourceWithVolumes) bool {
+		return n.NodeName == node
+	})
+
+	return nil, nil
+}
+
+func (f *FakeLinstor) viewResources(r *http.Request) (any, error) {
 	r.URL.Query()
 
 	resources := slices.Clone(f.resources)
@@ -231,4 +277,15 @@ func (f *fakeLinstor) viewResources(r *http.Request) (any, error) {
 	}
 
 	return resources, nil
+}
+
+func (f *FakeLinstor) SetConnectionStatus(name string, status string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	for i := range f.nodes {
+		if f.nodes[i].Name == name {
+			f.nodes[i].ConnectionStatus = status
+		}
+	}
 }

--- a/pkg/merge/linstorsatelliteconfiguration.go
+++ b/pkg/merge/linstorsatelliteconfiguration.go
@@ -62,6 +62,10 @@ func SatelliteConfigurations(ctx context.Context, node *corev1.Node, configs ...
 		if cfg.Spec.IPFamilies != nil {
 			result.Spec.IPFamilies = cfg.Spec.IPFamilies
 		}
+
+		if cfg.Spec.DeletionPolicy != "" {
+			result.Spec.DeletionPolicy = cfg.Spec.DeletionPolicy
+		}
 	}
 
 	for _, v := range propsMap {


### PR DESCRIPTION
Adds a configurable policy for deletion of satellites. We had some reports that the currently implemented "eviction" was unexpected, in particular because no automatic restore happened once the satellite was "undeleted". 

So now the default is to leave the satellite registered in LINSTOR, only cleaning up the kubernetes resources. The old default is still available as the `Evacuate` strategy.

Needs #818.

Closes #519 and #297.