### PR TITLE
fix: handle dirty Kubernetes minor versions

### DIFF
--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -34,12 +35,12 @@ func (ac *APIDiscoveryClient) ServerVersion() *APIVersion {
 		return ac.fallbackVersion
 	}
 
-	major, err := strconv.Atoi(version.Major)
+	major, err := parseKubernetesVersionPart(version.Major)
 	if err != nil {
 		return ac.fallbackVersion
 	}
 
-	minor, err := strconv.Atoi(version.Minor)
+	minor, err := parseKubernetesVersionPart(version.Minor)
 	if err != nil {
 		return ac.fallbackVersion
 	}
@@ -67,6 +68,10 @@ func (ac *APIDiscoveryClient) HasGroupVersionResource(gvr schema.GroupVersionRes
 	}
 
 	return false
+}
+
+func parseKubernetesVersionPart(version string) (int, error) {
+	return strconv.Atoi(strings.TrimSuffix(version, "+"))
 }
 
 type APIVersion struct {

--- a/pkg/utils/version_internal_test.go
+++ b/pkg/utils/version_internal_test.go
@@ -1,0 +1,74 @@
+package utils
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/rest"
+)
+
+func TestParseKubernetesVersionPart(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name     string
+		version  string
+		expected int
+		wantErr  bool
+	}{
+		{
+			name:     "plain-number",
+			version:  "34",
+			expected: 34,
+		},
+		{
+			name:     "dirty-git-version",
+			version:  "34+",
+			expected: 34,
+		},
+		{
+			name:    "empty",
+			version: "",
+			wantErr: true,
+		},
+	}
+
+	for i := range testcases {
+		tcase := &testcases[i]
+		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := parseKubernetesVersionPart(tcase.version)
+			if tcase.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tcase.expected, actual)
+		})
+	}
+}
+
+func TestAPIDiscoveryClientServerVersionHandlesDirtyMinorVersion(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/version", r.URL.Path)
+		err := json.NewEncoder(w).Encode(apimachineryversion.Info{
+			Major: "1",
+			Minor: "34+",
+		})
+		assert.NoError(t, err)
+	}))
+	t.Cleanup(srv.Close)
+
+	fallback := &APIVersion{Major: 1, Minor: 20}
+	client := NewAPIDiscoveryClient(&rest.Config{Host: srv.URL}, fallback)
+
+	assert.Equal(t, &APIVersion{Major: 1, Minor: 34}, client.ServerVersion())
+}


### PR DESCRIPTION
Tiny fix for Kubernetes version discovery.

Kubernetes minor versions can be numeric with a trailing `+`; client-go documents this as `numeric possibly followed by "+"`. Right now `ServerVersion()` uses `strconv.Atoi` directly, so `34+` falls back to `v1.20`. That can make version-gated behavior pick the wrong path, oof.

Repro:
- serve `/version` with `major: "1"`, `minor: "34+"`
- call `APIDiscoveryClient.ServerVersion()`
- before: returns the fallback `v1.20`
- after: returns `v1.34`

Checks:
- `go test ./pkg/utils`
- `make test`

I searched related issues/PRs for Kubernetes version fallback / minor parsing and did not find a direct match.