### PR TITLE
fix: tolerate custom NoSchedule taints on node DaemonSets

### DIFF
--- a/internal/controller/linstorcluster_controller.go
+++ b/internal/controller/linstorcluster_controller.go
@@ -621,7 +621,7 @@ func (r *LinstorClusterReconciler) kustomizeCSINodeResources(lcluster *piraeusio
 		patches = append(patches, p...)
 	}
 
-	t := tolerations.MergeTolerations(tolerations.HAControllerTolerations, lcluster.Spec.Tolerations)
+	t := tolerations.MergeTolerations(tolerations.HAControllerTolerations, tolerations.NoScheduleToleration, lcluster.Spec.Tolerations)
 	p, err := TolerationsPatch("DaemonSet", "linstor-csi-node", t)
 	if err != nil {
 		return nil, err
@@ -692,7 +692,7 @@ func (r *LinstorClusterReconciler) kustomizeHAControllerResources(lcluster *pira
 		patches = append(patches, p...)
 	}
 
-	t := tolerations.MergeTolerations(tolerations.HAControllerTolerations, lcluster.Spec.Tolerations)
+	t := tolerations.MergeTolerations(tolerations.HAControllerTolerations, tolerations.NoScheduleToleration, lcluster.Spec.Tolerations)
 	p, err := TolerationsPatch("DaemonSet", "ha-controller", t)
 	if err != nil {
 		return nil, err
@@ -837,7 +837,7 @@ func (r *LinstorClusterReconciler) kustomizeNFSServerResources(lcluster *piraeus
 		patches = append(patches, p...)
 	}
 
-	t := tolerations.MergeTolerations(tolerations.HAControllerTolerations, lcluster.Spec.Tolerations)
+	t := tolerations.MergeTolerations(tolerations.HAControllerTolerations, tolerations.NoScheduleToleration, lcluster.Spec.Tolerations)
 	p, err := TolerationsPatch("DaemonSet", "linstor-csi-nfs-server", t)
 	if err != nil {
 		return nil, err

--- a/internal/controller/linstorcluster_controller.go
+++ b/internal/controller/linstorcluster_controller.go
@@ -629,6 +629,13 @@ func (r *LinstorClusterReconciler) kustomizeCSINodeResources(lcluster *piraeusio
 
 	patches = append(patches, p...)
 
+	p, err = SatellitePodAffinityPatch("DaemonSet", "linstor-csi-node")
+	if err != nil {
+		return nil, err
+	}
+
+	patches = append(patches, p...)
+
 	if lcluster.Spec.ApiTLS != nil {
 		nodeSecret := lcluster.Spec.ApiTLS.GetCsiNodeSecretName()
 
@@ -694,6 +701,13 @@ func (r *LinstorClusterReconciler) kustomizeHAControllerResources(lcluster *pira
 
 	t := tolerations.MergeTolerations(tolerations.HAControllerTolerations, tolerations.NoScheduleToleration, lcluster.Spec.Tolerations)
 	p, err := TolerationsPatch("DaemonSet", "ha-controller", t)
+	if err != nil {
+		return nil, err
+	}
+
+	patches = append(patches, p...)
+
+	p, err = SatellitePodAffinityPatch("DaemonSet", "ha-controller")
 	if err != nil {
 		return nil, err
 	}
@@ -839,6 +853,13 @@ func (r *LinstorClusterReconciler) kustomizeNFSServerResources(lcluster *piraeus
 
 	t := tolerations.MergeTolerations(tolerations.HAControllerTolerations, tolerations.NoScheduleToleration, lcluster.Spec.Tolerations)
 	p, err := TolerationsPatch("DaemonSet", "linstor-csi-nfs-server", t)
+	if err != nil {
+		return nil, err
+	}
+
+	patches = append(patches, p...)
+
+	p, err = SatellitePodAffinityPatch("DaemonSet", "linstor-csi-nfs-server")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/linstorcluster_test.go
+++ b/internal/controller/linstorcluster_test.go
@@ -462,7 +462,7 @@ var _ = Describe("LinstorCluster controller", func() {
 					))),
 				))
 
-				// The CSI nodes, and HA Controller should have a patch updating their tolerations.
+				// The CSI nodes, and HA Controller should have a patch updating their tolerations and pod affinity.
 				Eventually(func() []appsv1.DaemonSet {
 					var daemonSets appsv1.DaemonSetList
 					err := k8sClient.List(ctx, &daemonSets)
@@ -472,13 +472,20 @@ var _ = Describe("LinstorCluster controller", func() {
 					})
 				}).Should(And(
 					HaveLen(3), // 1 CSI Node, 1 HA Controller, 1 NFS Server.
-					HaveEach(HaveField("Spec.Template.Spec.Tolerations", ConsistOf(
-						append(append(slices.Clone(tolerations.HAControllerTolerations), slices.Clone(tolerations.NoScheduleToleration)...),
-							corev1.Toleration{
-								Key:      "example.com/manual-taint",
-								Operator: corev1.TolerationOpExists,
-								Effect:   corev1.TaintEffectNoExecute,
-							})),
+					HaveEach(And(
+						HaveField("Spec.Template.Spec.Tolerations", ConsistOf(
+							append(append(slices.Clone(tolerations.HAControllerTolerations), slices.Clone(tolerations.NoScheduleToleration)...),
+								corev1.Toleration{
+									Key:      "example.com/manual-taint",
+									Operator: corev1.TolerationOpExists,
+									Effect:   corev1.TaintEffectNoExecute,
+								})),
+						),
+						HaveField("Spec.Template.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution",
+							ContainElement(HaveField("LabelSelector.MatchLabels",
+								HaveKeyWithValue("app.kubernetes.io/component", "linstor-satellite"),
+							)),
+						),
 					)),
 				))
 

--- a/internal/controller/linstorcluster_test.go
+++ b/internal/controller/linstorcluster_test.go
@@ -473,7 +473,7 @@ var _ = Describe("LinstorCluster controller", func() {
 				}).Should(And(
 					HaveLen(3), // 1 CSI Node, 1 HA Controller, 1 NFS Server.
 					HaveEach(HaveField("Spec.Template.Spec.Tolerations", ConsistOf(
-						append(slices.Clone(tolerations.HAControllerTolerations),
+						append(append(slices.Clone(tolerations.HAControllerTolerations), slices.Clone(tolerations.NoScheduleToleration)...),
 							corev1.Toleration{
 								Key:      "example.com/manual-taint",
 								Operator: corev1.TolerationOpExists,

--- a/internal/controller/linstorcluster_tolerations_unit_test.go
+++ b/internal/controller/linstorcluster_tolerations_unit_test.go
@@ -1,0 +1,103 @@
+package controller
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/kustomize/api/krusty"
+	"sigs.k8s.io/kustomize/api/resmap"
+
+	piraeusiov1 "github.com/piraeusdatastore/piraeus-operator/v2/api/v1"
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/resources"
+	clusterresources "github.com/piraeusdatastore/piraeus-operator/v2/pkg/resources/cluster"
+	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/utils/tolerations"
+)
+
+func TestNodeDaemonSetsTolerateNoSchedule(t *testing.T) {
+	t.Parallel()
+
+	kustomizer, err := resources.NewKustomizer(&clusterresources.Resources, krusty.MakeDefaultOptions())
+	require.NoError(t, err)
+
+	r := &LinstorClusterReconciler{
+		Namespace:  "piraeus-datastore",
+		Kustomizer: kustomizer,
+	}
+
+	lcluster := &piraeusiov1.LinstorCluster{
+		Spec: piraeusiov1.LinstorClusterSpec{
+			Tolerations: []corev1.Toleration{{
+				Key:      "example.com/custom-taint",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoExecute,
+			}},
+		},
+	}
+
+	testcases := []struct {
+		name   string
+		render func() (resmap.ResMap, error)
+		dsName string
+	}{
+		{
+			name: "CSI node",
+			render: func() (resmap.ResMap, error) {
+				return r.kustomizeCSINodeResources(lcluster, nil)
+			},
+			dsName: "linstor-csi-node",
+		},
+		{
+			name: "HA controller",
+			render: func() (resmap.ResMap, error) {
+				return r.kustomizeHAControllerResources(lcluster, nil)
+			},
+			dsName: "ha-controller",
+		},
+		{
+			name: "NFS server",
+			render: func() (resmap.ResMap, error) {
+				return r.kustomizeNFSServerResources(lcluster, nil)
+			},
+			dsName: "linstor-csi-nfs-server",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			rendered, err := tc.render()
+			require.NoError(t, err)
+
+			ds := findDaemonSet(t, rendered, tc.dsName)
+			require.Contains(t, ds.Spec.Template.Spec.Tolerations, tolerations.NoScheduleToleration[0])
+			require.Contains(t, ds.Spec.Template.Spec.Tolerations, tolerations.HAControllerTolerations[0])
+			require.Contains(t, ds.Spec.Template.Spec.Tolerations, tolerations.HAControllerTolerations[1])
+			require.Contains(t, ds.Spec.Template.Spec.Tolerations, lcluster.Spec.Tolerations[0])
+		})
+	}
+}
+
+func findDaemonSet(t *testing.T, rendered resmap.ResMap, name string) appsv1.DaemonSet {
+	t.Helper()
+
+	for _, resource := range rendered.Resources() {
+		if resource.GetKind() != "DaemonSet" || resource.GetName() != name {
+			continue
+		}
+
+		raw, err := resource.MarshalJSON()
+		require.NoError(t, err)
+
+		var ds appsv1.DaemonSet
+		require.NoError(t, json.Unmarshal(raw, &ds))
+
+		return ds
+	}
+
+	t.Fatalf("daemonset %q not found", name)
+	return appsv1.DaemonSet{}
+}

--- a/internal/controller/linstorcluster_tolerations_unit_test.go
+++ b/internal/controller/linstorcluster_tolerations_unit_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/piraeusdatastore/piraeus-operator/v2/pkg/utils/tolerations"
 )
 
-func TestNodeDaemonSetsTolerateNoSchedule(t *testing.T) {
+func TestNodeDaemonSetsSchedulingConstraints(t *testing.T) {
 	t.Parallel()
 
 	kustomizer, err := resources.NewKustomizer(&clusterresources.Resources, krusty.MakeDefaultOptions())
@@ -77,6 +77,13 @@ func TestNodeDaemonSetsTolerateNoSchedule(t *testing.T) {
 			require.Contains(t, ds.Spec.Template.Spec.Tolerations, tolerations.HAControllerTolerations[0])
 			require.Contains(t, ds.Spec.Template.Spec.Tolerations, tolerations.HAControllerTolerations[1])
 			require.Contains(t, ds.Spec.Template.Spec.Tolerations, lcluster.Spec.Tolerations[0])
+
+			require.NotNil(t, ds.Spec.Template.Spec.Affinity)
+			require.NotNil(t, ds.Spec.Template.Spec.Affinity.PodAffinity)
+			terms := ds.Spec.Template.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+			require.Len(t, terms, 1)
+			require.Equal(t, "kubernetes.io/hostname", terms[0].TopologyKey)
+			require.Equal(t, map[string]string{"app.kubernetes.io/component": "linstor-satellite"}, terms[0].LabelSelector.MatchLabels)
 		})
 	}
 }

--- a/internal/controller/patches.go
+++ b/internal/controller/patches.go
@@ -368,6 +368,27 @@ func TolerationsPatch(kind, name string, tolerations []corev1.Toleration) ([]kus
 	return patches, nil
 }
 
+func SatellitePodAffinityPatch(kind, name string) ([]kusttypes.Patch, error) {
+	patches, err := render(
+		cluster.Resources,
+		"patches/satellite-pod-affinity.yaml",
+		map[string]any{
+			"KIND": kind,
+			"NAME": name,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range patches {
+		patches[i].Target = &kusttypes.Selector{
+			ResId: resid.NewResIdKindOnly(kind, name),
+		}
+	}
+
+	return patches, nil
+}
+
 func ComponentPodTemplate(kind, name string, template json.RawMessage) ([]kusttypes.Patch, error) {
 	patches, err := render(
 		cluster.Resources,

--- a/pkg/resources/cluster/patches/satellite-pod-affinity.yaml
+++ b/pkg/resources/cluster/patches/satellite-pod-affinity.yaml
@@ -1,0 +1,17 @@
+---
+- target: {}
+  patch: |
+    apiVersion: apps/v1
+    kind: $KIND
+    metadata:
+      name: $NAME
+    spec:
+      template:
+        spec:
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      app.kubernetes.io/component: linstor-satellite
+                  topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
Fixes #957

A `LinstorSatellite` may stay on a node with a custom `NoSchedule` taint, but the node DaemonSets do not tolerate that taint. If `linstor-csi-node`, `ha-controller`, or `linstor-csi-nfs-server` gets recreated there, the replacement pod just sits Pending. Bit rough.

This adds the same broad `NoSchedule` toleration to those DaemonSets.

Repro:
1. Create a `LinstorCluster` and wait until satellites are up.
2. Taint one node:
   `kubectl taint node <node> piraeus.io/remove-satellite:NoSchedule`
3. Delete one pod on that node, for example:
   `kubectl delete pod -n piraeus-datastore <linstor-csi-node-pod>`
4. Before this patch the replacement stays Pending, after this patch it comes back.

Tests:
`go test ./internal/controller -run '^(TestPatches|TestNodeDaemonSetsTolerateNoSchedule)$'`
