### PR TITLE
operator: route Ubuntu 26.04 to drbd9-resolute loader

### DIFF
--- a/charts/piraeus/templates/config.yaml
+++ b/charts/piraeus/templates/config.yaml
@@ -85,6 +85,8 @@ data:
             image: drbd9-jammy
           - osImage: Ubuntu 24\.04
             image: drbd9-noble
+          - osImage: Ubuntu 26\.04
+            image: drbd9-resolute
           - osImage: Debian GNU/Linux 13
             image: drbd9-trixie
           - osImage: Debian GNU/Linux 12

--- a/config/manager/0_piraeus_datastore_images.yaml
+++ b/config/manager/0_piraeus_datastore_images.yaml
@@ -75,6 +75,8 @@ components:
         image: drbd9-jammy
       - osImage: Ubuntu 24\.04
         image: drbd9-noble
+      - osImage: Ubuntu 26\.04
+        image: drbd9-resolute
       - osImage: Debian GNU/Linux 13
         image: drbd9-trixie
       - osImage: Debian GNU/Linux 12

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Image configuration for Ubuntu 26.04 (Resolute Raccoon)
+
 ### Fixed
 
 - Fixed NFS Server DaemonSet capabilities.

--- a/docs/how-to/drbd-loader.md
+++ b/docs/how-to/drbd-loader.md
@@ -68,6 +68,7 @@ Piraeus maintains the following images:
 | `quay.io/piraeusdatastore/drbd9-almalinux10` | RedHat Enterprise Linux 10 rebuilds |
 | `quay.io/piraeusdatastore/drbd9-almalinux9`  | RedHat Enterprise Linux 9 rebuilds  |
 | `quay.io/piraeusdatastore/drbd9-almalinux8`  | RedHat Enterprise Linux 8 rebuilds  |
+| `quay.io/piraeusdatastore/drbd9-resolute`    | Ubuntu 26.04                        |
 | `quay.io/piraeusdatastore/drbd9-noble`       | Ubuntu 24.04                        |
 | `quay.io/piraeusdatastore/drbd9-jammy`       | Ubuntu 22.04                        |
 | `quay.io/piraeusdatastore/drbd9-bookworm`    | Debian 12                           |


### PR DESCRIPTION
Add a node-OS match rule so satellites scheduled on Ubuntu 26.04 LTS ("Resolute Raccoon", released 2026-04-23) pull `drbd9-resolute` instead of falling through to the `drbd9-noble` fallback.

## Why

The fallback `drbd9-noble` is based on `ubuntu:noble` (gcc-13). Ubuntu 26.04 kernel 7.0 was built with gcc-15 and its headers reference `-fmin-function-alignment=16`, which gcc-13 does not recognise, so the on-node DRBD compile fails:

```text
gcc: error: unrecognized command-line option '-fmin-function-alignment=16';
     did you mean '-flimit-function-alignment'?
```

The `drbd9-resolute` image (added in piraeusdatastore/piraeus#253) uses `ubuntu:resolute` as its base and pulls gcc-15 via the dkms recommendation logic — matching the toolchain that built the 26.04 kernel.

## Notes

- **Depends on piraeusdatastore/piraeus#253.** `drbd-module-loader.tag` is already at `v9.3.1` in master (no bump needed here), so this PR can merge as soon as #253's release pipeline has pushed `quay.io/piraeusdatastore/drbd9-resolute:v9.3.1`. Merging earlier would make satellites on 26.04 nodes crash-loop pulling a non-existent tag.
- `charts/piraeus/templates/config.yaml` is regenerated from `config/manager/0_piraeus_datastore_images.yaml` via `tools/copy-image-config-to-chart.sh` (per the existing automation comment).
- `docs/CHANGELOG.md` and `docs/how-to/drbd-loader.md` updated to match the precedent set by v2.10.5 (`drbd9-trixie` addition).