### PR TITLE
evacuation: do not wait on deleting satellites

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Name collision for CSI Node container ports
+- Do not block evacuation on other satellites being evacuated.
 
 ## [v2.10.3] - 2025-12-05
 

--- a/pkg/evacuation/evacuation.go
+++ b/pkg/evacuation/evacuation.go
@@ -287,6 +287,11 @@ func waitForConfiguredSatellites(ctx context.Context, cl client.Client, nodeName
 			continue
 		}
 
+		// Ignore all satellites with a deletion timestamp set, they are probably being removed just like this one.
+		if satellite.DeletionTimestamp != nil {
+			continue
+		}
+
 		cond := meta.FindStatusCondition(satellite.Status.Conditions, string(conditions.Configured))
 		if cond == nil {
 			unreadySatellites = append(unreadySatellites, satellite.Name)

--- a/pkg/evacuation/evacuation_test.go
+++ b/pkg/evacuation/evacuation_test.go
@@ -53,6 +53,11 @@ var (
 			},
 		},
 	}
+	TestNodeC = &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-C",
+		},
+	}
 	MachineA = &clusterapiv1beta1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "machine-a",
@@ -238,11 +243,20 @@ func TestEvacuateSatelliteWithEvacuationActionPVs(t *testing.T) {
 
 func TestEvacuateSatelliteWaitForOtherSatellites(t *testing.T) {
 	t.Parallel()
+
+	satelliteC := createSatellite(TestNodeC, false)
+	satelliteC.Finalizers = []string{"piraeus.io/test"}
+
 	cl, lc := setupTestCluster(t,
-		TestNodeA, TestNodeB, MachineA, MachineB,
+		TestNodeA, TestNodeB, TestNodeC, MachineA, MachineB,
 		createSatellite(TestNodeA, true),
 		createSatellite(TestNodeB, false),
+		satelliteC,
 	)
+
+	// Delete satellite C. It is unavailable but deleting, so it should not block evacuation
+	err := cl.Delete(t.Context(), satelliteC)
+	assert.NoError(t, err)
 
 	// Satellite still has a local-only PV
 	msg, cont, err := runEvacuateSatellite(t, cl, lc)
@@ -251,6 +265,7 @@ func TestEvacuateSatelliteWaitForOtherSatellites(t *testing.T) {
 	assert.Contains(t, msg, "Waiting for LinstorSatellites to become ready")
 	assert.Contains(t, msg, "node-b")
 	assert.NotContains(t, msg, "node-a")
+	assert.NotContains(t, msg, "node-c")
 
 	// No evacuation, no drain, no termination
 	assert.NotContains(t, getSatellite(t, lc, "node-a").Flags, linstor.FlagEvacuate)


### PR DESCRIPTION
We wait for other satellites to be ready when starting the evacuation. However, we do not need to wait for satellites that are also being deleted currently, as those may never get into a "ready" state again.