### PR TITLE
fix: render Helm image pull secrets

### DIFF
--- a/charts/piraeus/templates/deployment.yaml
+++ b/charts/piraeus/templates/deployment.yaml
@@ -107,6 +107,10 @@ spec:
         {{ toYaml . | nindent 8 }}
         {{- end }}
       serviceAccountName: {{ include "piraeus-operator.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 10
       priorityClassName: {{ .Values.priorityClassName | default "system-cluster-critical" }}
       nodeSelector:


### PR DESCRIPTION
Small Helm chart papercut.

`imagePullSecrets` is in `values.yaml`, but setting it was a no-op. So private registry users could pass a pull secret and the operator Deployment still would not use it. Kinda rough.

Repro:
```sh
helm template test charts/piraeus \
  --namespace piraeus-datastore \
  --set imagePullSecrets[0].name=registry-creds | rg "imagePullSecrets|registry-creds"
```

Before: no output.
After: the Deployment pod spec includes:
```yaml
imagePullSecrets:
  - name: registry-creds
```

Checked:
```sh
helm lint charts/piraeus
helm template test charts/piraeus --namespace piraeus-datastore
```

No direct related issue found, afaict.
