### PR TITLE
evacuation: add option to remove PVCs on evacuation

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -28,6 +28,7 @@ rules:
   - nodes
   - persistentvolumeclaims
   verbs:
+  - delete
   - get
   - list
   - patch

--- a/docs/explanation/deletion-policies.md
+++ b/docs/explanation/deletion-policies.md
@@ -66,12 +66,22 @@ snapshots are removed.
 In order to keep potential fail-over times short, Piraeus Datastore performs the following steps during evacuation:
 
 1. Piraeus Datastore searches for PersistentVolumes (PVs) that:
-    * Are attached on the Node to be evacuated and marks them with `wait-for-reattach.evacuation.piraeus.io/<node-name>`
-      annotation. It will later use this annotation to wait for the PV to be reattached.
-    * In addition, if the PVs are also either using the `allowRemoteVolumeAcesss: "false"` policy or are otherwise bound
-      to the Node to be evacuated in their `.spec.nodeAffinity`, they are annotated with
-      `override.piraeus.io/<nodename>`. This causes the LINSTOR Affinity Controller to temporarily mark the PV as
-      accessible from any Node.
+    *   Are attached on the Node to be evacuated and marks them with `wait-for-reattach.evacuation.piraeus.io/<node-name>`
+        annotation. It will later use this annotation to wait for the PV to be reattached.
+    *   If the PV has a `linstor.csi.linbit.com/evacuation-action` annotation or the storage class has the
+        `property.linstor.csi.linbit.com/Aux/linstor.csi.linbit.com/evacuation-action` parameter set, the value is used
+        to determine the evacuation action. Possible actions are:
+        * `AffinityOverride`: Annotate the PV with `override.piraeus.io/<nodename>`. This causes the LINSTOR Affinity
+          Controller to temporarily mark the PV as accessible from any Node.
+        * `Delete`: Delete the PVC and PV, causing the **existing data** to be **lost**. This is _only_ useful for PVCs
+          storing caches or otherwise ephemeral data that get recreated automatically, for example using a StatefulSet
+          with `volumeClaimTemplates`.
+        * `None`: No special action is taken to ensure the PV can be evacuated.
+
+        If no action is specified, PVs using the `allowRemoteVolumeAccess: "false"` policy, or PVs that are otherwise
+        bound to the Node to be evacuated in their `.spec.nodeAffinity`, default to using the `AffinityOverride` action.
+        All other PVs use the `None` action.
+
 2. Piraeus Datastore will wait for all other `LinstorSatellite` resources to become available. This ensures that during
    rolling upgrades of the infrastructure, it waits until a replacement node for the node to be evacuated is available.
 3. If using ClusterAPI, the `pre-drain.delete.hook.machine.cluster.x-k8s.io/linstor-prepare-for-drain` annotation on the

