### PR TITLE
ci: fix image signing step when commit message contains apostrophe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,9 @@ jobs:
         # Take the digest we just pushed to the registry and sign the image using "keyless" signing:
         #   https://docs.sigstore.dev/cosign/signing/overview/
         # With this, users can verify that the image was actually created by this github workflow.
+        env:
+          BUILD_METADATA: ${{ steps.build.outputs.metadata }}
         run: |
-          jq '."containerimage.digest" as $DIGEST | ."image.name" | split(":")[0] | "\(.)@\($DIGEST)"' -r <<<'${{ steps.build.outputs.metadata }}' \
+          printf '%s' "$BUILD_METADATA" \
+            | jq '."containerimage.digest" as $DIGEST | ."image.name" | split(":")[0] | "\(.)@\($DIGEST)"' -r \
             | xargs --no-run-if-empty cosign sign --yes


### PR DESCRIPTION
A commit message containing an isolated `'` character, that is a single quote or apostrophe, caused the "Sign images" step to fail. The error message was extremely cryptic:

```
Run jq '."containerimage.digest" as $DIGEST | ."image.name" | split(":")[0] | "\(.)@\($DIGEST)"' -r <<<'{
...
/home/runner/work/_temp/4a1f55e3-cea3-4bb3-b356-51419ed4b652.sh: line 124: syntax error near unexpected token `('
```

The underlying issue was that the `'` finished the string. The shell parser then failed when it came to the next `(`.

Note that substrings like `'5'` did not cause problems because the shell concatenates the strings.

Fix this by evaluating the expression into an environment variable first, as shown at
https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable