### PR TITLE
patches: ensure containers remain in same order

### DIFF
--- a/pkg/resources/cluster/patches/csi-controller-disable-volume-group-snapshots.yaml
+++ b/pkg/resources/cluster/patches/csi-controller-disable-volume-group-snapshots.yaml
@@ -11,6 +11,11 @@
       template:
         spec:
           containers:
+          # Preserve order of containers: https://github.com/kubernetes-sigs/kustomize/issues/3912
+          - name: linstor-csi
+          - name: csi-attacher
+          - name: csi-livenessprobe
+          - name: csi-provisioner
           - name: csi-snapshotter
             env:
             - name: FEATURE_GATE_CSI_VOLUME_GROUP_SNAPSHOT


### PR DESCRIPTION
When using strategic merge patches, kustomize reorders items in a list if the preceeding items are skipped. This caused the csi-snapshotter container to be reordered to be the first container in the csi-controller deployment.

This is generally not an issue, but may cause a surprise when combined with "jsonpath" style patches, where the containers are expected in a fixed order and are addressed by index.

To fix this, update the patch to include the name of all intermediate containers. Since this patch gets applied before any user-controlled patches, we can be sure all the containers still exist and have not been patched out.