### PR TITLE
Configure workloads to share process namespaces

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Image configuration for RHEL10 clones.
 - Do not remove existing satellites for `*NoSchedule` taints.
+- Set `shareProcessNamespace: true` on workloads to automatically reap orphaned processes.
 
 ### Fixed
 

--- a/pkg/resources/cluster/affinity-controller/affinity-controller-deployment.yaml
+++ b/pkg/resources/cluster/affinity-controller/affinity-controller-deployment.yaml
@@ -71,3 +71,4 @@ spec:
       enableServiceLinks: false
       serviceAccountName: linstor-affinity-controller
       priorityClassName: system-cluster-critical
+      shareProcessNamespace: true

--- a/pkg/resources/cluster/controller/controller-deployment.yaml
+++ b/pkg/resources/cluster/controller/controller-deployment.yaml
@@ -102,6 +102,7 @@ spec:
               name: tmp
       enableServiceLinks: false
       serviceAccountName: linstor-controller
+      shareProcessNamespace: true
       priorityClassName: system-node-critical
       volumes:
         - name: etc-linstor

--- a/pkg/resources/cluster/csi-controller/csi-controller-deployment.yaml
+++ b/pkg/resources/cluster/csi-controller/csi-controller-deployment.yaml
@@ -18,6 +18,7 @@ spec:
     spec:
       enableServiceLinks: false
       serviceAccountName: linstor-csi-controller
+      shareProcessNamespace: true
       priorityClassName: system-node-critical
       initContainers:
         - name: linstor-wait-api-online

--- a/pkg/resources/cluster/csi-node/csi-node-daemon-set.yaml
+++ b/pkg/resources/cluster/csi-node/csi-node-daemon-set.yaml
@@ -19,6 +19,7 @@ spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
       serviceAccountName: linstor-csi-node
+      shareProcessNamespace: true
       priorityClassName: system-node-critical
       initContainers:
         - name: linstor-wait-node-online

--- a/pkg/resources/cluster/ha-controller/daemonset.yaml
+++ b/pkg/resources/cluster/ha-controller/daemonset.yaml
@@ -15,6 +15,7 @@ spec:
         app.kubernetes.io/component: ha-controller
     spec:
       serviceAccountName: ha-controller
+      shareProcessNamespace: true
       priorityClassName: system-cluster-critical
       containers:
         - name: ha-controller

--- a/pkg/resources/satellite/satellite/daemonset.yaml
+++ b/pkg/resources/satellite/satellite/daemonset.yaml
@@ -19,6 +19,7 @@ spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
       serviceAccountName: satellite
+      shareProcessNamespace: true
       priorityClassName: system-node-critical
       hostIPC: true
       initContainers:


### PR DESCRIPTION
The "shareProcessNamespace" spec means that all containers in a Pod share the same process namespace. This also means that PID 1 is managed by the implicit "pause" container managed by k8s.

This container also acts as a child process reaper. This fixes issues with certain workloads, such as LINSTOR Satellites sometimes leaving behind some child processes in case of timeouts.