### PR TITLE
docs: clarify test workflow in development guide

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -50,8 +50,12 @@ golangci-lint............................................................Failed
 Use `make test` to run our test suite. It will download the required control plane binaries to execute the webhook and
 controller tests.
 
-For basic unit testing use the basic go test framework. If something you want to test relies on the Kubernetes API,
-check out the test suite for the [`controllers`](./internal/controller/suite_test.go)
+For packages that do not rely on envtest, use the basic `go test` framework. If a test touches the Kubernetes API, use
+`make test` so the required control plane binaries are downloaded first. For example, a plain `go test ./...` will
+fail on a fresh checkout because `etcd` is not installed yet.
+
+If something you want to test relies on the Kubernetes API, check out the test suite for the
+[`controllers`](./internal/controller/suite_test.go)
 
 As of right now, there is no recommended way to end-to-end test the operator. It probably involves some
 virtual machines running a basic kubernetes cluster.
@@ -59,9 +63,9 @@ virtual machines running a basic kubernetes cluster.
 ## Automated Tests
 
 On every pull request, we run a set of tests, specified in `.github/workflows`. The checks include
-* `go test`
-* `golandci-lint`
+* `golangci-lint`
 * `pre-commit run`
+* `make compat-test`
 
 ## Commits
 


### PR DESCRIPTION
Small docs mismatch.

`DEVELOPMENT.md` says `go test` is the basic path and lists `go test` as a PR check.
On a fresh checkout that is a bit off, `go test ./...` fails with `fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory` because envtest assets are not there yet.
The repo really wants `make test` for envtest-backed suites, and CI runs `pre-commit run` plus `make compat-test`.

Repro:
1. Fresh checkout
2. Run `go test ./...`
3. Hit `fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory`

This patch just makes the guide say that, plain and simple. Saves a bit of yak shaving.