### PR TITLE
fix excessive reconciles for updated status

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Disable group snapshots if we cannot be sure they are supported, otherwise the csi-snapshot silently breaks.
 
+### Fixed
+
+- Status update on LinstorCluster and LinstorSatellite resources no longer causes infinite reconciles.
+
 ## [v2.10.0] - 2025-11-05
 
 ### Added

--- a/internal/controller/linstorcluster_controller.go
+++ b/internal/controller/linstorcluster_controller.go
@@ -142,6 +142,14 @@ func (r *LinstorClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	status, stateErr := r.reconcileClusterState(ctx, lcluster, conds)
 
 	_, condErr := controllerutil.CreateOrPatch(ctx, r.Client, lcluster, func() error {
+		// Fill in existing conditions so meta.SetStatusCondition does not update the LastTransitionTime if the
+		// condition is already set.
+		status.Conditions = lcluster.Status.Conditions
+
+		for _, cond := range conds.ToConditions(lcluster.Generation) {
+			meta.SetStatusCondition(&status.Conditions, cond)
+		}
+
 		status.DeepCopyInto(&lcluster.Status)
 
 		if status.RunningSatellites != nil && status.ScheduledSatellites != nil {
@@ -154,10 +162,6 @@ func (r *LinstorClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				resource.NewQuantity(*status.TotalCapacityBytes-*status.FreeCapacityBytes, resource.BinarySI).ScaledValue(resource.Giga),
 				resource.NewQuantity(*status.TotalCapacityBytes, resource.BinarySI).ScaledValue(resource.Giga),
 			)
-		}
-
-		for _, cond := range conds.ToConditions(lcluster.Generation) {
-			meta.SetStatusCondition(&lcluster.Status.Conditions, cond)
 		}
 
 		return nil

--- a/internal/controller/linstorsatellite_controller.go
+++ b/internal/controller/linstorsatellite_controller.go
@@ -140,11 +140,15 @@ func (r *LinstorSatelliteReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	_, condErr := controllerutil.CreateOrPatch(ctx, r.Client, lsatellite, func() error {
-		status.DeepCopyInto(&lsatellite.Status)
+		// Fill in existing conditions so meta.SetStatusCondition does not update the LastTransitionTime if the
+		// condition is already set.
+		status.Conditions = lsatellite.Status.Conditions
 
 		for _, cond := range conds.ToConditions(lsatellite.Generation) {
-			meta.SetStatusCondition(&lsatellite.Status.Conditions, cond)
+			meta.SetStatusCondition(&status.Conditions, cond)
 		}
+
+		status.DeepCopyInto(&lsatellite.Status)
 
 		if status.FreeCapacityBytes != nil && status.TotalCapacityBytes != nil {
 			// Report used/total capacity. Assume "used" is total - free. Always report in GiB.


### PR DESCRIPTION
When implementing the extended status, we accidentally changed the behaviour of status conditions: when call DeepCopyInto() on the status object, we reset the conditions to nil. This caused SetStatusCondition() to set the renew time of the condition to the current time, causing an update.

As this happened on every reconcile, we effectively created a reconcile loop, where every reconciliation caused another reconciliation to be queued.

To fix this, copy and update the existing conditions before merging it back to the status object. This ensures that SetStatusCondition() finds the old conditions and only updates the conditions on change.

Fixes: d564cc6deef9 ("Report additional status for LinstorSatellite")
Fixes: b9f84ff140d1 ("Report additional status for LinstorCluster")