### PR TITLE
images: remove stable distros for DRBD

### DIFF
--- a/charts/piraeus/templates/config.yaml
+++ b/charts/piraeus/templates/config.yaml
@@ -47,8 +47,6 @@ data:
         # here. If one matches, that specific image name will be used instead of the fallback image.
         image: drbd9-noble # Fallback image: chose a recent kernel, which can hopefully compile whatever config is actually in use
         match:
-          - osImage: Red Hat Enterprise Linux Server 7\.
-            image: drbd9-centos7
           - osImage: Red Hat Enterprise Linux 8\.
             image: drbd9-almalinux8
           - osImage: Red Hat Enterprise Linux 9\.
@@ -59,8 +57,6 @@ data:
             image: drbd9-almalinux9
           - osImage: Red Hat Enterprise Linux CoreOS
             image: drbd9-almalinux8
-          - osImage: CentOS Linux 7
-            image: drbd9-centos7
           - osImage: CentOS Linux 8
             image: drbd9-almalinux8
           - osImage: AlmaLinux 8
@@ -81,10 +77,6 @@ data:
             image: drbd9-almalinux9
           - osImage: Rocky Linux 10
             image: drbd9-almalinux10
-          - osImage: Ubuntu 18\.04
-            image: drbd9-bionic
-          - osImage: Ubuntu 20\.04
-            image: drbd9-focal
           - osImage: Ubuntu 22\.04
             image: drbd9-jammy
           - osImage: Ubuntu 24\.04
@@ -93,8 +85,6 @@ data:
             image: drbd9-bookworm
           - osImage: Debian GNU/Linux 11
             image: drbd9-bullseye
-          - osImage: Debian GNU/Linux 10
-            image: drbd9-buster
   0_sig_storage_images.yaml: |
     ---
     base: registry.k8s.io/sig-storage

--- a/config/manager/0_piraeus_datastore_images.yaml
+++ b/config/manager/0_piraeus_datastore_images.yaml
@@ -38,8 +38,6 @@ components:
     # here. If one matches, that specific image name will be used instead of the fallback image.
     image: drbd9-noble # Fallback image: chose a recent kernel, which can hopefully compile whatever config is actually in use
     match:
-      - osImage: Red Hat Enterprise Linux Server 7\.
-        image: drbd9-centos7
       - osImage: Red Hat Enterprise Linux 8\.
         image: drbd9-almalinux8
       - osImage: Red Hat Enterprise Linux 9\.
@@ -50,8 +48,6 @@ components:
         image: drbd9-almalinux9
       - osImage: Red Hat Enterprise Linux CoreOS
         image: drbd9-almalinux8
-      - osImage: CentOS Linux 7
-        image: drbd9-centos7
       - osImage: CentOS Linux 8
         image: drbd9-almalinux8
       - osImage: AlmaLinux 8
@@ -72,10 +68,6 @@ components:
         image: drbd9-almalinux9
       - osImage: Rocky Linux 10
         image: drbd9-almalinux10
-      - osImage: Ubuntu 18\.04
-        image: drbd9-bionic
-      - osImage: Ubuntu 20\.04
-        image: drbd9-focal
       - osImage: Ubuntu 22\.04
         image: drbd9-jammy
       - osImage: Ubuntu 24\.04
@@ -84,5 +76,3 @@ components:
         image: drbd9-bookworm
       - osImage: Debian GNU/Linux 11
         image: drbd9-bullseye
-      - osImage: Debian GNU/Linux 10
-        image: drbd9-buster

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [LINSTOR Affinity Controller]: https://github.com/piraeusdatastore/linstor-affinity-controller
 
+### Removed
+
+- Removed image configuration for EOL distributions:
+  * Ubuntu 18.04 ("Bionic Beaver")
+  * Ubuntu 20.04 ("Focal Fossa")
+  * CentOS 7
+  * Debian 10 ("Buster")
+
 ### Changed
 
 - Image configuration for RHEL10 clones.

--- a/docs/how-to/drbd-loader.md
+++ b/docs/how-to/drbd-loader.md
@@ -63,18 +63,15 @@ spec:
 
 Piraeus maintains the following images:
 
-| Image                                       | Distribution                       |
-|---------------------------------------------|------------------------------------|
-| `quay.io/piraeusdatastore/drbd9-almalinux9` | RedHat Enterprise Linux 9 rebuilds |
-| `quay.io/piraeusdatastore/drbd9-almalinux8` | RedHat Enterprise Linux 8 rebuilds |
-| `quay.io/piraeusdatastore/drbd9-centos7`    | RedHat Enterprise Linux 7 rebuilds |
-| `quay.io/piraeusdatastore/drbd9-noble`      | Ubuntu 24.04                       |
-| `quay.io/piraeusdatastore/drbd9-jammy`      | Ubuntu 22.04                       |
-| `quay.io/piraeusdatastore/drbd9-focal`      | Ubuntu 20.04                       |
-| `quay.io/piraeusdatastore/drbd9-bionic`     | Ubuntu 18.04                       |
-| `quay.io/piraeusdatastore/drbd9-bookworm`   | Debian 12                          |
-| `quay.io/piraeusdatastore/drbd9-bullseye`   | Debian 11                          |
-| `quay.io/piraeusdatastore/drbd9-buster`     | Debian 10                          |
+| Image                                        | Distribution                        |
+|----------------------------------------------|-------------------------------------|
+| `quay.io/piraeusdatastore/drbd9-almalinux10` | RedHat Enterprise Linux 10 rebuilds |
+| `quay.io/piraeusdatastore/drbd9-almalinux9`  | RedHat Enterprise Linux 9 rebuilds  |
+| `quay.io/piraeusdatastore/drbd9-almalinux8`  | RedHat Enterprise Linux 8 rebuilds  |
+| `quay.io/piraeusdatastore/drbd9-noble`       | Ubuntu 24.04                        |
+| `quay.io/piraeusdatastore/drbd9-jammy`       | Ubuntu 22.04                        |
+| `quay.io/piraeusdatastore/drbd9-bookworm`    | Debian 12                           |
+| `quay.io/piraeusdatastore/drbd9-bullseye`    | Debian 11                           |
 
 You can create a loader image for your own distribution using the [Piraeus sources](https://github.com/piraeusdatastore/piraeus/tree/master/dockerfiles/drbd-driver-loader)
 as reference.


### PR DESCRIPTION
We stopped building new DRBD images for EOL distributions. However they were still configured in the image configuration, which ended up causing people to try to pull images which never existed.

Closes #856 