### PR TITLE
fix: avoid panic in convertStrategicMergePatch when spec or metadata is absent

### DIFF
--- a/pkg/barepodpatch/barepodpatch.go
+++ b/pkg/barepodpatch/barepodpatch.go
@@ -74,8 +74,8 @@ func convertStrategicMergePatch(patch []byte) []byte {
 		return nil
 	}
 
-	spec := decoded["spec"].(map[string]any)
-	metadata := decoded["metadata"].(map[string]any)
+	spec, _ := decoded["spec"].(map[string]any)
+	metadata, _ := decoded["metadata"].(map[string]any)
 	if spec == nil && metadata == nil {
 		return nil
 	}

--- a/pkg/barepodpatch/barepodpatch_test.go
+++ b/pkg/barepodpatch/barepodpatch_test.go
@@ -82,6 +82,36 @@ spec:
 			},
 		},
 		{
+			name: "convert-strategic-merge-patch-metadata-only",
+			patch: piraeusiov1.Patch{
+				Patch: `apiVersion: v1
+kind: Pod
+metadata:
+  name: satellite
+  labels:
+    example.com/foo: bar
+`,
+			},
+			expected: piraeusiov1.Patch{
+				Target: &piraeusiov1.Selector{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "DaemonSet",
+					Name:    "linstor-satellite",
+				},
+				Patch: `apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: linstor-satellite
+spec:
+  template:
+    metadata:
+      labels:
+        example.com/foo: bar
+`,
+			},
+		},
+		{
 			name: "convert-json-patch",
 			patch: piraeusiov1.Patch{
 				Target: &piraeusiov1.Selector{


### PR DESCRIPTION
## What

`convertStrategicMergePatch` does bare type assertions on the `spec` and `metadata` keys:

```go
spec := decoded["spec"].(map[string]any)
metadata := decoded["metadata"].(map[string]any)
```

If a user writes a bare pod patch that touches only labels/annotations and has no `spec` block, `decoded["spec"]` is a nil `interface{}`, and the assertion panics.

## How to reproduce

Apply a `LinstorSatelliteConfiguration` with a patch like this (valid use case - just adding a label):

```yaml
patches:
  - patch: |
      apiVersion: v1
      kind: Pod
      metadata:
        name: satellite
        labels:
          example.com/team: storage
```

Operator panics with `interface conversion: interface {} is nil, not map[string]interface {}`.

## Fix

Use the comma-ok form so missing keys yield `nil` instead of a panic:

```go
spec, _ := decoded["spec"].(map[string]any)
metadata, _ := decoded["metadata"].(map[string]any)
```

The existing `if spec == nil && metadata == nil` guard already handles the fully-empty case correctly, so no other changes needed. Added a test case that covers this path.