### PR TITLE
ensure csi-node can mount with SELinux flags

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure `mount` commands pass along SELinux options by mounting SELinux directories.
+
 ## [v2.10.1] - 2025-11-12
 
 ### Added

--- a/pkg/resources/cluster/csi-node/csi-node-daemon-set.yaml
+++ b/pkg/resources/cluster/csi-node/csi-node-daemon-set.yaml
@@ -84,6 +84,12 @@ spec:
               mountPath: /run/mount
             - name: run-fsck
               mountPath: /run/fsck
+            - name: etc-selinux
+              mountPath: /etc/selinux
+              readOnly: true
+            - name: sys
+              mountPath: /sys
+              readOnly: true
         - name: csi-node-driver-registrar
           image: csi-node-driver-registrar
           args:
@@ -130,6 +136,14 @@ spec:
         - name: publish-dir
           hostPath:
             path: /var/lib/kubelet
+            type: Directory
+        - name: etc-selinux
+          hostPath:
+            path: /etc/selinux
+            type: DirectoryOrCreate
+        - name: sys
+          hostPath:
+            path: /sys
             type: Directory
         - name: registration-dir
           hostPath:


### PR DESCRIPTION
Our CSI driver can pass along SELinux options for filesystem volumes. Up to now, those options were always ignored because mount does a check for the availability of SELinux on the system.

This check does two things:
* Checks for the presence of /etc/selinux/config
* Checks for the presence of a RW-mounted selinuxfs, typically /sys/fs/selinux

To ensure the mount option is passed along as expected, we:

* Mount /etc/selinux from the host (or create it if it does not exist, which should be safe on all distributions)
* Mount /sys from the host. We cannot mount /sys/fs/selinux directly, as that only exists if SELinux is enabled (Ubuntu does not have that directory, for example), and we also cannot set it to be created as you cannot mkdir in sysfs.