### PR TITLE
Let satellites daemonset ignore NoSchedule taints

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Updated NFS server template to work with NFS Ganesha instances with monitoring enabled.
+- Ensure Satellites are always rescheduled on NoScheduled nodes as long as the LinstorSatellite resource exists.
 
 ## [v2.10.4] - 2026-01-13
 

--- a/internal/controller/linstorcluster_controller.go
+++ b/internal/controller/linstorcluster_controller.go
@@ -973,7 +973,7 @@ func (r *LinstorClusterReconciler) kustomizeLinstorSatellite(ctx context.Context
 		})
 	}
 
-	t := tolerations.MergeTolerations(tolerations.HAControllerTolerations, lcluster.Spec.Tolerations)
+	t := tolerations.MergeTolerations(tolerations.HAControllerTolerations, tolerations.NoScheduleToleration, lcluster.Spec.Tolerations)
 	tolerationsPatches, err := TolerationsPatch("DaemonSet", "linstor-satellite", t)
 	if err != nil {
 		return nil, nil, err

--- a/internal/controller/linstorcluster_test.go
+++ b/internal/controller/linstorcluster_test.go
@@ -460,16 +460,38 @@ var _ = Describe("LinstorCluster controller", func() {
 					))),
 				))
 
-				// The Satellites, CSI nodes, and HA Controller should have a patch updating their tolerations
+				// The CSI nodes, and HA Controller should have a patch updating their tolerations.
 				Eventually(func() []appsv1.DaemonSet {
 					var daemonSets appsv1.DaemonSetList
 					err := k8sClient.List(ctx, &daemonSets)
 					Expect(err).NotTo(HaveOccurred())
-					return daemonSets.Items
+					return slices.DeleteFunc(daemonSets.Items, func(ds appsv1.DaemonSet) bool {
+						return ds.GetLabels()["app.kubernetes.io/component"] == "linstor-satellite"
+					})
 				}).Should(And(
-					HaveLen(5), // 2 Satellites DS, 1 CSI Node, 1 HA Controller, 1 NFS Server.
+					HaveLen(3), // 1 CSI Node, 1 HA Controller, 1 NFS Server.
 					HaveEach(HaveField("Spec.Template.Spec.Tolerations", ConsistOf(
 						append(slices.Clone(tolerations.HAControllerTolerations),
+							corev1.Toleration{
+								Key:      "example.com/manual-taint",
+								Operator: corev1.TolerationOpExists,
+								Effect:   corev1.TaintEffectNoExecute,
+							})),
+					)),
+				))
+
+				// The Satellites should also have been patched updating the tolerations.
+				Eventually(func() []appsv1.DaemonSet {
+					var daemonSets appsv1.DaemonSetList
+					err := k8sClient.List(ctx, &daemonSets)
+					Expect(err).NotTo(HaveOccurred())
+					return slices.DeleteFunc(daemonSets.Items, func(ds appsv1.DaemonSet) bool {
+						return ds.GetLabels()["app.kubernetes.io/component"] != "linstor-satellite"
+					})
+				}).Should(And(
+					HaveLen(2), // 2 Satellites.
+					HaveEach(HaveField("Spec.Template.Spec.Tolerations", ConsistOf(
+						append(append(slices.Clone(tolerations.HAControllerTolerations), slices.Clone(tolerations.NoScheduleToleration)...),
 							corev1.Toleration{
 								Key:      "example.com/manual-taint",
 								Operator: corev1.TolerationOpExists,

--- a/pkg/utils/tolerations/tolerations.go
+++ b/pkg/utils/tolerations/tolerations.go
@@ -80,6 +80,14 @@ var (
 			TolerationSeconds: &FailOverTimeOut,
 		},
 	}
+
+	// NoScheduleToleration tolerates all NoSchedule taints.
+	NoScheduleToleration = []corev1.Toleration{
+		{
+			Effect:   corev1.TaintEffectNoSchedule,
+			Operator: corev1.TolerationOpExists,
+		},
+	}
 )
 
 // MergeTolerations combines all the given tolerations.


### PR DESCRIPTION
If a user added a NoSchedule taint to a Node (for example for planned removal of a LINSTOR Satellite), and then accidentally deleted the Satellite Pod before the Operator completed the Satellites' removal, we got stuck in a situation where:

* There is a LinstorSatellite resource
* There is no Satellite Pod
* The operator tries to reconcile, but fails because the Pod cannot get rescheduled.

This is caused by LinstorSatellite resource effectively working like they directly control the specific Pod, but that Pod is managed by the indirection of the DaemonSet.

To resolve this, always let the Satellite DaemonSet tolerate all NoSchedule taints. This way, the Pod gets restarted until the LinstorSatellite is actually gone.