### PR TITLE
Add podLabels, podAnnotations, podSecurityContext

### DIFF
--- a/charts/piraeus/templates/deployment.yaml
+++ b/charts/piraeus/templates/deployment.yaml
@@ -13,9 +13,15 @@ spec:
   template:
     metadata:
       labels:
-      {{- include "piraeus-operator.selectorLabels" . | nindent 8 }}
+        {{- include "piraeus-operator.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - args:
@@ -90,6 +96,9 @@ spec:
       {{- end }}
       securityContext:
         runAsNonRoot: true
+        {{- with .Values.podSecurityContext }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
       serviceAccountName: {{ include "piraeus-operator.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10
       priorityClassName: {{ .Values.priorityClassName | default "system-cluster-critical" }}

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -1,3 +1,4 @@
+---
 replicaCount: 1
 
 installCRDs: false
@@ -81,6 +82,7 @@ rbac:
   create: true
 
 podAnnotations: { }
+podLabels: {}
 
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
This PR adds support for configurable podLabels and fixes issues with podSecurityContext and podAnnotations in the Piraeus Operator Helm chart.

Key Changes:

`values.yaml`:

Added `podLabels: {}` for custom pod labeling.
Added/fixed `podAnnotations: {}` for custom annotations.
Added/fixed `podSecurityContext: {}` for security configurations.

`deployment.yaml`:

Integrated `podLabels` and `podAnnotations` into pod template metadata.
Applied `podSecurityContext` for enhanced pod-level security.