### PR TITLE
Release 2.10.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PROJECT_NAME ?= piraeus-operator
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 2.9.1
+VERSION ?= 2.10.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PROJECT_NAME ?= piraeus-operator
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 2.9.0
+VERSION ?= 2.9.1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/charts/piraeus/Chart.yaml
+++ b/charts/piraeus/Chart.yaml
@@ -3,8 +3,8 @@ name: piraeus
 description: |
   The Piraeus Operator manages software defined storage clusters using LINSTOR in Kubernetes.
 type: application
-version: 2.9.0
-appVersion: "v2.9.0"
+version: 2.9.1
+appVersion: "v2.9.1"
 maintainers:
   - name: Piraeus Datastore
     url: https://piraeus.io

--- a/charts/piraeus/Chart.yaml
+++ b/charts/piraeus/Chart.yaml
@@ -3,8 +3,8 @@ name: piraeus
 description: |
   The Piraeus Operator manages software defined storage clusters using LINSTOR in Kubernetes.
 type: application
-version: 2.9.1
-appVersion: "v2.9.1"
+version: 2.10.0
+appVersion: "v2.10.0"
 maintainers:
   - name: Piraeus Datastore
     url: https://piraeus.io

--- a/charts/piraeus/templates/config.yaml
+++ b/charts/piraeus/templates/config.yaml
@@ -17,25 +17,25 @@ data:
     #   quay.io/piraeusdatastore/piraeus-server:v1.24.2
     components:
       linstor-controller:
-        tag: v1.32.1
+        tag: v1.32.3
         image: piraeus-server
       linstor-satellite:
-        tag: v1.32.1
+        tag: v1.32.3
         image: piraeus-server
       linstor-csi:
-        tag: v1.9.0
+        tag: v1.10.1
         image: piraeus-csi
       nfs-server:
-        tag: v1.9.0
+        tag: v1.10.1
         image: piraeus-csi-nfs-server
       drbd-reactor:
-        tag: v1.9.0
+        tag: v1.10.0
         image: drbd-reactor
       ha-controller:
-        tag: v1.3.0
+        tag: v1.3.1
         image: piraeus-ha-controller
       drbd-shutdown-guard:
-        tag: v1.0.0
+        tag: v1.1.1
         image: drbd-shutdown-guard
       ktls-utils:
         tag: v1.2.1
@@ -99,13 +99,13 @@ data:
         tag: v2.17.0
         image: livenessprobe
       csi-provisioner:
-        tag: v5.3.0
+        tag: v6.0.0
         image: csi-provisioner
       csi-snapshotter:
-        tag: v8.3.0
+        tag: v8.4.0
         image: csi-snapshotter
       csi-resizer:
-        tag: v1.14.0
+        tag: v2.0.0
         image: csi-resizer
       csi-external-health-monitor-controller:
         tag: v0.16.0

--- a/charts/piraeus/templates/config.yaml
+++ b/charts/piraeus/templates/config.yaml
@@ -17,10 +17,10 @@ data:
     #   quay.io/piraeusdatastore/piraeus-server:v1.24.2
     components:
       linstor-controller:
-        tag: v1.31.2
+        tag: v1.32.1
         image: piraeus-server
       linstor-satellite:
-        tag: v1.31.2
+        tag: v1.32.1
         image: piraeus-server
       linstor-csi:
         tag: v1.9.0
@@ -29,7 +29,7 @@ data:
         tag: v1.9.0
         image: piraeus-csi-nfs-server
       drbd-reactor:
-        tag: v1.8.0
+        tag: v1.9.0
         image: drbd-reactor
       ha-controller:
         tag: v1.3.0
@@ -38,13 +38,13 @@ data:
         tag: v1.0.0
         image: drbd-shutdown-guard
       ktls-utils:
-        tag: v1.1.0
+        tag: v1.2.1
         image: ktls-utils
       linstor-affinity-controller:
         tag: v1.3.0
         image: linstor-affinity-controller
       drbd-module-loader:
-        tag: v9.2.14
+        tag: v9.2.15
         # The special "match" attribute is used to select an image based on the node's reported OS.
         # The operator will first check the k8s node's ".status.nodeInfo.osImage" field, and compare it against the list
         # here. If one matches, that specific image name will be used instead of the fallback image.
@@ -93,25 +93,25 @@ data:
     base: registry.k8s.io/sig-storage
     components:
       csi-attacher:
-        tag: v4.9.0
+        tag: v4.10.0
         image: csi-attacher
       csi-livenessprobe:
-        tag: v2.16.0
+        tag: v2.17.0
         image: livenessprobe
       csi-provisioner:
         tag: v5.3.0
         image: csi-provisioner
       csi-snapshotter:
-        tag: v8.2.1
+        tag: v8.3.0
         image: csi-snapshotter
       csi-resizer:
-        tag: v1.13.2
+        tag: v1.14.0
         image: csi-resizer
       csi-external-health-monitor-controller:
