### PR TITLE
Release 2.10.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PROJECT_NAME ?= piraeus-operator
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 2.10.2
+VERSION ?= 2.10.3
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/charts/piraeus/Chart.yaml
+++ b/charts/piraeus/Chart.yaml
@@ -3,8 +3,8 @@ name: piraeus
 description: |
   The Piraeus Operator manages software defined storage clusters using LINSTOR in Kubernetes.
 type: application
-version: 2.10.2
-appVersion: "v2.10.2"
+version: 2.10.3
+appVersion: "v2.10.3"
 maintainers:
   - name: Piraeus Datastore
     url: https://piraeus.io

--- a/charts/piraeus/templates/config.yaml
+++ b/charts/piraeus/templates/config.yaml
@@ -23,19 +23,19 @@ data:
         tag: v1.32.3
         image: piraeus-server
       linstor-csi:
-        tag: v1.10.3
+        tag: v1.10.4
         image: piraeus-csi
       nfs-server:
-        tag: v1.10.3
+        tag: v1.10.4
         image: piraeus-csi-nfs-server
       drbd-reactor:
         tag: v1.10.0
         image: drbd-reactor
       ha-controller:
-        tag: v1.3.1
+        tag: v1.3.2
         image: piraeus-ha-controller
       drbd-shutdown-guard:
-        tag: v1.1.1
+        tag: v1.1.2
         image: drbd-shutdown-guard
       ktls-utils:
         tag: v1.2.1

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,7 +12,7 @@ labels:
 images:
 - name: controller
   newName: quay.io/piraeusdatastore/piraeus-operator
-  newTag: v2.10.3
+  newTag: v2
 
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,7 +12,7 @@ labels:
 images:
 - name: controller
   newName: quay.io/piraeusdatastore/piraeus-operator
-  newTag: v2
+  newTag: v2.10.3
 
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus

--- a/config/manager/0_piraeus_datastore_images.yaml
+++ b/config/manager/0_piraeus_datastore_images.yaml
@@ -14,19 +14,19 @@ components:
     tag: v1.32.3
     image: piraeus-server
   linstor-csi:
-    tag: v1.10.3
+    tag: v1.10.4
     image: piraeus-csi
   nfs-server:
-    tag: v1.10.3
+    tag: v1.10.4
     image: piraeus-csi-nfs-server
   drbd-reactor:
     tag: v1.10.0
     image: drbd-reactor
   ha-controller:
-    tag: v1.3.1
+    tag: v1.3.2
     image: piraeus-ha-controller
   drbd-shutdown-guard:
-    tag: v1.1.1
+    tag: v1.1.2
     image: drbd-shutdown-guard
   ktls-utils:
     tag: v1.2.1

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update RBAC for `csi-resizer` sidecar.
 
+### Changed
+- Updated images:
+    * LINSTOR CSI 1.10.4
+    * HA Controller 1.3.2
+    * DRBD Shutdown Guard 1.1.2
+
 ## [v2.10.2] - 2025-11-26
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [v2.10.3] - 2025-12-05
 
 ### Fixed
@@ -1131,3 +1133,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v2.10.1]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.10.0...v2.10.1
 [v2.10.2]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.10.1...v2.10.2
 [v2.10.3]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.10.2...v2.10.3
+[Unreleased]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.10.3...HEAD

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v2.10.3] - 2025-12-05
 
 ### Fixed
 
@@ -1130,4 +1130,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v2.10.0]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.9.1...v2.10.0
 [v2.10.1]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.10.0...v2.10.1
 [v2.10.2]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.10.1...v2.10.2
-[Unreleased]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.10.2...HEAD
+[v2.10.3]: https://github.com/piraeusdatastore/piraeus-operator/compare/v2.10.2...v2.10.3


### PR DESCRIPTION
In this patch release:

* CSI Resizer RBAC fixes
* Update LINSTOR CSI to fix further issues with new snapshot names
* Update HA Controller to ignore volumes that have no DRBD quorum configuration
* Update DRBD Shutdown Guard to include latest drbd-utils fixes to JSON output