### PR TITLE
update csi-resizer RBAC

### DIFF
--- a/charts/piraeus/templates/rbac.yaml
+++ b/charts/piraeus/templates/rbac.yaml
@@ -283,6 +283,7 @@ rules:
     - storage.k8s.io
   resources:
     - storageclasses
+    - volumeattributesclasses
   verbs:
     - get
     - list

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -279,6 +279,7 @@ rules:
   - storage.k8s.io
   resources:
   - storageclasses
+  - volumeattributesclasses
   verbs:
   - get
   - list

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Update RBAC for `csi-resizer` sidecar.
+
 ## [v2.10.2] - 2025-11-26
 
 ### Added

--- a/internal/controller/linstorcluster_controller.go
+++ b/internal/controller/linstorcluster_controller.go
@@ -109,6 +109,7 @@ type LinstorClusterReconciler struct {
 //+kubebuilder:rbac:groups=storage.k8s.io,resources=volumeattachments,verbs=get;list;watch;patch
 //+kubebuilder:rbac:groups=storage.k8s.io,resources=volumeattachments/status,verbs=patch
 //+kubebuilder:rbac:groups=storage.k8s.io,resources=csistoragecapacities,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=storage.k8s.io,resources=volumeattributesclasses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshotclasses;volumesnapshots,verbs=get;list;watch
 //+kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshotcontents,verbs=get;list;watch;patch;update
 //+kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshotcontents/status,verbs=patch;update

--- a/pkg/resources/cluster/csi-controller/csi-controller-service-account.yaml
+++ b/pkg/resources/cluster/csi-controller/csi-controller-service-account.yaml
@@ -40,6 +40,9 @@ rules:
   - apiGroups: [ "" ]
     resources: [ "events" ]
     verbs: [ "list", "watch", "create", "update", "patch" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "volumeattributesclasses" ]
+    verbs: [ "get", "list", "watch" ]
 # csi-provisioner rules
   - apiGroups: [ "" ]
     resources: [ "persistentvolumes" ]


### PR DESCRIPTION
CSI Resizer release 2.0.0 enabled the VolumeAttributeClass feature by default. This causes some warning/errors to be printed because the corresponding access rules have not been updated.

This commit fixes that by updating the RBAC resources.

Closes #918.