-        tag: v0.15.0
+        tag: v0.16.0
         image: csi-external-health-monitor-controller
       csi-node-driver-registrar:
-        tag: v2.14.0
+        tag: v2.15.0
         image: csi-node-driver-registrar
   {{- range $idx, $value := .Values.imageConfigOverride }}
   {{ add $idx 1 }}_helm_override.yaml: |

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,7 +12,7 @@ labels:
 images:
 - name: controller
   newName: quay.io/piraeusdatastore/piraeus-operator
-  newTag: v2
+  newTag: v2.10.0
 
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,7 +12,7 @@ labels:
 images:
 - name: controller
   newName: quay.io/piraeusdatastore/piraeus-operator
-  newTag: v2.10.0
+  newTag: v2
 
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus

--- a/config/manager/0_piraeus_datastore_images.yaml
+++ b/config/manager/0_piraeus_datastore_images.yaml
@@ -8,10 +8,10 @@ base: quay.io/piraeusdatastore
 #   quay.io/piraeusdatastore/piraeus-server:v1.24.2
 components:
   linstor-controller:
-    tag: v1.31.2
+    tag: v1.32.1
     image: piraeus-server
   linstor-satellite:
-    tag: v1.31.2
+    tag: v1.32.1
     image: piraeus-server
   linstor-csi:
     tag: v1.9.0
@@ -20,7 +20,7 @@ components:
     tag: v1.9.0
     image: piraeus-csi-nfs-server
   drbd-reactor:
-    tag: v1.8.0
+    tag: v1.9.0
     image: drbd-reactor
   ha-controller:
     tag: v1.3.0
@@ -29,13 +29,13 @@ components:
     tag: v1.0.0
     image: drbd-shutdown-guard
   ktls-utils:
-    tag: v1.1.0
+    tag: v1.2.1
     image: ktls-utils
   linstor-affinity-controller:
     tag: v1.3.0
     image: linstor-affinity-controller
   drbd-module-loader:
-    tag: v9.2.14
+    tag: v9.2.15
     # The special "match" attribute is used to select an image based on the node's reported OS.
     # The operator will first check the k8s node's ".status.nodeInfo.osImage" field, and compare it against the list
     # here. If one matches, that specific image name will be used instead of the fallback image.

--- a/config/manager/0_piraeus_datastore_images.yaml
+++ b/config/manager/0_piraeus_datastore_images.yaml
@@ -8,25 +8,25 @@ base: quay.io/piraeusdatastore
 #   quay.io/piraeusdatastore/piraeus-server:v1.24.2
 components:
   linstor-controller:
-    tag: v1.32.1
+    tag: v1.32.3
     image: piraeus-server
   linstor-satellite:
-    tag: v1.32.1
+    tag: v1.32.3
     image: piraeus-server
   linstor-csi:
-    tag: v1.9.0
+    tag: v1.10.1
     image: piraeus-csi
   nfs-server:
-    tag: v1.9.0
+    tag: v1.10.1
     image: piraeus-csi-nfs-server
   drbd-reactor:
-    tag: v1.9.0
+    tag: v1.10.0
     image: drbd-reactor
   ha-controller:
-    tag: v1.3.0
+    tag: v1.3.1
     image: piraeus-ha-controller
   drbd-shutdown-guard:
-    tag: v1.0.0
+    tag: v1.1.1
     image: drbd-shutdown-guard
   ktls-utils:
     tag: v1.2.1

--- a/config/manager/0_sig_storage_images.yaml
+++ b/config/manager/0_sig_storage_images.yaml
@@ -2,23 +2,23 @@
 base: registry.k8s.io/sig-storage
 components:
   csi-attacher:
-    tag: v4.9.0
+    tag: v4.10.0
     image: csi-attacher
   csi-livenessprobe:
-    tag: v2.16.0
+    tag: v2.17.0
     image: livenessprobe
   csi-provisioner:
     tag: v5.3.0
     image: csi-provisioner
   csi-snapshotter:
-    tag: v8.2.1
+    tag: v8.3.0
     image: csi-snapshotter
   csi-resizer:
-    tag: v1.13.2
+    tag: v1.14.0
     image: csi-resizer
   csi-external-health-monitor-controller:
-    tag: v0.15.0
+    tag: v0.16.0
     image: csi-external-health-monitor-controller
   csi-node-driver-registrar:
-    tag: v2.14.0
+    tag: v2.15.0
     image: csi-node-driver-registrar

--- a/config/manager/0_sig_storage_images.yaml
+++ b/config/manager/0_sig_storage_images.yaml
@@ -8,13 +8,13 @@ components:
     tag: v2.17.0
     image: livenessprobe
   csi-provisioner:
-    tag: v5.3.0
+    tag: v6.0.0
     image: csi-provisioner
   csi-snapshotter:
-    tag: v8.3.0
+    tag: v8.4.0
     image: csi-snapshotter
   csi-resizer:
