### PR TITLE
monitoring: exclude Inconsistent resources from drbdDeviceNotUpToDate…

### DIFF
--- a/config/extras/monitoring/alerts.yaml
+++ b/config/extras/monitoring/alerts.yaml
@@ -73,7 +73,7 @@ spec:
           annotations:
             description: |
               DRBD device "{{ $labels.name }}" on "{{ $labels.node }}" has unexpected device state "{{ $labels.drbd_device_state }}".
-          expr: drbd_device_state{drbd_device_state!~"UpToDate|Diskless"} > 0
+          expr: drbd_device_state{drbd_device_state!~"UpToDate|Diskless|Inconsistent"} > 0
           for: 1m
           labels:
             severity: warn

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Deletion of `LinstorSatellite` no longer causes a node evacuation by default. See [`spec.deletionPolicy`](./reference/linstorsatelliteconfiguration.md#specdeletionpolicy).
 - Piraeus Datastore no longer runs on control plane nodes by default.
+- "Inconsistent" resources no longer cause AlertManager notifications, as long as there is resync progress.
 
 ## [v2.8.1] - 2025-04-09
 


### PR DESCRIPTION
… alert

This alert should report resources in "unexpected" states. However, the way we handle restoring from a snapshot, or even the addition of new peers to a resource might be triggering this alert by accident.

The issue is that when new peers are added to an existing volume, it will cause a partial or full resync, during which the volume stays Inconsistent. This is expected and fine. We already have a separate alert "drbdResourceResyncWithoutProgress" that reports disks that are Inconsistent but made no progress on the resync front.