### PR TITLE
satellites: keep running on "NoSchedule" nodes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Image configuration for RHEL10 clones.
+- Do not remove existing satellites for `*NoSchedule` taints.
 
 ## [v2.9.0] - 2025-06-17
 

--- a/internal/controller/linstorcluster_controller.go
+++ b/internal/controller/linstorcluster_controller.go
@@ -155,9 +155,24 @@ func (r *LinstorClusterReconciler) reconcileAppliedResource(ctx context.Context,
 		})
 	}
 
+	existingSatellites := piraeusiov1.LinstorSatelliteList{}
+	err = r.Client.List(ctx, &existingSatellites, &client.ListOptions{})
+	if err != nil {
+		return err
+	}
+
 	satelliteTolerations := tolerations.MergeTolerations(tolerations.DefaultDaemonSetTolerations, tolerations.HAControllerTolerations, lcluster.Spec.Tolerations)
 	satelliteNodes.Items = slices.DeleteFunc(satelliteNodes.Items, func(node corev1.Node) bool {
-		_, untolerated := schedulingcorev1.FindMatchingUntoleratedTaint(node.Spec.Taints, satelliteTolerations, nil)
+		hasExistingSatellite := slices.ContainsFunc(existingSatellites.Items, func(existing piraeusiov1.LinstorSatellite) bool {
+			return existing.DeletionTimestamp == nil && existing.Name == node.Name
+		})
+		_, untolerated := schedulingcorev1.FindMatchingUntoleratedTaint(node.Spec.Taints, satelliteTolerations, func(taint *corev1.Taint) bool {
+			if hasExistingSatellite {
+				return taint.Effect == corev1.TaintEffectNoExecute
+			} else {
+				return taint.Effect == corev1.TaintEffectNoSchedule || taint.Effect == corev1.TaintEffectNoExecute
+			}
+		})
 		return untolerated
 	})
 

--- a/internal/controller/linstorcluster_test.go
+++ b/internal/controller/linstorcluster_test.go
@@ -334,7 +334,7 @@ var _ = Describe("LinstorCluster controller", func() {
 					// Another "core" taint we ignore by default.
 					{Key: corev1.TaintNodeUnschedulable, Effect: corev1.TaintEffectNoSchedule},
 					// A Taint we manually tolerate later.
-					{Key: "example.com/manual-taint", Effect: corev1.TaintEffectPreferNoSchedule},
+					{Key: "example.com/manual-taint", Effect: corev1.TaintEffectNoExecute},
 					// A Taint we never tolerate.
 					{Key: "example.com/untolerated-taint", Effect: corev1.TaintEffectNoExecute},
 				}
@@ -364,7 +364,7 @@ var _ = Describe("LinstorCluster controller", func() {
 				cluster.Spec.Tolerations = append(cluster.Spec.Tolerations, corev1.Toleration{
 					Key:      "example.com/manual-taint",
 					Operator: corev1.TolerationOpExists,
-					Effect:   corev1.TaintEffectPreferNoSchedule,
+					Effect:   corev1.TaintEffectNoExecute,
 				})
 				err = k8sClient.Update(ctx, &cluster)
 				Expect(err).NotTo(HaveOccurred())
@@ -377,7 +377,7 @@ var _ = Describe("LinstorCluster controller", func() {
 				}).Should(HaveField("Spec.Template.Spec.Tolerations", ContainElement(corev1.Toleration{
 					Key:      "example.com/manual-taint",
 					Operator: corev1.TolerationOpExists,
-					Effect:   corev1.TaintEffectPreferNoSchedule,
+					Effect:   corev1.TaintEffectNoExecute,
 				})))
 
 				Eventually(func() []piraeusiov1.LinstorSatellite {
@@ -406,7 +406,7 @@ var _ = Describe("LinstorCluster controller", func() {
 							corev1.Toleration{
 								Key:      "example.com/manual-taint",
 								Operator: corev1.TolerationOpExists,
-								Effect:   corev1.TaintEffectPreferNoSchedule,
+								Effect:   corev1.TaintEffectNoExecute,
 							}),
 					))),
 				))
@@ -424,9 +424,66 @@ var _ = Describe("LinstorCluster controller", func() {
 							corev1.Toleration{
 								Key:      "example.com/manual-taint",
 								Operator: corev1.TolerationOpExists,
-								Effect:   corev1.TaintEffectPreferNoSchedule,
+								Effect:   corev1.TaintEffectNoExecute,
 							})),
 					)),
