### PR TITLE
clusterapi: ignore more errors when fetching machine

### DIFF
--- a/pkg/clusterapi/machine.go
+++ b/pkg/clusterapi/machine.go
@@ -5,6 +5,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1" //nolint:staticcheck
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -29,7 +30,7 @@ func (cl *Client) GetMachineForNode(ctx context.Context, node *corev1.Node) (*Ma
 	var machine clusterapiv1beta1.Machine
 	err := cl.client.Get(ctx, client.ObjectKey{Name: machineName, Namespace: clusterNs}, &machine)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if errors.IsNotFound(err) || meta.IsNoMatchError(err) {
 			return nil, nil
 		}
 


### PR DESCRIPTION
There might be cases where the Machine annotations are present, but the Cluster API is running on another cluster. This is why we support setting a separate kube config for cluster API.

However, if a user just wants to use the Operator without the integration, we currently run into errors because theb client returns "NoKindMatched" errors. We ignore those errors now.