### PR TITLE
config: move gencert leader-election RBAC out of default config

### DIFF
--- a/config/default/gencert_rbac_patch.yaml
+++ b/config/default/gencert_rbac_patch.yaml
@@ -2,10 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: leader-election-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: leader-election-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
+- kind: ServiceAccount
+  name: gencert

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -25,6 +25,7 @@ resources:
 
 patches:
 - path: manager_webhook_patch.yaml
+- path: gencert_rbac_patch.yaml
 
 replacements:
 - source:


### PR DESCRIPTION
This moves the only resource referencing gencert out of the regular "rbac" resources. This helps with other consumers trying to use the operator without gencert, such as deployments with OLM or cert-manager.

The "default" deployment is left unchanged with this commit.