### PR TITLE
nfs-server: disable metrics in default template

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Updated NFS server template to work with NFS Ganesha instances with monitoring enabled.
+
 ## [v2.10.4] - 2026-01-13
 
 ### Fixed

--- a/pkg/resources/cluster/nfs-server/default-config.tmpl
+++ b/pkg/resources/cluster/nfs-server/default-config.tmpl
@@ -7,6 +7,7 @@ NFS_Core_Param
 	Enable_RQUOTA = false;
 	fsid_device = true;
 	Enable_UDP = false;
+	Enable_Metrics = false;
 	NFS_Port = {{.Port}};
 }
 


### PR DESCRIPTION
Some newer versions of ganesha automatically start exporting metrics on port
9587. This causes problems when trying to run multiple NFS servers in the same Pod. Notably, NFS Ganesha silently fails to come up, making DRBD Reactor think the process started correctly, but actually not exporting the volume.

To fix this, disable metrics in the default template, cause NFS ganesha no to bind an additional port.