### PR TITLE
samples: make operator-sdk scorecard tests happy

### DIFF
--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - linstorcluster.yaml
 - linstorsatelliteconfiguration.yaml
+- linstorsatellite.yaml
 - linstornodeconnection.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/linstorcluster.yaml
+++ b/config/samples/linstorcluster.yaml
@@ -26,3 +26,5 @@ spec: {}
 #          name: csi-controller
 #        spec:
 #          replicas: 3
+status:
+  conditions: []

--- a/config/samples/linstornodeconnection.yaml
+++ b/config/samples/linstornodeconnection.yaml
@@ -1,19 +1,21 @@
 apiVersion: piraeus.io/v1
 kind: LinstorNodeConnection
 metadata:
-  name: cross-region-replication
-spec:
-  selector:
-    - matchLabels:
-        - key: example.com/storage
-          op: In
-          values:
-            - "yes"
-        - key: topology.kubernetes.io/region
-          op: NotSame
-  properties:
-    - name: DrbdOptions/Net/protocol
-      value: A
-  paths:
-    - name: wan
-      interface: wan-nic
+  name: example-connection
+spec: {}
+#  selector:
+#    - matchLabels:
+#        - key: example.com/storage
+#          op: In
+#          values:
+#            - "yes"
+#        - key: topology.kubernetes.io/region
+#          op: NotSame
+#  properties:
+#    - name: DrbdOptions/Net/protocol
+#      value: A
+#  paths:
+#    - name: wan
+#      interface: wan-nic
+status:
+  conditions: []

--- a/config/samples/linstorsatellite.yaml
+++ b/config/samples/linstorsatellite.yaml
@@ -1,0 +1,9 @@
+apiVersion: piraeus.io/v1
+kind: LinstorSatellite
+metadata:
+  name: example-satellite
+spec:
+  clusterRef:
+    name: linstorcluster
+status:
+  conditions: []

--- a/config/samples/linstorsatelliteconfiguration.yaml
+++ b/config/samples/linstorsatelliteconfiguration.yaml
@@ -19,3 +19,5 @@ spec: {}
 #      source:
 #        hostDevices:
 #          - /dev/vdb
+status:
+  conditions: []


### PR DESCRIPTION
operator-sdk expects:
* A sample for every CRD, even if it is marked as "internal".
* A `status` field for every example, even if it is empty.