### PR TITLE
fix: drbd-module-loader failing due to missing mount on debian trixie

### DIFF
--- a/pkg/resources/satellite/satellite/daemonset.yaml
+++ b/pkg/resources/satellite/satellite/daemonset.yaml
@@ -49,6 +49,9 @@ spec:
             - mountPath: /usr/src
               name: usr-src
               readOnly: true
+            - name: usr-lib
+              mountPath: /usr/lib
+              readOnly: true
             - mountPath: /tmp
               name: tmp
         - name: drbd-shutdown-guard
@@ -176,6 +179,10 @@ spec:
         - name: usr-src
           hostPath:
             path: /usr/src
+            type: Directory
+        - name: usr-lib
+          hostPath:
+            path: /usr/lib
             type: Directory
         - name: dev
           hostPath:


### PR DESCRIPTION
The DRBD module loader fails on Debian Trixie due to a chain of softlinks from /lib/modules -> /usr/src -> /usr/lib not being available for a dependency of the `make` call, so add it as a volume mount.

The specific error that is seen is: 
```
/usr/src/linux-headers-6.12.43+deb13-common/Makefile:366: /usr/src/linux-headers-6.12.43+deb13-common/scripts/Kbuild.include:
```

This is because `scripts` is actually a softlink to the `/usr/lib/linux-kbuild-6.12.43+deb13/scripts/` directory on Debian Trixie and the call fails since the hostPath is not mounted into the pod.

This was replicated on Debian 13.1 using the `quay.io/piraeusdatastore/drbd9-trixie:v9.2.14` image via `podTemplate` overrides. The fix was also tested this way.