### PR TITLE
add guide and chart config for external Cluster API

### DIFF
--- a/charts/piraeus/templates/deployment.yaml
+++ b/charts/piraeus/templates/deployment.yaml
@@ -70,6 +70,9 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
+        {{- with .Values.operator.extraVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- if .Values.kubeRbacProxy.enabled }}
       - args:
         - --secure-listen-address=0.0.0.0:8443
@@ -91,8 +94,11 @@ spec:
         securityContext:
           {{- toYaml .Values.kubeRbacProxy.securityContext | nindent 12}}
         volumeMounts:
-          - mountPath: /etc/tls
-            name: cert
+        - mountPath: /etc/tls
+          name: cert
+        {{- with .Values.kubeRbacProxy.extraVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       securityContext:
         runAsNonRoot: true
@@ -113,3 +119,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: {{ include "piraeus-operator.certifcateName" . }}
+      {{- with .Values.extraVolumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}

--- a/charts/piraeus/templates/extra-objects.yaml
+++ b/charts/piraeus/templates/extra-objects.yaml
@@ -1,0 +1,15 @@
+{{- /* Normalize extraObjects to a list, easier to loop over */ -}}
+{{- $extraObjects := .Values.extraManifests | default (list) -}}
+
+{{- if kindIs "map" $extraObjects -}}
+  {{- $extraObjects = values $extraObjects -}}
+{{- end -}}
+
+{{- range $extraObjects }}
+---
+  {{- if kindIs "map" . }}
+    {{- tpl (toYaml .) $ | nindent 0 }}
+  {{- else if kindIs "string" . }}
+    {{- tpl . $ | nindent 0 }}
+  {{- end }}
+{{- end }}

--- a/charts/piraeus/values.yaml
+++ b/charts/piraeus/values.yaml
@@ -29,6 +29,12 @@ operator:
     #   cpu: 100m
     #   memory: 128Mi
 
+  ## Additional volume mounts
+  extraVolumeMounts: [ ]
+  # - name: clusterapi-kubeconfig
+  #   mountPath: /etc/operator
+  #   readOnly: true
+
 kubeRbacProxy:
   enabled: false
   image:
@@ -53,6 +59,16 @@ kubeRbacProxy:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
+
+  ## Additional volume mounts
+  extraVolumeMounts: [ ]
+
+
+## Additional volumes
+extraVolumes: []
+# - name: clusterapi-kubeconfig
+#   secret:
+#     secretName: super-secret
 
 webhook:
   timeoutSeconds: 2
@@ -111,3 +127,30 @@ imageConfigOverride: []
   #       tag: my-custom-tag
   #   Results in the image example.com/piraeus/linstor-csi:my-custom-tag being used.
   #   See templates/config.yaml for available components.
+
+## Extra manifests to deploy. Can be of type dict or list.
+## If dict, keys are ignored and only values are used.
+## Items contained within extraObjects can be defined as dict or string and are passed through tpl.
+extraManifests: null
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #   labels:
+  #     name: piraeus-extra
+  #   data:
+  #     extra-data: "value"
+  #
+  # can also be defined as a string, useful for templating field names
+  # - |
+  #   apiVersion: v1
+  #   kind: Secret
+  #   type: Opaque
+  #   metadata:
+  #     name: super-secret
+  #     labels:
+  #       {{- range $key, $value := .Values.commonLabels }}
+  #       {{ $key }}: {{ $value }}
+  #       {{- end }}
+  #   data:
+  #     plaintext: Zm9vYmFy
+#     templated: '{{ print "foobar" | upper | b64enc }}'

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -21,6 +21,10 @@ These guides show you how to configure a specific aspect or achieve a specific t
 
     [:octicons-arrow-right-24: Guide](./install-kernel-headers.md)
 
+*   Integrate with a Cluster API Management Cluster
+
+    [:octicons-arrow-right-24: Guide](./external-cluster-api.md)
+
 </div>
 
 ## Securing Components

--- a/docs/how-to/external-cluster-api.md
+++ b/docs/how-to/external-cluster-api.md
@@ -1,0 +1,139 @@
+# Integrate with a Cluster API Management Cluster
+
+This guide shows you how to integrate Piraeus in a cluster managed by Cluster API, where the Cluster API is running
+in a different cluster from Piraeus.
+
+To complete this guide, you should be familiar with:
+
+* Cluster API concepts such as [Management Clusters](https://cluster-api.sigs.k8s.io/user/concepts#management-cluster).
+* editing the Piraeus Operator Deployment, using either `kustomize` or `helm`.
+* managing Service Accounts and RBAC resources.
+
+## Preconditions
+
+This guide assumes that the Management Cluster and the Workload Cluster are distinct clusters. If they are the same
+cluster, no additional configuration is necessary to integrate with Cluster API and you can skip this guide.
+
+## Create a ServiceAccount on the Management Cluster
+
+Piraeus Operator needs to be able to update annotations on the Machine resource to
+[hook into the Machine deletion process](../explanation/deletion-policies.md#satellite-evacuation-when-using-clusterapi).
+
+Create a Service Account and matching RBAC resources in the Management Cluster using the following kubectl commands.
+The commands assume that the Cluster API resources are deployed in the `workload-cluster-ns` namespace, and
+`management.kubeconfig` is the name of the kubeconfig file used to access the Management Cluster.
+
+```
+$ export KUBECONFIG=management.kubeconfig
+$ export KUBENS=workload-cluster-ns
+$ kubectl --namespace=$KUBENS create serviceaccount piraeus-operator
+serviceaccount/piraeus-operator created
+$ kubectl --namespace=$KUBENS role piraeus-operator --verb=get,update --resource=machines.cluster.x-k8s.io
+role.rbac.authorization.k8s.io/piraeus-operator created
+$ kubectl --namespace=$KUBENS create rolebinding piraeus-operator --role=piraeus-operator --serviceaccount=$KUBENS:piraeus-operator
+rolebinding.rbac.authorization.k8s.io/piraeus-operator created
+```
+
+## Create a Kubeconfig File for the Service Account
+
+The following commands create a `piraeus-clusterapi.kubeconfig` file.
+
+```
+$ export KUBECONFIG=management.kubeconfig
+$ export KUBENS=workload-cluster-ns
+$ TOKEN="$(kubectl --namespace=$KUBENS create token piraeus-operator)"
+$ kubectl config view --flatten --minify -ojson | jq --arg TOKEN "$TOKEN" '.users[0].user = {"token": $TOKEN}' > piraeus-clusterapi.kubeconfig
+```
+
+This file contains the access credentials that Piraeus Operator can use to get and set the necessary annotations
+on the Machine resources in the Management Cluster.
+
+## Configure the Piraeus Operator to Use the Kubeconfig File
+
+Now, update the Piraeus Operator Deployment to use the `piraeus-clusterapi.kubeconfig` created in the previous step.
+
+=== "Kustomize"
+
+    Update `kustomization.yaml` to create a secret containing the `piraeus-clusterapi.kubeconfig` and apply a patch to
+    let the Piraeus Operator use the updated configuration. Apply using `kubectl apply -k .`.
+
+    ```yaml
+    resources:
+    - https://github.com/piraeusdatastore/piraeus-operator/releases/latest/download/manifest.yaml
+    secretGenerator:
+    - name: piraeus-clusterapi-kubeconfig
+      namespace: piraeus-datastore
+      files:
+      - kubeconfig=piraeus-clusterapi.kubeconfig
+      options:
+        disableSuffixHash: true
+    patches:
+    - patch: |
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: piraeus-operator-controller-manager
+          namespace: piraeus-datastore
+        spec:
+          template:
+            spec:
+              containers:
+              - name: manager
+                env:
+                - name: CLUSTER_API_KUBECONFIG
+                  value: /etc/clusterapi/kubeconfig
+                volumeMounts:
+                - name: piraeus-clusterapi-kubeconfig
+                  mountPath: /etc/clusterapi
+                  readOnly: true
+              volumes:
+              - name: piraeus-clusterapi-kubeconfig
+                secret:
+                  secretName: piraeus-clusterapi-kubeconfig
+    ```
+
+=== "Helm"
+
+    Create or update `values.yaml`, replacing the content of the secret in `extraManifests` with the content of
+    `piraeus-clusterapi.kubeconfig`. Update the Piraeus Operator deployment using
+    `helm upgrade --namespace piraeus-datastore piraeus-operator ... --values values.yaml`.
+
+    ```yaml
+    operator:
+      options:
+        clusterApiKubeconfig: /etc/clusterapi/kubeconfig
+      extraVolumeMounts:
+      - name: piraeus-clusterapi-kubeconfig
+        mountPath: /etc/clusterapi
+        readOnly: true
+
+    extraVolumes:
+    - name: piraeus-clusterapi-kubeconfig
+      secret:
+        secretName: piraeus-clusterapi-kubeconfig
+
+    extraManifests:
+    - apiVersion: v1
+      kind: Secret
+      metadata:
+        name: piraeus-clusterapi-kubeconfig
+      stringData:
+       kubeconfig: |
+         REPLACE THIS
+    ```
+
+## Confirm a Working Cluster API Integration
+
+To confirm that the integration works, check for the presence of the following annotations on the Machine resources:
+
+```
+$ export KUBECONFIG=management.kubeconfig
+$ export KUBENS=workload-cluster-ns
+$ kubectl get machines --namespace=$KUBENS -ocustom-columns='NAME:metadata.name,HOOK:metadata.annotations.pre-drain\.delete\.hook\.machine\.cluster\.x-k8s\.io/linstor-prepare-for-drain'
+NAME                           HOOK
+machine-without-integration    <none>
+machine-with-integration
+```
+
+If the `HOOK` field shows `<none>`, the integration is not active. If the output is empty, the integration is
+enabled.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
       - Use Piraeus Datastore with an Existing LINSTOR Cluster: how-to/external-controller.md
       - Configure the DRBD Module Loader: how-to/drbd-loader.md
       - Install Kernel Headers to build DRBD: how-to/install-kernel-headers.md
+      - Integrate with a Cluster API Management Cluster: how-to/external-cluster-api.md
     - Securing Components:
       - Configure TLS Between LINSTOR Controller and LINSTOR Satellite: how-to/internal-tls.md
       - Configure TLS for the LINSTOR API: how-to/api-tls.md
@@ -135,6 +136,8 @@ markdown_extensions:
     options:
       custom_icons:
       - overrides/.icons
+- pymdownx.tabbed:
+    alternate_style: true
 
 plugins:
 - search:


### PR DESCRIPTION
Cluster API has the concept of Management and Workload Cluster. Piraeus is usually deployed in a Workload Cluster to provide storage. Piraeus can also integrate with Cluster API, provided it has access to the "Machine" resources, which are deployed in the Management Cluster.

The Operator automatically configures the integration in case the Workload Cluster is also the Management Cluster. For the common case, we already added an option to specify a custom "kubeconfig" file used by the operator when getting and updating the "Machine" resources, but it was not documented how one would use this.

This commit adds the necessary configuration, along with updates to the Helm chart to simplify the deployment process.