--- a/internal/controller/linstorcluster_controller.go
+++ b/internal/controller/linstorcluster_controller.go
@@ -91,7 +91,7 @@ type LinstorClusterReconciler struct {
 //+kubebuilder:rbac:groups=apps,resources=daemonsets;deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=replicasets,verbs=get
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;clusterroles;rolebindings;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups="",resources=nodes;persistentvolumeclaims,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups="",resources=nodes;persistentvolumeclaims,verbs=get;list;watch;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=persistentvolumeclaims/status,verbs=patch
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=internal.linstor.linbit.com,resources=*,verbs=get;list;watch;create;update;patch;delete;deletecollection

--- a/pkg/evacuation/evacuation.go
+++ b/pkg/evacuation/evacuation.go
@@ -32,7 +32,7 @@ import (
 // The function should be called repeatedly until completion of the evacuation.
 func EvacuateSatellite(ctx context.Context, cl client.Client, lclient *lapi.Client, node *lapi.Node, machineClient *clusterapi.Client, machine *clusterapi.Machine) (string, bool, error) {
 	// Step 1: ensure PVs can be rescheduled to other nodes
-	msg, done, err := preparePVsforEvacuation(ctx, cl, node.Name)
+	msg, done, err := preparePVsforEvacuation(ctx, cl, lclient, node.Name)
 	if err != nil || !done {
 		return msg, done, err
 	}
@@ -87,7 +87,7 @@ func EvacuateSatellite(ctx context.Context, cl client.Client, lclient *lapi.Clie
 // It checks for PVs attached to the current node and:
 // * marks them with annotations so later steps can find them.
 // * ensures that "local" PVs are temporarily reschedulable during evacuation.
-func preparePVsforEvacuation(ctx context.Context, cl client.Client, nodeName string) (string, bool, error) {
+func preparePVsforEvacuation(ctx context.Context, cl client.Client, lclient *lapi.Client, nodeName string) (string, bool, error) {
 	var volumeAttachmentList storagev1.VolumeAttachmentList
 	err := cl.List(ctx, &volumeAttachmentList)
 	if err != nil {
@@ -98,6 +98,24 @@ func preparePVsforEvacuation(ctx context.Context, cl client.Client, nodeName str
 	err = cl.List(ctx, &nodeList)
 	if err != nil {
 		return "", false, err
+	}
+
+	rgSlice, err := lclient.ResourceGroups.GetAll(ctx)
+	if err != nil {
+		return "", false, err
+	}
+	rgs := make(map[string]lapi.ResourceGroup)
+	for _, rg := range rgSlice {
+		rgs[rg.Name] = rg
+	}
+
+	rdSlice, err := lclient.ResourceDefinitions.GetAll(ctx, lapi.RDGetAllRequest{})
+	if err != nil {
+		return "", false, err
+	}
+	rds := make(map[string]lapi.ResourceDefinition)
+	for _, rd := range rdSlice {
+		rds[rd.Name] = rd.ResourceDefinition
 	}
 
 	attachedPVs := getAttachedPVs(volumeAttachmentList.Items, nodeName)
@@ -125,10 +143,8 @@ func preparePVsforEvacuation(ctx context.Context, cl client.Client, nodeName str
 			pv.Annotations[vars.PersistentVolumeWaitForReattachAnnotationPrefix+"/"+nodeName] = "true"
 		}
 
-		// Check if the PV is "local access only". This can either be because of a local-only access policy, or some
-		// more complicated affinity settings. In both cases, we need to temporarily lift the affinity requirements
-		// on the PV, so that the workloads can be rescheduled.
-		if hasLocalOnlyAccessPolicy(&pv, nodeName) || !isAttachableOnOtherNode(&pv, nodeName, nodeList.Items) {
+		switch evacuationActionForPV(&pv, rds, rgs, nodeName, nodeList.Items) {
+		case PVEvacuationActionAffinityOverride:
 			// This annotation is used by the Affinity Controller to override the normal Node Affinity of the PV.
 			// We set it to "true", meaning "allow access from anywhere".
 			_, ok := pv.Annotations[affinity.OverrideAnnotationPrefix+"/"+nodeName]
@@ -138,10 +154,33 @@ func preparePVsforEvacuation(ctx context.Context, cl client.Client, nodeName str
 			}
 
 			unschedulablePVs = append(unschedulablePVs, pv.Name)
+		case PVEvacuationActionDelete:
+			// Delete the PVC and the PV, so that they can get recreated on new nodes.
+			if pv.Spec.ClaimRef != nil {
+				pvc := &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      pv.Spec.ClaimRef.Name,
+						Namespace: pv.Spec.ClaimRef.Namespace,
+					},
+				}
+				if err := cl.Delete(ctx, pvc, client.Preconditions(*metav1.NewUIDPreconditions(string(pv.Spec.ClaimRef.UID)))); err != nil && !k8serrors.IsNotFound(err) {
+					errs = append(errs, err)
+				}
+			}
+
+			if pv.DeletionTimestamp == nil {
+				if err := cl.Delete(ctx, &pv, client.Preconditions(*metav1.NewUIDPreconditions(string(pv.UID)))); err != nil && !k8serrors.IsNotFound(err) {
+					errs = append(errs, err)
+				}
+			}
+		case PVEvacuationActionNone:
+			// Nothing to do
 		}
 
 		if toUpdate {
-			errs = append(errs, cl.Update(ctx, &pv))
+			if err := cl.Update(ctx, &pv); err != nil && !k8serrors.IsNotFound(err) {
+				errs = append(errs, err)
+			}
 		}
 	}
 
@@ -155,6 +194,49 @@ func preparePVsforEvacuation(ctx context.Context, cl client.Client, nodeName str
 	}
 
 	return "", true, nil
+}
+
+type PVEvacuationAction string
+
+const (
+	// PVEvacuationActionNone indicates the PV is ready for evacuation as-is.
+	PVEvacuationActionNone PVEvacuationAction = "None"
+	// PVEvacuationActionDelete indicates the PV and PVC should be deleted so that it gets recreated on draining the node.
+	PVEvacuationActionDelete PVEvacuationAction = "Delete"
+	// PVEvacuationActionAffinityOverride indicates the PV should be prepared for evacuation by setting a less strict affinity.
+	PVEvacuationActionAffinityOverride PVEvacuationAction = "AffinityOverride"
+)
+
+// Determine the evacuation action for this PV.
+//
+// It first searches the PV annotations for vars.EvacuationActionAnnotation.
+// Then, it searches first on the ResourceDefinition and then the ResourceGroup properties.
+// As fallback, it returns PVEvacuationActionAffinityOverride for volumes which are local accessible only.
+func evacuationActionForPV(pv *corev1.PersistentVolume, rds map[string]lapi.ResourceDefinition, rgs map[string]lapi.ResourceGroup, nodeName string, nodes []corev1.Node) PVEvacuationAction {
+	if v, ok := pv.Annotations[vars.EvacuationActionAnnotation]; ok {
+		return PVEvacuationAction(v)
+	}
+
+	if pv.Spec.CSI != nil {
+		rd := rds[pv.Spec.CSI.VolumeHandle]
+		if v, ok := rd.Props[linstor.NamespcAuxiliary+"/"+vars.EvacuationActionAnnotation]; ok {
+			return PVEvacuationAction(v)
+		}
+
+		rg := rgs[rd.ResourceGroupName]
+		if v, ok := rg.Props[linstor.NamespcAuxiliary+"/"+vars.EvacuationActionAnnotation]; ok {
+			return PVEvacuationAction(v)
+		}
+	}
+
+	// Check if the PV is "local access only". This can either be because of a local-only access policy, or some
+	// more complicated affinity settings. In both cases, we need to temporarily lift the affinity requirements
+	// on the PV, so that the workloads can be rescheduled.
+	if hasLocalOnlyAccessPolicy(pv, nodeName) && !isAttachableOnOtherNode(pv, nodeName, nodes) {
+		return PVEvacuationActionAffinityOverride
+	}
+
+	return PVEvacuationActionNone
 }
 
 func waitForConfiguredSatellites(ctx context.Context, cl client.Client, nodeName string) (string, bool, error) {

--- a/pkg/evacuation/evacuation_test.go
+++ b/pkg/evacuation/evacuation_test.go
@@ -129,6 +129,116 @@ func TestEvacuateSatelliteWithLocalPVs(t *testing.T) {
 	assert.Contains(t, getMachine(t, cl, "machine-a").Annotations, vars.MachinePreTerminateHookAnnotation)
 }
 
+func TestEvacuateSatelliteWithEvacuationActionPVs(t *testing.T) {
+	t.Parallel()
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-ns"}}
+	localPV := createPV("local-pv-attached", "false", nil, TestNodeA.Name)
+
+	localActionDeletePV := createPV("local-pv-action-delete-on-pv", "false", map[string]string{
+		vars.EvacuationActionAnnotation: "Delete",
+	}, TestNodeA.Name)
+	localActionDeletePV.Spec.ClaimRef = &corev1.ObjectReference{
+		Namespace: namespace.Name,
+		Name:      "local-pv-action-delete-on-pv",
+	}
+	localActionDeletePVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "local-pv-action-delete-on-pv",
+			Namespace: namespace.Name,
+		},
+	}
+	localActionDeleteOnRDPV := createPV("local-pv-action-delete-on-rd", "true", nil, TestNodeA.Name)
+	localActionDeleteOnRDPV.Spec.ClaimRef = &corev1.ObjectReference{
+		Namespace: namespace.Name,
+		Name:      "local-pv-action-delete-on-rd",
+	}
+	localActionDeleteOnRDPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "local-pv-action-delete-on-rd",
+			Namespace: namespace.Name,
+		},
+	}
+	localActionDeleteOnRGPV := createPV("local-pv-action-delete-on-rg", "true", nil, TestNodeA.Name)
+	localActionDeleteOnRGPV.Spec.ClaimRef = &corev1.ObjectReference{
+		Namespace: namespace.Name,
+		Name:      "local-pv-action-delete-on-rg",
+	}
+	localActionDeleteOnRGPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "local-pv-action-delete-on-rg",
+			Namespace: namespace.Name,
+		},
+	}
+
+	cl, lc := setupTestCluster(t,
+		TestNodeA, TestNodeB, MachineA, MachineB, namespace,
+		localPV, createAttachment(TestNodeA, localPV),
+		localActionDeletePVC, localActionDeletePV, createAttachment(TestNodeA, localActionDeletePV),
+		localActionDeleteOnRDPVC, localActionDeleteOnRDPV, createAttachment(TestNodeA, localActionDeleteOnRDPV),
+		localActionDeleteOnRGPVC, localActionDeleteOnRGPV, createAttachment(TestNodeA, localActionDeleteOnRGPV),
+	)
+
+	err := lc.ResourceGroups.Create(t.Context(), lapi.ResourceGroup{
+		Name: "test-rg-default",
+	})
+	assert.NoError(t, err)
+
+	err = lc.ResourceGroups.Create(t.Context(), lapi.ResourceGroup{
+		Name: "test-rg-delete",
+		Props: map[string]string{
+			linstor.NamespcAuxiliary + "/" + vars.EvacuationActionAnnotation: "Delete",
+		},
+	})
+	assert.NoError(t, err)
+
+	err = lc.ResourceDefinitions.Create(t.Context(), lapi.ResourceDefinitionCreate{ResourceDefinition: lapi.ResourceDefinition{
+		Name:              "local-pv-action-delete-on-pv",
+		ResourceGroupName: "test-rg-default",
+	}})
+	assert.NoError(t, err)
+
+	err = lc.ResourceDefinitions.Create(t.Context(), lapi.ResourceDefinitionCreate{ResourceDefinition: lapi.ResourceDefinition{
+		Name:              "local-pv-action-delete-on-rd",
+		ResourceGroupName: "test-rg-default",
+		Props: map[string]string{
+			linstor.NamespcAuxiliary + "/" + vars.EvacuationActionAnnotation: "Delete",
+		},
+	}})
+	assert.NoError(t, err)
+
+	err = lc.ResourceDefinitions.Create(t.Context(), lapi.ResourceDefinitionCreate{ResourceDefinition: lapi.ResourceDefinition{
+		Name:              "local-pv-action-delete-on-rg",
+		ResourceGroupName: "test-rg-delete",
+	}})
+	assert.NoError(t, err)
+
+	// Satellite still has a local-only PV
+	msg, cont, err := runEvacuateSatellite(t, cl, lc)
+	assert.NoError(t, err)
+	assert.False(t, cont)
+	assert.Contains(t, msg, "Waiting for PVs to be schedulable on other nodes")
+	assert.Contains(t, msg, "local-pv-attached")
+	assert.NotContains(t, msg, "local-pv-action-delete-on-pv")
+	assert.NotContains(t, msg, "local-pv-action-delete-on-rd")
+	assert.NotContains(t, msg, "local-pv-action-delete-on-rg")
+
+	// Attached PVs should be marked for rescheduling, local only PV additionally with attach override
+	assert.Contains(t, getPV(t, cl, "local-pv-attached").Annotations, affinity.OverrideAnnotationPrefix+"/node-a")
+	assert.Contains(t, getPV(t, cl, "local-pv-attached").Annotations, vars.PersistentVolumeWaitForReattachAnnotationPrefix+"/node-a")
+
+	for _, pvName := range []string{"local-pv-action-delete-on-pv", "local-pv-action-delete-on-rd", "local-pv-action-delete-on-rg"} {
+		var pvc corev1.PersistentVolumeClaim
+		assert.Error(t, cl.Get(t.Context(), client.ObjectKey{Namespace: namespace.Name, Name: pvName}, &pvc))
+		var pv corev1.PersistentVolume
+		assert.Error(t, cl.Get(t.Context(), client.ObjectKey{Name: pvName}, &pv))
+	}
+
+	// No evacuation, no drain, no termination
+	assert.NotContains(t, getSatellite(t, lc, "node-a").Flags, linstor.FlagEvacuate)
+	assert.Contains(t, getMachine(t, cl, "machine-a").Annotations, vars.MachinePreDrainHookAnnotation)
+	assert.Contains(t, getMachine(t, cl, "machine-a").Annotations, vars.MachinePreTerminateHookAnnotation)
+}
+
 func TestEvacuateSatelliteWaitForOtherSatellites(t *testing.T) {
 	t.Parallel()
 	cl, lc := setupTestCluster(t,

--- a/pkg/fakelinstor/fakelinstor.go
+++ b/pkg/fakelinstor/fakelinstor.go
@@ -26,7 +26,10 @@ func New() *FakeLinstor {
 	mux.Handle("PUT /v1/nodes/{node}/evacuate", wrapHandler(f.evacuateNode))
 	mux.Handle("PUT /v1/nodes/{node}/restore", wrapHandler(f.restoreNode))
 	mux.Handle("DELETE /v1/nodes/{node}/lost", wrapHandler(f.lostNode))
+	mux.Handle("POST /v1/resource-groups", wrapHandler(f.createResourceGroup))
+	mux.Handle("GET /v1/resource-groups", wrapHandler(f.getResourceGroups))
 	mux.Handle("POST /v1/resource-definitions", wrapHandler(f.createResourceDefinition))
+	mux.Handle("GET /v1/resource-definitions", wrapHandler(f.getResourceDefinitions))
 	mux.Handle("DELETE /v1/resource-definitions/{rd}", wrapHandler(f.deleteResourceDefinition))
 	mux.Handle("GET /v1/resource-definitions/{rd}/resources/{node}", wrapHandler(f.getResource))
 	mux.Handle("POST /v1/resource-definitions/{rd}/resources/{node}", wrapHandler(f.createResource))
@@ -43,6 +46,7 @@ type FakeLinstor struct {
 	nodes               []lapi.Node
 	resources           []lapi.ResourceWithVolumes
 	resourceDefinitions []lapi.ResourceDefinition
+	resourceGroups      []lapi.ResourceGroup
 }
 
 func wrapHandler(f func(r *http.Request) (any, error)) http.Handler {
@@ -131,6 +135,35 @@ func (f *FakeLinstor) deleteNode(r *http.Request) (any, error) {
 	return nil, nil
 }
 
+func (f *FakeLinstor) createResourceGroup(r *http.Request) (any, error) {
+	defer r.Body.Close() //nolint:errcheck
+
+	var rg lapi.ResourceGroup
+	err := json.NewDecoder(r.Body).Decode(&rg)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding resource group: %w", err)
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if slices.ContainsFunc(f.resourceGroups, func(exist lapi.ResourceGroup) bool {
+		return exist.Name == rg.Name
+	}) {
+		return nil, fmt.Errorf("resource group '%s' already exists", rg.Name)
+	}
+
+	f.resourceGroups = append(f.resourceGroups, rg)
+	return nil, nil
+}
+
+func (f *FakeLinstor) getResourceGroups(r *http.Request) (any, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.resourceGroups, nil
+}
+
 func (f *FakeLinstor) createResourceDefinition(r *http.Request) (any, error) {
 	defer r.Body.Close() //nolint:errcheck
 
@@ -151,6 +184,13 @@ func (f *FakeLinstor) createResourceDefinition(r *http.Request) (any, error) {
 
 	f.resourceDefinitions = append(f.resourceDefinitions, rd.ResourceDefinition)
 	return nil, nil
+}
+
+func (f *FakeLinstor) getResourceDefinitions(r *http.Request) (any, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.resourceDefinitions, nil
 }
 
 func (f *FakeLinstor) getResource(r *http.Request) (any, error) {

--- a/pkg/vars/vars.go
+++ b/pkg/vars/vars.go
@@ -1,6 +1,7 @@
 package vars
 
 import (
+	linstorcsi "github.com/piraeusdatastore/linstor-csi/pkg/linstor"
 	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/utils"
@@ -26,6 +27,7 @@ const (
 	SatelliteNodeLabel                              = Domain + "/linstor-satellite"
 	SatelliteFinalizer                              = Domain + "/satellite-protection"
 	PersistentVolumeWaitForReattachAnnotationPrefix = "wait-for-reattach.evacuation." + Domain
+	EvacuationActionAnnotation                      = linstorcsi.DriverName + "/evacuation-action"
 	MachinePreDrainHookAnnotation                   = clusterapiv1beta1.PreDrainDeleteHookAnnotationPrefix + "/linstor-prepare-for-drain"
 	MachinePreTerminateHookAnnotation               = clusterapiv1beta1.PreTerminateDeleteHookAnnotationPrefix + "/linstor-wait-for-complete-evacuation"
 	GenCertLeaderElectionID                         = OperatorName + "-gencert"


### PR DESCRIPTION
For some types of volumes, such as "scratch" volumes, it might be desirable to automatically delete the volume instead of migrating.

To allow that, scan the PV and as a fallback the RD and RG. There, we search for specific annotations/properties. This allows users to set either the property on the storage class, or update the PV when needed to trigger deletion.

The deletion of the volume will only complete after the currently using Pod released the volume.