### PR TITLE
docs: add instructions for Raspian

### DIFF
--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -59,6 +59,10 @@ These guides show you how to configure a specific aspect or achieve a specific t
 
     [:octicons-arrow-right-24: Guide](./k0s.md)
 
+*   Deploy Piraeus Datastore on Raspberry Pi OS / Raspian
+
+    [:octicons-arrow-right-24: Guide](./raspian.md)
+
 </div>
 
 ## Networking

--- a/docs/how-to/raspian.md
+++ b/docs/how-to/raspian.md
@@ -1,0 +1,56 @@
+# How to Load DRBD on Raspberry Pi OS / Raspian
+
+This guide shows you how to set the DRBD® Module Loader when using [Raspberry Pi OS / Raspian].
+
+To complete this guide, you should be familiar with:
+
+* editing `LinstorSatelliteConfiguration` resources.
+
+## Configure the DRBD module loader for Raspberry Pi OS / Raspian
+
+By default, the DRBD Module Loader will try to find the necessary header files to build DRBD from source on the host
+system. In [Raspberry Pi OS / Raspian] these files reference specific tools that are not mounted into the build
+container by default, leading to errors such as:
+
+```
+make[2]: *** No rule to make target '/usr/src/linux-headers-6.6.51+rpt-common-rpi/scripts/Makefile.extrawarn'.  Stop.
+make[1]: *** [Makefile:236: compat.h] Error 2
+make: *** [Makefile:131: module] Error 2
+```
+
+To resolve this issue, apply a LINSTOR Satellite configuration that passes the tool directory into the build container:
+
+```yaml hl_lines="14 18"
+apiVersion: piraeus.io/v1
+kind: LinstorSatelliteConfiguration
+metadata:
+  name: raspi-kbuild
+spec:
+  nodeSelector:
+    kubernetes.io/arch: arm64
+  podTemplate:
+    spec:
+      volumes:
+      - name: raspi-kbuild-tools
+        hostPath:
+          type: Directory
+          path: /usr/lib/linux-kbuild-6.6.51+rpt/
+      initContainers:
+      - name: drbd-module-loader
+        volumeMounts:
+        - mountPath:  /usr/lib/linux-kbuild-6.6.51+rpt/
+          name: raspi-kbuild-tools
+          readOnly: true
+```
+
+The specific directory that needs to be passed may change over time. Update the configuration above with the directory
+determined by running the following command on the host:
+
+```
+$ dirname $(readlink -f /usr/src/linux-headers-$(uname -r)/scripts)
+/usr/lib/linux-kbuild-6.6.51+rpt/
+```
+
+Apply the update configuration file. The LINSTOR Satellite containers will restart and start building the DRBD module.
+
+[Raspberry Pi OS / Raspian]: https://www.raspberrypi.com/software/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
       - Flatcar Container Linux: how-to/flatcar.md
       - Microk8s: how-to/microk8s.md
       - k0s: how-to/k0s.md
+      - Raspian: how-to/raspian.md
     - Networking:
       - Deploy Piraeus Datastore behind an HTTP Proxy: how-to/http-proxy.md
       - Deploy a NetworkPolicy for Piraeus Datastore: how-to/network-policy.md


### PR DESCRIPTION
There have been repeated requests for help when trying Piraeus Datastore on Raspian. Because of the weird packaging on Debian-based distros, we have to either install or bind-mount the "kbuild" tools.

For the default "Debian", we chose to install these tools directly in the loader image, but Raspian uses a different kernel, making it necessary to manually configure a bind-mount for the updated directory.

Closes https://github.com/piraeusdatastore/piraeus/issues/206