### PR TITLE
resolve name collision on CSI node container ports

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Name collision for CSI Node container ports
+
 ## [v2.10.3] - 2025-12-05
 
 ### Fixed

--- a/pkg/resources/cluster/csi-node/csi-node-daemon-set.yaml
+++ b/pkg/resources/cluster/csi-node/csi-node-daemon-set.yaml
@@ -104,11 +104,11 @@ spec:
                 - ALL
           ports:
             - containerPort: 9809
-              name: healthz
+              name: reg-healthz
           livenessProbe:
             httpGet:
               path: /healthz
-              port: healthz
+              port: reg-healthz
             initialDelaySeconds: 5
             timeoutSeconds: 5
           volumeMounts:


### PR DESCRIPTION
There were two ports with the name "healthz". Resolve this by renaming one to "reg-healthz" for the node-driver-registrar.