### PR TITLE
nfs-server: fix dropped capabilites

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed NFS Server DaemonSet capabilities.
+
 ## [v2.10.5] - 2026-03-10
 
 ### Added

--- a/pkg/resources/cluster/nfs-server/nfs-server-daemon-set.yaml
+++ b/pkg/resources/cluster/nfs-server/nfs-server-daemon-set.yaml
@@ -41,7 +41,7 @@ spec:
           privileged: true
           capabilities:
             drop:
-            - "*"
+            - ALL
         env:
         # Set according to https://systemd.io/CONTAINER_INTERFACE/
         - name: container


### PR DESCRIPTION
`*` is not an alias for `ALL`.