+				))
+			})
+
+			It("should keep scheduled satellites on '*NoSchedule' tainted nodes", func(ctx context.Context) {
+				var nodes corev1.NodeList
+				err := k8sClient.List(ctx, &nodes)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(nodes.Items).Should(HaveLen(3))
+
+				By("Ensuring we have all Satellites scheduled")
+				Eventually(func() []piraeusiov1.LinstorSatellite {
+					var satellites piraeusiov1.LinstorSatelliteList
+					err := k8sClient.List(ctx, &satellites)
+					Expect(err).NotTo(HaveOccurred())
+
+					return satellites.Items
+				}).Should(HaveLen(3))
+
+				By("Tainting nodes with NoExecute, NoSchedule and PreferNoSchedule effects")
+				taintsToAdd := []corev1.Taint{
+					{Key: "example.com/manual-taint", Effect: corev1.TaintEffectNoExecute},
+					{Key: "example.com/manual-taint", Effect: corev1.TaintEffectNoSchedule},
+					{Key: "example.com/manual-taint", Effect: corev1.TaintEffectPreferNoSchedule},
+				}
+
+				for i := range nodes.Items {
+					// Apply one taint to each node, all having different effects.
+					nodes.Items[i].Spec.Taints = append(nodes.Items[i].Spec.Taints, taintsToAdd[i])
+					err := k8sClient.Update(ctx, &nodes.Items[i])
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				Eventually(func() []piraeusiov1.LinstorSatellite {
+					var satellites piraeusiov1.LinstorSatelliteList
+					err := k8sClient.List(ctx, &satellites)
+					Expect(err).NotTo(HaveOccurred())
+					return satellites.Items
+				}).Should(ConsistOf(
+					// The satellite of the first node should be removed, as it has a NoExecute taint.
+					HaveField("Name", nodes.Items[1].Name),
+					HaveField("Name", nodes.Items[2].Name),
+				))
+
+				By("Deleting the remaining Satellites, only the PreferNoSchedule node should be recreated")
+				err = k8sClient.DeleteAllOf(ctx, &piraeusiov1.LinstorSatellite{})
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func() []piraeusiov1.LinstorSatellite {
+					var satellites piraeusiov1.LinstorSatelliteList
+					err := k8sClient.List(ctx, &satellites)
+					Expect(err).NotTo(HaveOccurred())
+					return satellites.Items
+				}).Should(ConsistOf(
+					// The satellite of the first node was already removed by the NoExecute taint.
+					// The satellite of the second node was removed, and now has a NoSchedule taint.
+					// The satellite of the third node should be recreated, as we ignore PreferNoSchedule taints.
+					HaveField("Name", nodes.Items[2].Name),
 				))
 			})
 		})

--- a/internal/controller/linstorcluster_test.go
+++ b/internal/controller/linstorcluster_test.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/exp/slices"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -545,9 +546,11 @@ var _ = Describe("LinstorCluster controller", func() {
 			g.Expect(container.Env[0]).To(Equal(corev1.EnvVar{Name: "LS_CONTROLLERS", Value: "http://linstor-controller.invalid:3370"}))
 		}).Should(Succeed())
 
-		var controllerDeployment appsv1.Deployment
-		err = k8sClient.Get(ctx, types.NamespacedName{Name: "linstor-controller", Namespace: Namespace}, &controllerDeployment)
-		Expect(err).NotTo(BeNil())
+		Eventually(func(g Gomega) {
+			var controllerDeployment appsv1.Deployment
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: "linstor-controller", Namespace: Namespace}, &controllerDeployment)
+			g.Expect(err).To(MatchError(errors.IsNotFound, "IsNotFound"))
+		}).Should(Succeed())
 	})
 
 	It("should add TLS secrets to the LINSTOR Components, configuring HTTPS access", func(ctx context.Context) {


### PR DESCRIPTION
We try to emulate DaemonSet logic for our Satellites, including the toleration of some default taints. However, our emulation was not perfect in two cases:

* DaemonSets only look at "NoExecute" and "NoSchedule" taints, ignoring "PreferNoSchedule" taints. This becomes noticable when certain distributions run upgrades (such as OpenShift or Cluster API managed k8s), as they generally set a "PreferNoSchedule" taint on nodes they consider outdated.
* When a Pod in a DaemonSet is already assigned to a node, it also does not get deleted when a "NoSchedule" taint is added. Instead, the Pod keeps running until manual deletion, or a NoExecute taint gets added.

This is now also implemented for our LinstorSatellite resources. A test is also added to verify the behaviour of keeping Pods running in the face of added "*NoSchedule" taints.