-    tag: v1.14.0
+    tag: v2.0.0
     image: csi-resizer
   csi-external-health-monitor-controller:
     tag: v0.16.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,7 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Set `shareProcessNamespace: true` on workloads to automatically reap orphaned processes.
 - LINSTOR CSI now use `hostNetwork: true` so RWX mounts use a stable IP when connecting to NFS.
-
+- Updated images:
+    * LINSTOR 1.32.3
+    * LINSTOR CSI 1.10.1
+    * DRBD Reactor 1.10.0
+    * DRBD Shutdown Guard: 1.1.1
+    * LINSTOR HA Controller 1.3.1
+    * Latest CSI sidecars
 
 ## [v2.9.1] - 2025-09-25
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [LINSTOR Affinity Controller]: https://github.com/piraeusdatastore/linstor-affinity-controller
 [cosign]: https://docs.sigstore.dev/quickstart/quickstart-cosign/
 
+### Changed
+
+- Set `shareProcessNamespace: true` on workloads to automatically reap orphaned processes.
+- LINSTOR CSI now use `hostNetwork: true` so RWX mounts use a stable IP when connecting to NFS.
+
+
+## [v2.9.1] - 2025-09-25
+
+### Changed
+
+- Image configuration for RHEL10 clones.
+- Do not remove existing satellites for `*NoSchedule` taints.
+- Updated images:
+    * LINSTOR 1.32.1
+    * LINSTOR CSI 1.9.0
+    * DRBD 9.2.15
+    * DRBD Reactor 1.9.0
+    * kTLS-utils 1.2.1
+    * Latest CSI sidecars
+
+### Fixed
+
+- Fix a crash in the validation webhook when trying to change the type of storage pool.
+
 ### Removed
 
 - Removed image configuration for EOL distributions:
@@ -27,17 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Ubuntu 20.04 ("Focal Fossa")
   * CentOS 7
   * Debian 10 ("Buster")
-
-### Changed
-
-- Image configuration for RHEL10 clones.
-- Do not remove existing satellites for `*NoSchedule` taints.
-- Set `shareProcessNamespace: true` on workloads to automatically reap orphaned processes.
-- LINSTOR CSI now use `hostNetwork: true` so RWX mounts use a stable IP when connecting to NFS.
-
-### Fixed
-
-- Fix a crash in the validation webhook when trying to change the type of storage pool.
 
 ## [v2.9.0] - 2025-06-17
 
@@ -1071,4 +1084,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v2.8.0]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.7.1...v2.8.0
 [v2.8.1]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.8.0...v2.8.1
 [v2.9.0]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.8.1...v2.9.0
-[Unreleased]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.9.0...HEAD
+[v2.9.1]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.9.0...v2.9.1
+[Unreleased]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.9.1...HEAD

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v2.10.0] - 2025-11-05
 
 ### Added
 
@@ -1091,4 +1091,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v2.8.1]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.8.0...v2.8.1
 [v2.9.0]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.8.1...v2.9.0
 [v2.9.1]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.9.0...v2.9.1
-[Unreleased]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.9.1...HEAD
+[v2.10.0]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.9.1...v2.10.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [v2.10.0] - 2025-11-05
 
 ### Added
@@ -1092,3 +1094,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v2.9.0]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.8.1...v2.9.0
 [v2.9.1]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.9.0...v2.9.1
 [v2.10.0]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.9.1...v2.10.0
+[Unreleased]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.10.0...HEAD

--- a/docs/upgrade/README.md
+++ b/docs/upgrade/README.md
@@ -51,6 +51,17 @@ spec:
     operator: Exists
 ```
 
+Combined, these changes might lead to situations where LINSTOR Satellites are registered for control plane nodes without
+any additional reconciliation. To clean up these LINSTOR Satellites, run:
+
+```
+$ kubectl exec deploy/linstor-controller -- linstor node list --props Aux/piraeus.io/last-applied
+# Check for OFFLINE nodes, verify that it is no longer managed by the Operator:
+$ kubectl get linstorsatellite <offline-node>
+# Must report: linstorsatellites.piraeus.io "<offline-node>" not found
+$ kubectl exec deploy/linstor-controller -- linstor node delete <offline-node>
+```
+
 # Upgrades from v2.7 to v2.8
 
 No special steps required.

--- a/pkg/resources/cluster/csi-node/csi-node-daemon-set.yaml
+++ b/pkg/resources/cluster/csi-node/csi-node-daemon-set.yaml
@@ -82,6 +82,8 @@ spec:
               mountPath: /dev
             - name: run-mount
               mountPath: /run/mount
+            - name: run-fsck
+              mountPath: /run/fsck
         - name: csi-node-driver-registrar
           image: csi-node-driver-registrar
           args:
@@ -141,3 +143,5 @@ spec:
           hostPath:
             path: /run/mount
             type: Directory
+        - name: run-fsck
+          emptyDir: {}


### PR DESCRIPTION
Lots of commits because I merged in the v2.9.1 release track. Otherwise just the regular image updates + mounting /run/fsck for the new `fsck /dev/<device>` during mounting.