### PR TITLE
Some CSI controller improvements

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Liveness probes for CSI sidecars
 
+### Changed
+
+- Disable group snapshots if we cannot be sure they are supported, otherwise the csi-snapshot silently breaks.
+
 ## [v2.10.0] - 2025-11-05
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Liveness probes for CSI sidecars
+
 ## [v2.10.0] - 2025-11-05
 
 ### Added

--- a/internal/controller/linstorcluster_controller.go
+++ b/internal/controller/linstorcluster_controller.go
@@ -37,6 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	schedulingcorev1 "k8s.io/component-helpers/scheduling/corev1"
@@ -71,14 +72,15 @@ import (
 // LinstorClusterReconciler reconciles a LinstorCluster object
 type LinstorClusterReconciler struct {
 	client.Client
-	Scheme             *runtime.Scheme
-	Namespace          string
-	PullSecret         string
-	ImageConfigMapName string
-	RequeueInterval    time.Duration
-	LinstorClientOpts  []lapi.Option
-	Kustomizer         *resources.Kustomizer
-	APIVersion         *utils.APIVersion
+	Scheme                       *runtime.Scheme
+	Namespace                    string
+	PullSecret                   string
+	ImageConfigMapName           string
+	RequeueInterval              time.Duration
+	LinstorClientOpts            []lapi.Option
+	Kustomizer                   *resources.Kustomizer
+	APIVersion                   *utils.APIVersion
+	SupportsVolumeGroupSnapshots bool
 }
 
 //+kubebuilder:rbac:groups=piraeus.io,resources=linstorclusters,verbs=get;list;watch;create;update;patch;delete
@@ -537,6 +539,15 @@ func (r *LinstorClusterReconciler) kustomizeCSIControllerResources(lcluster *pir
 
 	if !lcluster.Spec.NFSServer.IsEnabled() {
 		p, err := ClusterCSIControllerDisableRWXPatch()
+		if err != nil {
+			return nil, err
+		}
+
+		patches = append(patches, p...)
+	}
+
+	if !r.SupportsVolumeGroupSnapshots {
+		p, err := ClusterCSIControllerDisableVolumeGroupSnapshotPatch()
 		if err != nil {
 			return nil, err
 		}
@@ -1345,7 +1356,13 @@ func (r *LinstorClusterReconciler) SetupWithManager(mgr ctrl.Manager, opts contr
 		opts.RateLimiter = DefaultRateLimiter[reconcile.Request]()
 	}
 
-	r.APIVersion = utils.NewAPIVersionFromConfigWithFallback(mgr.GetConfig(), &vars.FallbackAPIVersion)
+	apiDiscovery := utils.NewAPIDiscoveryClient(mgr.GetConfig(), &vars.FallbackAPIVersion)
+	r.APIVersion = apiDiscovery.ServerVersion()
+	r.SupportsVolumeGroupSnapshots = apiDiscovery.HasGroupVersionResource(schema.GroupVersionResource{
+		Group:    "groupsnapshot.storage.k8s.io",
+		Version:  "v1beta2",
+		Resource: "volumegroupsnapshots",
+	})
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&piraeusiov1.LinstorCluster{}).

--- a/internal/controller/patches.go
+++ b/internal/controller/patches.go
@@ -209,6 +209,14 @@ func ClusterCSIControllerDisableRWXPatch() ([]kusttypes.Patch, error) {
 	)
 }
 
+func ClusterCSIControllerDisableVolumeGroupSnapshotPatch() ([]kusttypes.Patch, error) {
+	return render(
+		cluster.Resources,
+		"patches/csi-controller-disable-volume-group-snapshots.yaml",
+		nil,
+	)
+}
+
 func ClusterCSIControllerApiTLSPatch(controllerSecret string, caRef *piraeusiov1.CAReference) ([]kusttypes.Patch, error) {
 	return render(
 		cluster.Resources,

--- a/internal/controller/patches_test.go
+++ b/internal/controller/patches_test.go
@@ -236,6 +236,12 @@ func TestPatches(t *testing.T) {
 			},
 		},
 		{
+			name: "ClusterCSIControllerDisableVolumeGroupSnapshotPatch",
+			call: func() ([]kusttypes.Patch, error) {
+				return controller.ClusterCSIControllerDisableVolumeGroupSnapshotPatch()
+			},
+		},
+		{
 			name: "ClusterCSIControllerApiTLSPatch",
 			call: func() ([]kusttypes.Patch, error) {
 				return controller.ClusterCSIControllerApiTLSPatch("controller", &piraeusiov1.CAReference{

--- a/pkg/resources/cluster/csi-controller/csi-controller-deployment.yaml
+++ b/pkg/resources/cluster/csi-controller/csi-controller-deployment.yaml
@@ -76,20 +76,35 @@ spec:
         - name: csi-attacher
           image: csi-attacher
           args:
-            - '--v=5'
+            - '--v=$(VERBOSE)'
             - '--csi-address=$(ADDRESS)'
-            - '--timeout=1m'
-            - '--leader-election=true'
+            - '--timeout=$(TIMEOUT)'
+            - '--leader-election=$(LEADER_ELECTION)'
             - '--leader-election-namespace=$(NAMESPACE)'
-            - '--worker-threads=10'
+            - '--worker-threads=$(WORKER_THREADS)'
+            - '--http-endpoint=$(HTTP_ENDPOINT)'
           env:
+            - name: VERBOSE
+              value: "5"
             - name: ADDRESS
               value: /csi/csi.sock
+            - name: TIMEOUT
+              value: "1m"
+            - name: LEADER_ELECTION
+              value: "true"
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+            - name: WORKER_THREADS
+              value: "10"
+            - name: HTTP_ENDPOINT
+              value: :9809
+          livenessProbe:
+            httpGet:
+              port: 9809
+              path: /healthz/leader-election
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -116,29 +131,52 @@ spec:
         - name: csi-provisioner
           image: csi-provisioner
           args:
+            - '--v=$(VERBOSE)'
             - '--csi-address=$(ADDRESS)'
-            - '--timeout=1m'
-            - '--default-fstype=ext4'
-            - '--feature-gates=Topology=true'
-            - '--leader-election=true'
+            - '--timeout=$(TIMEOUT)'
+            - '--leader-election=$(LEADER_ELECTION)'
             - '--leader-election-namespace=$(NAMESPACE)'
-            - '--enable-capacity'
-            - '--extra-create-metadata'
-            - '--capacity-ownerref-level=2'
-            - '--worker-threads=10'
+            - '--worker-threads=$(WORKER_THREADS)'
+            - '--http-endpoint=$(HTTP_ENDPOINT)'
+            - '--default-fstype=$(DEFAULT_FS_TYPE)'
+            - '--enable-capacity=$(ENABLE_CAPACITY)'
+            - '--extra-create-metadata=$(EXTRA_CREATE_METADATA)'
+            - '--capacity-ownerref-level=$(CAPACITY_OWNERREF_LEVEL)'
           env:
+            - name: VERBOSE
+              value: "5"
             - name: ADDRESS
               value: /csi/csi.sock
+            - name: TIMEOUT
+              value: "1m"
+            - name: LEADER_ELECTION
+              value: "true"
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+            - name: WORKER_THREADS
+              value: "10"
+            - name: HTTP_ENDPOINT
+              value: :9810
+            - name: DEFAULT_FS_TYPE
+              value: ext4
+            - name: ENABLE_CAPACITY
+              value: "true"
+            - name: EXTRA_CREATE_METADATA
+              value: "true"
+            - name: CAPACITY_OWNERREF_LEVEL
+              value: "2"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
+          livenessProbe:
+            httpGet:
+              port: 9810
+              path: /healthz/leader-election
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -150,22 +188,38 @@ spec:
         - name: csi-snapshotter
           image: csi-snapshotter
           args:
-            - '--timeout=1m'
+            - '--v=$(VERBOSE)'
             - '--csi-address=$(ADDRESS)'
-            - '--leader-election=true'
+            - '--timeout=$(TIMEOUT)'
+            - '--leader-election=$(LEADER_ELECTION)'
             - '--leader-election-namespace=$(NAMESPACE)'
-            - '--worker-threads=10'
+            - '--worker-threads=$(WORKER_THREADS)'
+            - '--http-endpoint=$(HTTP_ENDPOINT)'
             - '--feature-gates=$(FEATURE_GATES)'
           env:
+            - name: VERBOSE
+              value: "5"
             - name: ADDRESS
               value: /csi/csi.sock
-            - name: FEATURE_GATES
-              value: CSIVolumeGroupSnapshot=true
+            - name: TIMEOUT
+              value: "1m"
+            - name: LEADER_ELECTION
+              value: "true"
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+            - name: WORKER_THREADS
+              value: "10"
+            - name: HTTP_ENDPOINT
+              value: :9811
+            - name: FEATURE_GATES
+              value: CSIVolumeGroupSnapshot=true
+          livenessProbe:
+            httpGet:
+              port: 9811
+              path: /healthz/leader-election
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -177,21 +231,38 @@ spec:
         - name: csi-resizer
           image: csi-resizer
           args:
-            - '--v=5'
+            - '--v=$(VERBOSE)'
             - '--csi-address=$(ADDRESS)'
-            - '--timeout=1m'
-            - '--handle-volume-inuse-error=false'
-            - '--leader-election=true'
+            - '--timeout=$(TIMEOUT)'
+            - '--leader-election=$(LEADER_ELECTION)'
             - '--leader-election-namespace=$(NAMESPACE)'
-            - '--workers=10'
+            - '--workers=$(WORKER_THREADS)' # the only one using a different name
+            - '--http-endpoint=$(HTTP_ENDPOINT)'
+            - '--handle-volume-inuse-error=$(HANDLE_VOLUME_INUSE_ERROR)'
           env:
+            - name: VERBOSE
+              value: "5"
             - name: ADDRESS
               value: /csi/csi.sock
+            - name: TIMEOUT
+              value: "1m"
+            - name: LEADER_ELECTION
+              value: "true"
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+            - name: WORKER_THREADS
+              value: "10"
+            - name: HTTP_ENDPOINT
+              value: :9812
+            - name: HANDLE_VOLUME_INUSE_ERROR
+              value: "false"
+          livenessProbe:
+            httpGet:
+              port: 9812
+              path: /healthz/leader-election
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -203,19 +274,35 @@ spec:
         - name: csi-health-monitor
           image: csi-external-health-monitor-controller
           args:
-            - '--v=5'
+            - '--v=$(VERBOSE)'
             - '--csi-address=$(ADDRESS)'
-            - '--timeout=1m'
-            - '--leader-election=true'
+            - '--timeout=$(TIMEOUT)'
+            - '--leader-election=$(LEADER_ELECTION)'
             - '--leader-election-namespace=$(NAMESPACE)'
+            - '--worker-threads=$(WORKER_THREADS)'
+            - '--http-endpoint=$(HTTP_ENDPOINT)'
           env:
+            - name: VERBOSE
+              value: "5"
             - name: ADDRESS
               value: /csi/csi.sock
+            - name: TIMEOUT
+              value: "1m"
+            - name: LEADER_ELECTION
+              value: "true"
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+            - name: WORKER_THREADS
+              value: "10"
+            - name: HTTP_ENDPOINT
+              value: :9813
+          livenessProbe:
+            httpGet:
+              port: 9813
+              path: /healthz/leader-election
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/pkg/resources/cluster/csi-controller/csi-controller-deployment.yaml
+++ b/pkg/resources/cluster/csi-controller/csi-controller-deployment.yaml
@@ -195,7 +195,7 @@ spec:
             - '--leader-election-namespace=$(NAMESPACE)'
             - '--worker-threads=$(WORKER_THREADS)'
             - '--http-endpoint=$(HTTP_ENDPOINT)'
-            - '--feature-gates=$(FEATURE_GATES)'
+            - '--feature-gates=CSIVolumeGroupSnapshot=$(FEATURE_GATE_CSI_VOLUME_GROUP_SNAPSHOT),$(FEATURE_GATES)'
           env:
             - name: VERBOSE
               value: "5"
@@ -214,8 +214,10 @@ spec:
               value: "10"
             - name: HTTP_ENDPOINT
               value: :9811
+            - name: FEATURE_GATE_CSI_VOLUME_GROUP_SNAPSHOT
+              value: "true"
             - name: FEATURE_GATES
-              value: CSIVolumeGroupSnapshot=true
+              value: ""
           livenessProbe:
             httpGet:
               port: 9811

--- a/pkg/resources/cluster/patches/csi-controller-disable-volume-group-snapshots.yaml
+++ b/pkg/resources/cluster/patches/csi-controller-disable-volume-group-snapshots.yaml
@@ -1,0 +1,17 @@
+---
+- target:
+    kind: Deployment
+    name: linstor-csi-controller
+  patch: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: linstor-csi-controller
+    spec:
+      template:
+        spec:
+          containers:
+          - name: csi-snapshotter
+            env:
+            - name: FEATURE_GATE_CSI_VOLUME_GROUP_SNAPSHOT
+              value: "false"

--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -5,35 +5,68 @@ import (
 	"fmt"
 	"strconv"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 )
 
-func NewAPIVersionFromConfigWithFallback(conf *rest.Config, fallback *APIVersion) *APIVersion {
-	client, err := discovery.NewDiscoveryClientForConfig(conf)
-	if err != nil {
-		return fallback
+type APIDiscoveryClient struct {
+	cl              *discovery.DiscoveryClient
+	fallbackVersion *APIVersion
+}
+
+func NewAPIDiscoveryClient(conf *rest.Config, fallback *APIVersion) *APIDiscoveryClient {
+	client, _ := discovery.NewDiscoveryClientForConfig(conf)
+
+	return &APIDiscoveryClient{
+		cl:              client,
+		fallbackVersion: fallback,
+	}
+}
+
+func (ac *APIDiscoveryClient) ServerVersion() *APIVersion {
+	if ac.cl == nil {
+		return ac.fallbackVersion
 	}
 
-	version, err := client.ServerVersion()
+	version, err := ac.cl.ServerVersion()
 	if err != nil {
-		return fallback
+		return ac.fallbackVersion
 	}
 
 	major, err := strconv.Atoi(version.Major)
 	if err != nil {
-		return fallback
+		return ac.fallbackVersion
 	}
 
 	minor, err := strconv.Atoi(version.Minor)
 	if err != nil {
-		return fallback
+		return ac.fallbackVersion
 	}
 
 	return &APIVersion{
 		Major: major,
 		Minor: minor,
 	}
+}
+
+func (ac *APIDiscoveryClient) HasGroupVersionResource(gvr schema.GroupVersionResource) bool {
+	if ac.cl == nil {
+		return false
+	}
+
+	resources, err := ac.cl.ServerResourcesForGroupVersion(gvr.GroupVersion().String())
+	if err != nil {
+		return false
+	}
+
+	for _, r := range resources.APIResources {
+		if r.Name == gvr.Resource {
+			return true
+		}
+	}
+
+	return false
 }
 
 type APIVersion struct {


### PR DESCRIPTION
* Ensure that all sidecars can be patched using the environment, as that is simpler than patching the `args`
* Disable Volume Group Snapshots if the necessary API is not present, as that causes the csi-snapshotter to silently stop working.