### PR TITLE
satellite configuration: reset status every run

### DIFF
--- a/internal/controller/linstorcluster_controller.go
+++ b/internal/controller/linstorcluster_controller.go
@@ -225,6 +225,7 @@ func (r *LinstorClusterReconciler) reconcileAppliedResource(ctx context.Context,
 				ObservedGeneration: config.Generation,
 			})
 
+			config.Status.AppliedTo = nil
 			for node, configs := range appliedConfigurations {
 				if slices.Contains(configs, config.Name) {
 					config.Status.AppliedTo = append(config.Status.AppliedTo, node)


### PR DESCRIPTION
Otherwise, the "AppliedTo" list builds up over time with repeated entries of the same Satellite names.

