### PR TITLE
fix: use consistent severity label in Prometheus alerts

### DIFF
--- a/config/extras/monitoring/alerts.yaml
+++ b/config/extras/monitoring/alerts.yaml
@@ -51,7 +51,7 @@ spec:
               Storage pool "{{ $labels.storage_pool }}" on node "{{ $labels.node }}" ({{ $labels.driver }}={{ $labels.backing_pool }}) has less than 20% free space available.
           expr: ( linstor_storage_pool_capacity_free_bytes / linstor_storage_pool_capacity_total_bytes ) < 0.20
           labels:
-            severity: warn
+            severity: warning
     - name: drbd.rules
       rules:
         - alert: drbdReactorOffline
@@ -68,7 +68,7 @@ spec:
           expr: drbd_connection_state{drbd_connection_state!="Connected"} > 0
           for: 1m
           labels:
-            severity: warn
+            severity: warning
         - alert: drbdDeviceNotUpToDate
           annotations:
             description: |
@@ -76,7 +76,7 @@ spec:
           expr: drbd_device_state{drbd_device_state!~"UpToDate|Diskless|Inconsistent"} > 0
           for: 1m
           labels:
-            severity: warn
+            severity: warning
         - alert: drbdDeviceUnintentionalDiskless
           annotations:
             description: |
@@ -84,7 +84,7 @@ spec:
               This usually indicates IO errors reported on the backing device. Check the kernel log.
           expr: drbd_device_unintentionaldiskless > 0
           labels:
-            severity: warn
+            severity: warning
         - alert: drbdDeviceWithoutQuorum
           annotations:
             description: |
@@ -93,7 +93,7 @@ spec:
           expr: drbd_device_quorum == 0
           for: 1m
           labels:
-            severity: warn
+            severity: warning
         - alert: drbdResourceSuspended
           annotations:
             description: |
@@ -101,7 +101,7 @@ spec:
           for: 1m
           expr: drbd_resource_suspended > 0
           labels:
-            severity: warn
+            severity: warning
         - alert: drbdResourceResyncWithoutProgress
           annotations:
             description: |
@@ -109,7 +109,7 @@ spec:
               This may indicate there is no connection to UpToDate data, or a stuck resync.
           expr: drbd_device_state{drbd_device_state="Inconsistent"} and delta(drbd_peerdevice_outofsync_bytes[5m]) >= 0
           labels:
-            severity: warn
+            severity: warning
         - alert: drbdResourceWithNoUpToDateReplicas
           annotations:
             description: |


### PR DESCRIPTION
Replace `warn` with `warning` throughout alerts.yaml to match the standard Prometheus severity convention used by the other rules.

Closes #1003 