### PR TITLE
fix: accept external controller failover URLs

### DIFF
--- a/internal/webhook/v1/linstorcluster_webhook.go
+++ b/internal/webhook/v1/linstorcluster_webhook.go
@@ -18,9 +18,10 @@ package v1
 
 import (
 	"context"
-	"net/url"
 	"strconv"
+	"strings"
 
+	lapi "github.com/LINBIT/golinstor/client"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -92,7 +93,7 @@ func ValidateExternalController(ref *piraeusiov1.LinstorExternalControllerRef, p
 	var result field.ErrorList
 
 	if ref != nil {
-		_, err := url.Parse(ref.URL)
+		_, err := lapi.NewClient(lapi.Controllers(strings.Split(ref.URL, ",")))
 		if err != nil {
 			result = append(result, field.Invalid(path.Child("url"), ref.URL, err.Error()))
 		}

--- a/internal/webhook/v1/linstorcluster_webhook_test.go
+++ b/internal/webhook/v1/linstorcluster_webhook_test.go
@@ -118,4 +118,18 @@ var _ = Describe("LinstorCluster webhook", func() {
 		err := k8sClient.Patch(ctx, clusterConfig, client.Apply, client.FieldOwner("test"), client.ForceOwnership)
 		Expect(err).To(HaveOccurred())
 	})
+
+	It("should allow valid external controller URL failover lists", func(ctx context.Context) {
+		clusterConfig := &piraeusv1.LinstorCluster{
+			TypeMeta:   typeMeta,
+			ObjectMeta: metav1.ObjectMeta{Name: "external-failover"},
+			Spec: piraeusv1.LinstorClusterSpec{
+				ExternalController: &piraeusv1.LinstorExternalControllerRef{
+					URL: "http://linstor-controller.example.com:3370,linstor://backup-controller.example.com:3370",
+				},
+			},
+		}
+		err := k8sClient.Patch(ctx, clusterConfig, client.Apply, client.FieldOwner("test"), client.ForceOwnership)
+		Expect(err).NotTo(HaveOccurred())
+	})
 })


### PR DESCRIPTION
Tiny fix for a real external-controller gotcha.

The webhook parsed `spec.externalController.url` as one URL. But the operator later splits it on `,` and passes the entries to the LINSTOR client. So this valid failover list got rejected at admission, kinda awkward:

```yaml
spec:
  externalController:
    url: http://linstor-controller.example.com:3370,linstor://backup-controller.example.com:3370
```

Repro before this patch:
`kubectl apply -f` that LinstorCluster, webhook rejects it with `invalid port ":3370,linstor:" after host`.

Fix: validate with the same LINSTOR client parser used at runtime.

Tests:
`KUBEBUILDER_ASSETS="$(pwd)/bin/k8s/1.36.0-linux-amd64" go test ./...`

Related to #393.