### PR TITLE
evacuation: limit repeated calls to node evacuate

### DIFF
--- a/pkg/evacuation/evacuation.go
+++ b/pkg/evacuation/evacuation.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	linstor "github.com/LINBIT/golinstor"
 	lapi "github.com/LINBIT/golinstor/client"
 	affinity "github.com/piraeusdatastore/linstor-affinity-controller/pkg/version"
 	linstorcsidriver "github.com/piraeusdatastore/linstor-csi/pkg/driver"
@@ -235,11 +236,40 @@ func waitForReattach(ctx context.Context, cl client.Client, nodeName string) (st
 }
 
 func evacuateNode(ctx context.Context, lclient *lapi.Client, node *lapi.Node) error {
-	// We retry evacuation every time. LINSTOR needs multiple kicks until it actually starts moving all resources in
-	// some cases.
-	err := lclient.Nodes.Evacuate(ctx, node.Name)
+	ress, err := lclient.Resources.GetResourceView(ctx, &lapi.ListOpts{Node: []string{node.Name}})
 	if err != nil && !errors.Is(err, lapi.NotFoundError) {
 		return err
+	}
+
+	// Workaround for current LINSTOR issues:
+	// * We need to call evacuate repeatedly, as a restart of the LINSTOR Controller causes LINSTOR to not properly
+	//   clean up the remaining resources on the evacuated node.
+	// * However, if we call evacuate while the replacement resource is syncing, LINSTOR will create a new replica
+	//   because it does not consider the syncing replica a valid replacement (yet).
+	// So we want to call evacuate only when:
+	// * Once to initiate evacuation.
+	// * All current resource are fully synced, but there are still resource remaining on the node.
+	evacuationInProgress := false
+	for _, resource := range ress {
+		// This key is set by LINSTOR to indicate that the resource should be cleaned up after syncing. Use this as an
+		// indication that the resource is being evacuated.
+		if resource.Props[linstor.KeyRscMigrateFrom] != "" {
+			status, err := lclient.ResourceDefinitions.SyncStatus(ctx, resource.Name)
+			if err != nil {
+				return fmt.Errorf("failed to check sync status of '%s': %w", resource.Name, err)
+			}
+
+			if !status.SyncedOnAll {
+				evacuationInProgress = true
+			}
+		}
+	}
+
+	if !slices.Contains(node.Flags, linstor.FlagEvacuate) || !evacuationInProgress {
+		err := lclient.Nodes.Evacuate(ctx, node.Name)
+		if err != nil && !errors.Is(err, lapi.NotFoundError) {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
There are two outstanding issues with LINSTOR evacuation we have to work around until a fix is provided upstream:

* If the LINSTOR Controller restarts during node evacuation, the evacuating resources may not be cleaned up properly. This often happens during evacuation, as the Controller could be running one the to-be-removed node. To deal with this, we would call "node evacuate" repeatedly until all resources have been moved.
* This caused the second issue: If a resource was not fully synced up when calling "node evacuate" a second time, LINSTOR would not consider the syncing replica as the proper replacement. Instead, it would create another copy of the data. So we ended up accumulating ever more replicas until the evacuation finally completes.

To work around these issues until a fix is provided in LINSTOR, we now call "node evacuate" only in these two cases:

* The node is not yet evacuating
* The node is evacuating, but all to-be-evacuated resources are in sync, indicating that another call to "node evacuate" will not create any additional replicas.