### PR TITLE
ci: sign images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -21,6 +23,9 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
+      - name: Set up cosign
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: sigstore/cosign-installer@v3
       - name: login to registry
         if: ${{ github.event_name != 'pull_request' }}
         env:
@@ -41,6 +46,7 @@ jobs:
             type=ref,event=pr
       - name: Build
         uses: docker/build-push-action@v6
+        id: build
         with:
           builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64,linux/arm64
@@ -52,3 +58,11 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             VERSION=${{ github.ref_name }}-${{ github.sha }}
+      - name: Sign images
+        if: ${{ github.event_name != 'pull_request' }}
+        # Take the digest we just pushed to the registry and sign the image using "keyless" signing:
+        #   https://docs.sigstore.dev/cosign/signing/overview/
+        # With this, users can verify that the image was actually created by this github workflow.
+        run: |
+          jq '."containerimage.digest" as $DIGEST | ."image.name" | split(":")[0] | "\(.)@\($DIGEST)"' -r <<<'${{ steps.build.outputs.metadata }}' \
+            | xargs --no-run-if-empty cosign sign --yes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,8 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add option to set replica count for Deployment components.
 - Integration with ClusterAPI to enable graceful node evacuation in case of rolling machine updates.
 - Additional status information on `LinstorCluster`, `LinstorSatelliteConfiguration` and `LinstorSatellite` resources.
+- Sign container images using keyless [cosign] signatures
 
 [LINSTOR Affinity Controller]: https://github.com/piraeusdatastore/linstor-affinity-controller
+[cosign]: https://docs.sigstore.dev/quickstart/quickstart-cosign/
 
 ### Removed
 


### PR DESCRIPTION
Use cosign to sign operator images using the "keyless" approach. The images are signed with a temporary identity tied to the specific github workflow that created them.