### PR TITLE
Add namespace values

### DIFF
--- a/charts/piraeus/templates/config.yaml
+++ b/charts/piraeus/templates/config.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "piraeus-operator.fullname" . }}-image-config
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "piraeus-operator.labels" . | nindent 4 }}
 data:

--- a/charts/piraeus/templates/deployment.yaml
+++ b/charts/piraeus/templates/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "piraeus-operator.fullname" . }}-controller-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "piraeus-operator.labels" . | nindent 4 }}
 spec:

--- a/charts/piraeus/templates/metrics-service.yaml
+++ b/charts/piraeus/templates/metrics-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "piraeus-operator.fullname" . }}-controller-manager-metrics-service
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "piraeus-operator.labels" . | nindent 4 }}
 spec:

--- a/charts/piraeus/templates/rbac.yaml
+++ b/charts/piraeus/templates/rbac.yaml
@@ -309,6 +309,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "piraeus-operator.fullname" . }}-leader-election
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "piraeus-operator.labels" . | nindent 4 }}
 rules:

--- a/charts/piraeus/templates/serviceaccount.yaml
+++ b/charts/piraeus/templates/serviceaccount.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "piraeus-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "piraeus-operator.labels" . | nindent 4 }}
 {{ end }}

--- a/charts/piraeus/templates/validating-webhook-configuration.yaml
+++ b/charts/piraeus/templates/validating-webhook-configuration.yaml
@@ -9,6 +9,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "piraeus-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "piraeus-operator.labels" . | nindent 4 }}
 spec:
@@ -36,6 +37,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "piraeus-operator.certifcateName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "piraeus-operator.labels" . | nindent 4 }}
 type: kubernetes.io/tls

--- a/charts/piraeus/templates/webhook-service.yaml
+++ b/charts/piraeus/templates/webhook-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "piraeus-operator.fullname" . }}-webhook-service
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "piraeus-operator.labels" . | nindent 4 }}
 spec:

--- a/tools/copy-image-config-to-chart.sh
+++ b/tools/copy-image-config-to-chart.sh
@@ -7,6 +7,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "piraeus-operator.fullname" . }}-image-config
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "piraeus-operator.labels" . | nindent 4 }}
 data:

--- a/tools/copy-rbac-config-to-chart.sh
+++ b/tools/copy-rbac-config-to-chart.sh
@@ -26,6 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "piraeus-operator.fullname" . }}-leader-election
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "piraeus-operator.labels" . | nindent 4 }}
 rules:


### PR DESCRIPTION
This pull request adds missing `namespace: {{ .Release.Namespace }}`. Important for Helm template in Terraform/ArgoCD. Else they get deployed in the `default` namespace.

See: https://github.com/helm/helm/issues/3553#issuecomment-2235841549