### PR TITLE
Add image digests & `RELATED_IMAGE_*` env support

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for different deletion policies on satellites.
 - Option to select taints that should be tolerated by Piraeus Datastore.
 - Allow pinning images in the image configuration to a specific digest.
+- Support overriding image configuration directly on the Operator Deployment using `RELATED_IMAGE_*` environment variables.
 
 ### Changed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for different deletion policies on satellites.
 - Option to select taints that should be tolerated by Piraeus Datastore.
+- Allow pinning images in the image configuration to a specific digest.
 
 ### Changed
 

--- a/docs/explanation/README.md
+++ b/docs/explanation/README.md
@@ -2,6 +2,19 @@
 
 The following documents explain how Piraeus Datastore works, and why it works the way it does.
 
-### [Understanding Piraeus Datastore Components](./components.md)
+<div class="grid cards" markdown>
 
-A short introduction for every component of Piraeus Datastore.
+-   :material-school:{ .lg .middle } __Understanding Piraeus Datastore Components__
+
+    ---
+    A short introduction for every component of Piraeus Datastore.
+
+    [:octicons-arrow-right-24: Read](./components.md)
+
+-   :material-school:{ .lg .middle } __How Piraeus Operator Selects Image Versions for Deployed Resources__
+
+    ---
+    An introduction on the image configuration format, selection process, and the ways to influence and override them.
+
+    [:octicons-arrow-right-24: Read](./image-configuration.md)
+</div>

