### PR TITLE
build: upgrade to Go 1.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/piraeusdatastore/piraeus-operator/v2
 
-go 1.25.5
+go 1.26.1
 
 require (
 	github.com/LINBIT/golinstor v0.60.0


### PR DESCRIPTION
The `envtest` Makefile target and GitHub workflow use `setup-envtest@latest`. This requires Go 1.26 since 598e330bda55 ("Bump to k8s.io/* v0.36.0-beta.0").