### PR TITLE
docs: fix typo and header inconsistencies in TLS docs

### DIFF
--- a/docs/how-to/drbd-tls.md
+++ b/docs/how-to/drbd-tls.md
@@ -142,7 +142,7 @@ Handshake with node3.example.com (10.125.97.42) was successful
         add_key: Bad message
 
 Next, check the statistics on TLS sessions controlled by the kernel on each node. You should see an equal, nonzero
-number of `TlsRxSw` and `TlsRxSw`.
+number of `TlsTxSw` and `TlsRxSw`.
 
 ```
 $ kubectl exec node1.example.com -- cat /proc/net/tls_stat

--- a/docs/reference/linstorsatelliteconfiguration.md
+++ b/docs/reference/linstorsatelliteconfiguration.md
@@ -283,7 +283,7 @@ spec:
       name: piraeus-root
 ```
 
-### `spec.deletionPolicy`
+### `.spec.deletionPolicy`
 
 Configure how Satellite removal is handled. Possible policies are:
 
@@ -308,7 +308,7 @@ spec:
  deletionPolicy: Evacuate
 ```
 
-### `spec.evacuationStrategy`
+### `.spec.evacuationStrategy`
 
 Configure timeouts for Satellite Evacuation. To have any effect, `deletionPolicy: Delete` is required.
 


### PR DESCRIPTION
Two small doc bugs in the TLS guides.

Typo in `docs/how-to/drbd-tls.md`:

```
You should see an equal, nonzero number of `TlsRxSw` and `TlsRxSw`.
```

First counter should be `TlsTxSw`. The code block right below already shows both `TlsTxSw` and `TlsRxSw` as separate counters with value 4, so the text just contradicts itself.

Missing leading dot in two section headers in `docs/reference/linstorsatelliteconfiguration.md` - `spec.deletionPolicy` and `spec.evacuationStrategy` vs every other header in the file which uses `.spec.*` prefix.

Related: #614