--- a/docs/explanation/image-configuration.md
+++ b/docs/explanation/image-configuration.md
@@ -1,0 +1,183 @@
+# How Piraeus Operator Selects Image Versions for Deployed Resources
+
+Piraeus Datastore consists of many different components, most of which follow their own release cycle. For this reason,
+Piraeus Operator comes with a default configuration that uses the latest versions of all components at the time of
+release.
+
+## The Default Image Configuration
+
+The default deployment of Piraeus Datastore creates a special ConfigMap resource named `piraeus-operator-image-config`.
+It contains two entries that represent YAML documents:
+
+* [`0_piraeus_datastore_images.yaml`](https://github.com/piraeusdatastore/piraeus-operator/tree/v2/config/manager/0_piraeus_datastore_images.yaml),
+  which contains the image configuration for all components developed under the Piraeus Datastore umbrella.
+* [`0_sig_storage_images.yaml`](https://github.com/piraeusdatastore/piraeus-operator/tree/v2/config/manager/0_sig_storage_images.yaml),
+  which contains the image configuration for all components developed under the [Kubernetes CSI](https://kubernetes-csi.github.io/) umbrella.
+
+The YAML documents follow the following scheme:
+
+```yaml
+base: quay.io/piraeusdatastore
+```
+
+The "base" repository. All images configured in this YAML document will start with `quay.io/piraeusdatastore/`.
+
+```yaml
+components:
+  linstor-controller:
+    tag: v1.31.0
+    image: piraeus-server
+```
+
+The `components` are the image names used in the workload resources. `image` is the image repository to use in the given
+"base" registry. `tag` is the image tag. There is also the option to set a `digest`, which takes precedence over tags,
+but is not used in the default configuration.
+
+These images are referenced in the Piraeus resources. For example, the LINSTOR Controller deployment has the
+[following container configuration](https://github.com/piraeusdatastore/piraeus-operator/tree/v2/pkg/resources/cluster/controller/controller-deployment.yaml),
+which will be replaced given the above configuration with `quay.io/piraeusdatastore/piraeus-server:v1.31.0`:
+
+```yaml
+# ...
+      containers:
+        - name: linstor-controller
+          # will be replaced with:
+          # image: quay.io/piraeusdatastore/piraeus-server:v1.31.0
+          image: linstor-controller
+# ...
+```
+
+For cases where it is necessary to use different images based on the node the workload is running on, there is the
+option to set an additional `match` configuration:
+
+```yaml
+components:
+  drbd-module-loader:
+    tag: v9.2.13
+    image: drbd9-noble
+    match:
+      - osImage: Red Hat Enterprise Linux Server 7\.
+        image: drbd9-centos7
+      - osImage: Red Hat Enterprise Linux 8\.
+        image: drbd9-almalinux8
+# ...
+```
+
+When a `match` section is present, the Operator will first try to match the Kubernetes Node "OS Image" (as reported by
+[`status.nodeInfo.osImage`](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/node-v1/#NodeStatus))
+against the given `osImage`. If a match is found, the matches' `image` is used instead of the component one. The
+`osImage` value is a [regular expression](https://pkg.go.dev/regexp). This is currently only used for the
+`drbd-module-loader`.
+
+## External Cluster Automations
+
+Apart from the matching of "OS Image" for the drbd-module-loader, there is a second automation built into the Operator:
+When using an [external LINSTOR cluster](../how-to/external-controller.md), the Operator will match the LINSTOR version
+as reported by the external cluster with matching tags.
+
+For example, assuming the external LINSTOR Cluster is running 1.31.2, as reported here:
+
+```
+$ linstor controller version
+linstor controller 1.31.2; GIT-hash: 6a9a4bb37f547ff73317585a3efa217523e01f43
+```
+
+The operator will automatically replace the default tags of the `linstor-satellite` component with the tag "v1.31.2".
+
+## Options for Overriding the Image Configuration
+
+In certain cases, it might be necessary to update or override parts of this configuration. The following methods are
+available to change the default image configuration.
+
+### Overriding the Image Configuration via LinstorCluster
+
+The following configuration will replace the `base:` setting in the image configuration with `registry.example.com/piraeus`.
+
+```yaml
+apiVersion: piraeus.io/v1
+kind: LinstorCluster
+metadata:
+  name: linstorcluster
+spec:
+  repository: registry.example.com/piraeus
+```
+
+This example results in the following changes:
+
+| Component          | Default Image                                   | New Image                                           |
+|--------------------|-------------------------------------------------|-----------------------------------------------------|
+| linstor-controller | quay.io/piraeusdatastore/piraeus-server:v1.31.0 | registry.example.com/piraeus/piraeus-server:v1.31.0 |
+| csi-attacher       | registry.k8s.io/sig-storage/csi-attacher:v4.8.1 | registry.example.com/piraeus/csi-attacher:v4.8.1    |
+
+### Overriding the Image Configuration by Adding New YAML Documents
+
+The Operator will read all YAML documents in the Image Configuration ConfigMap. The files are read in ascending order,
+so providing a `1_override.yaml` document ensures the Operator will read this document after the default configuration.
+Since the Operator applies a "last configuration wins" algorithm for components, this document overrides the default
+configuration.
+
+The following example replaces the `linstor-controller` with version 1.31.1 and pins the `linstor-satellite` image
+to a specific digest:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: piraeus-operator-image-config
+data:
+  0_piraeus_datastore_images.yaml: |
+    # ...
+  0_sig_storage_images.yaml: |
+    # ...
+  1_override.yaml: |
+    ---
+    base: quay.io/piraeusdatastore
+    components:
+      linstor-controller:
+        image: piraeus-server
+        tag: v1.31.1
+      linstor-satellite:
+        image: piraeus-server
+        digest: sha256:8bc7fd45545744864633371161e6fcd6bcaea1e7a21fb053588f970b9f912b07
+```
+
+This example results in the following changes:
+
+| Component          | Default Image                                   | New Image                                                                                                       |
+|--------------------|-------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
+| linstor-controller | quay.io/piraeusdatastore/piraeus-server:v1.31.0 | quay.io/piraeusdatastore/piraeus-server:v1.31.1                                                                 |
+| linstor-satellite  | quay.io/piraeusdatastore/piraeus-server:v1.31.0 | quay.io/piraeusdatastore/piraeus-server@sha256:8bc7fd45545744864633371161e6fcd6bcaea1e7a21fb053588f970b9f912b07 |
+
+### Overriding the Image Configuration by Adding Environment Variables to the Operator Deployment
+
+To support the recommendation for "offline enabled" Operators, the Operator can also be configured using environment
+variables. These take precedence over all other configuration options. To override a specific image set the
+`RELATED_IMAGE_<component>` or `RELATED_IMAGE_<component>_<image>` environment variable. The second form is useful
+for overriding images from `match` configurations.
+
+The following example replaces the `linstor-controller` with version and 1.31.1 and replaces the AlmaLinux 9 loader
+image with a different image:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: piraeus-operator-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: RELATED_IMAGE_linstor-controller
+          value: quay.io/piraeusdatastore/piraeus-server:v1.31.1
+        - name: RELATED_IMAGE_drbd-module-loader_drbd9-almalinux9
+          value: registry.example.com/piraeus/drbd@sha256:16e5adec119cd0849e019fb40dbb2b256a3579a3a7e4e34b6ec35252edfeb231
+```
+
+This example results in the following changes:
+
+| Component          | Default Image                                     | New Image                                                                                                 |
+|--------------------|---------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| linstor-controller | quay.io/piraeusdatastore/piraeus-server:v1.31.0   | quay.io/piraeusdatastore/piraeus-server:v1.31.1                                                           |
+| drbd-module-loader | quay.io/piraeusdatastore/drbd9-almalinux9:v9.2.13 | registry.example.com/piraeus/drbd@sha256:16e5adec119cd0849e019fb40dbb2b256a3579a3a7e4e34b6ec35252edfeb231 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
   - Understanding Piraeus:
     - Understanding Piraeus: explanation/README.md
     - Piraeus Components: explanation/components.md
+    - Image Configuration: explanation/image-configuration.md
   - Reference:
     - Reference: reference/README.md
     - LinstorCluster: reference/linstorcluster.md

--- a/pkg/imageversions/versions.go
+++ b/pkg/imageversions/versions.go
@@ -3,10 +3,14 @@ package imageversions
 import (
 	_ "embed"
 	"fmt"
+	"os"
 	"regexp"
 
+	imageutil "sigs.k8s.io/kustomize/api/pkg/util"
 	kusttypes "sigs.k8s.io/kustomize/api/types"
 )
+
+const ImageOverrideEnvPrefix = "RELATED_IMAGE_"
 
 // Configs is a list of Config, where later
 type Configs []*Config
@@ -57,7 +61,7 @@ func (f *Config) GetVersions(base string, osImage string) ([]kusttypes.Image, bo
 	precompiled := false
 
 	for c := range f.Components {
-		img, compiled := f.get(f.Components[c], base, osImage)
+		img, compiled := f.get(f.Components[c], base, c, osImage)
 
 		precompiled = precompiled || compiled
 
@@ -70,13 +74,17 @@ func (f *Config) GetVersions(base string, osImage string) ([]kusttypes.Image, bo
 	return result, precompiled
 }
 
-func (f *Config) get(img ComponentConfig, base string, osImage string) (*kusttypes.Image, bool) {
+func (f *Config) get(img ComponentConfig, base, component, osImage string) (*kusttypes.Image, bool) {
 	if base == "" {
 		base = f.Base
 	}
 
 	for _, matchRule := range img.Match {
 		if ok, _ := regexp.MatchString(matchRule.OsImage, osImage); ok {
+			if img := getOverrideForImageFromEnv(component, matchRule.Image); img != nil {
+				return img, matchRule.Precompiled
+			}
+
 			return &kusttypes.Image{
 				NewName: fmt.Sprintf("%s/%s", base, matchRule.Image),
 				NewTag:  img.Tag,
@@ -89,9 +97,31 @@ func (f *Config) get(img ComponentConfig, base string, osImage string) (*kusttyp
 		return nil, false
 	}
 
+	if img := getOverrideForImageFromEnv(component, img.Image); img != nil {
+		return img, false
+	}
+
 	return &kusttypes.Image{
 		NewName: fmt.Sprintf("%s/%s", base, img.Image),
 		NewTag:  img.Tag,
 		Digest:  img.Digest,
 	}, false
+}
+
+func getOverrideForImageFromEnv(component, image string) *kusttypes.Image {
+	img := os.Getenv(ImageOverrideEnvPrefix + component + "_" + image)
+	if img == "" {
+		img = os.Getenv(ImageOverrideEnvPrefix + component)
+	}
+
+	if img == "" {
+		return nil
+	}
+
+	name, tag, digest := imageutil.SplitImageName(img)
+	return &kusttypes.Image{
+		NewName: name,
+		NewTag:  tag,
+		Digest:  digest,
+	}
 }

--- a/pkg/imageversions/versions.go
+++ b/pkg/imageversions/versions.go
@@ -18,15 +18,17 @@ type Config struct {
 }
 
 type ComponentConfig struct {
-	Tag   string    `yaml:"tag"`
-	Match []OsMatch `yaml:"match"`
-	Image string    `yaml:"image"`
+	Tag    string    `yaml:"tag"`
+	Match  []OsMatch `yaml:"match"`
+	Image  string    `yaml:"image"`
+	Digest string    `yaml:"digest,omitempty"`
 }
 
 type OsMatch struct {
 	OsImage     string `yaml:"osImage"`
 	Image       string `yaml:"image"`
 	Precompiled bool   `yaml:"precompiled"`
+	Digest      string `yaml:"digest,omitempty"`
 }
 
 func (c Configs) GetVersions(base string, osImage string) ([]kusttypes.Image, bool) {
@@ -55,36 +57,41 @@ func (f *Config) GetVersions(base string, osImage string) ([]kusttypes.Image, bo
 	precompiled := false
 
 	for c := range f.Components {
-		name, tag, compiled := f.get(f.Components[c], base, osImage)
+		img, compiled := f.get(f.Components[c], base, osImage)
 
 		precompiled = precompiled || compiled
 
-		if name != "" {
-			result = append(result, kusttypes.Image{
-				Name:    string(c),
-				NewName: name,
-				NewTag:  tag,
-			})
+		if img != nil {
+			img.Name = c
+			result = append(result, *img)
 		}
 	}
 
 	return result, precompiled
 }
 
-func (f *Config) get(img ComponentConfig, base string, osImage string) (string, string, bool) {
+func (f *Config) get(img ComponentConfig, base string, osImage string) (*kusttypes.Image, bool) {
 	if base == "" {
 		base = f.Base
 	}
 
 	for _, matchRule := range img.Match {
 		if ok, _ := regexp.MatchString(matchRule.OsImage, osImage); ok {
-			return fmt.Sprintf("%s/%s", base, matchRule.Image), img.Tag, matchRule.Precompiled
+			return &kusttypes.Image{
+				NewName: fmt.Sprintf("%s/%s", base, matchRule.Image),
+				NewTag:  img.Tag,
+				Digest:  matchRule.Digest,
+			}, matchRule.Precompiled
 		}
 	}
 
 	if img.Image == "" {
-		return "", "", false
+		return nil, false
 	}
 
-	return fmt.Sprintf("%s/%s", base, img.Image), img.Tag, false
+	return &kusttypes.Image{
+		NewName: fmt.Sprintf("%s/%s", base, img.Image),
+		NewTag:  img.Tag,
+		Digest:  img.Digest,
+	}, false
 }

--- a/pkg/imageversions/versions_test.go
+++ b/pkg/imageversions/versions_test.go
@@ -1,6 +1,7 @@
 package imageversions_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,6 +48,21 @@ var (
 				Match: []imageversions.OsMatch{
 					{OsImage: "Ubuntu", Image: "ubuntu"},
 					{OsImage: "AlmaLinux 9", Image: "new-alma", Precompiled: true, Digest: "sha256:dcba"},
+				},
+			},
+		},
+	}
+	// Special config, as we don't want to override images from other tests. We need to use "Setenv()", which modifies
+	// the environment for all tests.
+	EnvConfig = imageversions.Config{
+		Base: "example.com/env",
+		Components: map[string]imageversions.ComponentConfig{
+			"image-with-env": {
+				Image: "fallback-env",
+				Tag:   "v1",
+				Match: []imageversions.OsMatch{
+					{OsImage: "Ubuntu", Image: "ubuntu-env"},
+					{OsImage: "AlmaLinux 9", Image: "alma-env"},
 				},
 			},
 		},
@@ -139,5 +155,29 @@ func TestConfigs_GetVersions_use_digests_if_set(t *testing.T) {
 	actual, _ = configs.GetVersions("", "AlmaLinux 9.0 (Emerald Puma)")
 	assert.ElementsMatch(t, actual, []kusttypes.Image{
 		{Name: "image-with-digest", NewName: "example.com/digest/new-alma", NewTag: "v1", Digest: "sha256:dcba"},
+	})
+}
+
+func TestConfigs_GetVersions_use_env_override(t *testing.T) {
+	err := os.Setenv("RELATED_IMAGE_image-with-env_fallback-env", "env.example.com/override/fallback:v2@sha256:1234")
+	assert.NoError(t, err)
+	err = os.Setenv("RELATED_IMAGE_image-with-env_ubuntu-env", "env.example.com/override/ubuntu@sha256:4321")
+	assert.NoError(t, err)
+
+	configs := imageversions.Configs{&EnvConfig}
+
+	actual, _ := configs.GetVersions("", "SomeOs")
+	assert.ElementsMatch(t, actual, []kusttypes.Image{
+		{Name: "image-with-env", NewName: "env.example.com/override/fallback", NewTag: "v2", Digest: "sha256:1234"},
+	})
+
+	actual, _ = configs.GetVersions("", "Ubuntu")
+	assert.ElementsMatch(t, actual, []kusttypes.Image{
+		{Name: "image-with-env", NewName: "env.example.com/override/ubuntu", Digest: "sha256:4321"},
+	})
+
+	actual, _ = configs.GetVersions("", "AlmaLinux 9.0 (Emerald Puma)")
+	assert.ElementsMatch(t, actual, []kusttypes.Image{
+		{Name: "image-with-env", NewName: "example.com/env/alma-env", NewTag: "v1"},
 	})
 }

--- a/pkg/imageversions/versions_test.go
+++ b/pkg/imageversions/versions_test.go
@@ -37,6 +37,20 @@ var (
 			},
 		},
 	}
+	DigestConfig = imageversions.Config{
+		Base: "example.com/digest",
+		Components: map[string]imageversions.ComponentConfig{
+			"image-with-digest": {
+				Image:  "fallback",
+				Tag:    "v1",
+				Digest: "sha256:abcd",
+				Match: []imageversions.OsMatch{
+					{OsImage: "Ubuntu", Image: "ubuntu"},
+					{OsImage: "AlmaLinux 9", Image: "new-alma", Precompiled: true, Digest: "sha256:dcba"},
+				},
+			},
+		},
+	}
 )
 
 func TestConfig_GetVersions(t *testing.T) {
@@ -106,4 +120,24 @@ func TestConfigs_GetVersions_prefer_later_config(t *testing.T) {
 		{Name: "linstor-satellite", NewName: "repo.example.com/base/satellite", NewTag: "v1"},
 		{Name: "drbd-module-loader", NewName: "repo.example.com/base/ubuntu", NewTag: "v2"},
 	}, actual)
+}
+
+func TestConfigs_GetVersions_use_digests_if_set(t *testing.T) {
+	t.Parallel()
+	configs := imageversions.Configs{&DigestConfig}
+
+	actual, _ := configs.GetVersions("", "SomeOs")
+	assert.ElementsMatch(t, actual, []kusttypes.Image{
+		{Name: "image-with-digest", NewName: "example.com/digest/fallback", NewTag: "v1", Digest: "sha256:abcd"},
+	})
+
+	actual, _ = configs.GetVersions("", "Ubuntu")
+	assert.ElementsMatch(t, actual, []kusttypes.Image{
+		{Name: "image-with-digest", NewName: "example.com/digest/ubuntu", NewTag: "v1"},
+	})
+
+	actual, _ = configs.GetVersions("", "AlmaLinux 9.0 (Emerald Puma)")
+	assert.ElementsMatch(t, actual, []kusttypes.Image{
+		{Name: "image-with-digest", NewName: "example.com/digest/new-alma", NewTag: "v1", Digest: "sha256:dcba"},
+	})
 }


### PR DESCRIPTION
- Allow pinning images in the image configuration to a specific digest.
- Support overriding image configuration directly on the Operator Deployment using `RELATED_IMAGE_*` environment variables.