### PR TITLE
limit concurrent satellite evacuations

### DIFF
--- a/api/v1/linstorcluster_types.go
+++ b/api/v1/linstorcluster_types.go
@@ -117,6 +117,17 @@ type LinstorClusterSpec struct {
 	// NFSServer controls the deployment of the LINSTOR CSI NFS Server DaemonSet.
 	// +kubebuilder:validation:Optional
 	NFSServer *ComponentSpec `json:"nfsServer,omitempty"`
+
+	// MaxConcurrentEvacuations limits how many Satellites are evacuated at the same time when using the
+	// "Evacuate" deletion policy.
+	//
+	// This applies both to Satellites removed because their node no longer matches the cluster, and to nodes
+	// removed through ClusterAPI. While the limit is reached, additional Satellites wait for a free slot before
+	// their volumes are moved and, for ClusterAPI managed nodes, before the node is allowed to drain.
+	// A value of 0 (the default) places no limit on the number of concurrent evacuations.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Minimum=0
+	MaxConcurrentEvacuations int32 `json:"maxConcurrentEvacuations,omitempty"`
 }
 
 type LinstorExternalControllerRef struct {

--- a/charts/piraeus/templates/crds.yaml
+++ b/charts/piraeus/templates/crds.yaml
@@ -353,6 +353,18 @@ spec:
                   * Store credentials for accessing remotes for backups.
                   See https://linbit.com/drbd-user-guide/linstor-guide-1_0-en/#s-encrypt_commands for more information.
                 type: string
+              maxConcurrentEvacuations:
+                description: |-
+                  MaxConcurrentEvacuations limits how many Satellites are evacuated at the same time when using the
+                  "Evacuate" deletion policy.
+
+                  This applies both to Satellites removed because their node no longer matches the cluster, and to nodes
+                  removed through ClusterAPI. While the limit is reached, additional Satellites wait for a free slot before
+                  their volumes are moved and, for ClusterAPI managed nodes, before the node is allowed to drain.
+                  A value of 0 (the default) places no limit on the number of concurrent evacuations.
+                format: int32
+                minimum: 0
+                type: integer
               nfsServer:
                 description: NFSServer controls the deployment of the LINSTOR CSI
                   NFS Server DaemonSet.

--- a/config/crd/bases/piraeus.io_linstorclusters.yaml
+++ b/config/crd/bases/piraeus.io_linstorclusters.yaml
@@ -352,6 +352,18 @@ spec:
                   * Store credentials for accessing remotes for backups.
                   See https://linbit.com/drbd-user-guide/linstor-guide-1_0-en/#s-encrypt_commands for more information.
                 type: string
+              maxConcurrentEvacuations:
+                description: |-
+                  MaxConcurrentEvacuations limits how many Satellites are evacuated at the same time when using the
+                  "Evacuate" deletion policy.
+
+                  This applies both to Satellites removed because their node no longer matches the cluster, and to nodes
+                  removed through ClusterAPI. While the limit is reached, additional Satellites wait for a free slot before
+                  their volumes are moved and, for ClusterAPI managed nodes, before the node is allowed to drain.
+                  A value of 0 (the default) places no limit on the number of concurrent evacuations.
+                format: int32
+                minimum: 0
+                type: integer
               nfsServer:
                 description: NFSServer controls the deployment of the LINSTOR CSI
                   NFS Server DaemonSet.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Allow configuring the separator between generated Satellite resource names and the Satellite name.
+- Add `LinstorCluster.spec.maxConcurrentEvacuations` to limit how many Satellites are evacuated at the same time, for both direct and ClusterAPI-driven node removals.
 
 ### Changed
 

--- a/docs/explanation/deletion-policies.md
+++ b/docs/explanation/deletion-policies.md
@@ -102,6 +102,15 @@ In order to keep potential fail-over times short, Piraeus Datastore performs the
    annotation on the Machine is removed, letting ClusterAPI proceed with shutting down the node.
 9. The Satellite is removed from LINSTOR.
 
+#### Limiting Concurrent Evacuations
+
+By default, all Satellites that need to be evacuated start their evacuation at the same time. On larger clusters
+this can move a lot of data at once. Set [`LinstorCluster.spec.maxConcurrentEvacuations`](../reference/linstorcluster.md#specmaxconcurrentevacuations)
+to limit how many Satellites evacuate simultaneously. While the limit is reached, additional Satellites wait for
+a free slot (reported through a `SatelliteEvacuated` condition with reason `Waiting`) before any of their volumes
+are moved. Already running evacuations are always allowed to finish first, so increasing the data movement never
+abandons work that has already started.
+
 ### `Delete` Policy
 
 When using the `Delete` policy, Piraeus Datastore will remove the Satellite from the LINSTOR Cluster in addition to
@@ -124,6 +133,12 @@ hook into the [Machine deletion process](https://cluster-api.sigs.k8s.io/tasks/a
 
 In particular, if the Satellites are using the `Evacuate` deletion policy, Piraeus Datastore will instruct ClusterAPI
 to wait at the appropriate times, keeping the Machine running until all resources have been evacuated.
+
+When [`LinstorCluster.spec.maxConcurrentEvacuations`](../reference/linstorcluster.md#specmaxconcurrentevacuations) is set,
+this limit also applies to ClusterAPI-driven removals: a Machine that is marked for deletion but not yet admitted keeps
+its pre-drain hook in place, so ClusterAPI keeps the node running until a free evacuation slot becomes available. This
+composes with ClusterAPI's own rollout settings (such as `maxUnavailable`); the effective concurrency is the smaller of
+the two.
 
 By default, Piraeus Operator will search the Cluster it is deployed in for the Machine resources. If the Machine is
 managed by a different Cluster, set the `CLUSTER_API_KUBECONFIG` environment variable in the Operator Deployment to

--- a/docs/reference/linstorcluster.md
+++ b/docs/reference/linstorcluster.md
@@ -565,6 +565,31 @@ spec:
       key: root.crt
 ```
 
+### `.spec.maxConcurrentEvacuations`
+
+Limits how many Satellites are evacuated at the same time when using the
+[`Evacuate` deletion policy](../explanation/deletion-policies.md#evacuate-policy).
+
+This applies both to Satellites removed because their node no longer matches the cluster, and to nodes removed
+through ClusterAPI. While the limit is reached, additional Satellites wait for a free slot before their volumes
+are moved and, for ClusterAPI managed nodes, before the node is allowed to drain. A Satellite that is waiting
+reports a `SatelliteEvacuated` condition with reason `Waiting`.
+
+A value of `0` (the default) places no limit on the number of concurrent evacuations.
+
+#### Example
+
+This example allows at most two Satellites to evacuate simultaneously:
+
+```yaml
+apiVersion: piraeus.io/v1
+kind: LinstorCluster
+metadata:
+  name: linstorcluster
+spec:
+  maxConcurrentEvacuations: 2
+```
+
 ## `.status`
 
 Reports the actual state of the cluster.

--- a/internal/controller/linstorsatellite_controller.go
+++ b/internal/controller/linstorsatellite_controller.go
@@ -79,6 +79,7 @@ type LinstorSatelliteReconciler struct {
 	PodExecutor        podexec.Executor
 	log                logr.Logger
 	recorder           record.EventRecorder
+	evacuator          *evacuation.Evacuator
 }
 
 //+kubebuilder:rbac:groups=piraeus.io,resources=linstorsatellites,verbs=get;list;watch;create;update;patch;delete
@@ -529,7 +530,7 @@ func (r *LinstorSatelliteReconciler) reconcileLinstorSatelliteState(ctx context.
 				return err
 			}
 
-			_, err = evacuation.EvacuateSatellite(ctx, r.Client, lc.Client, r.recorder, lnode, r.MachineClient, machine, &lsatellite.Spec.EvacuationStrategy, conds, limit)
+			_, err = r.evacuator.EvacuateSatellite(ctx, lc.Client, lnode, machine, &lsatellite.Spec.EvacuationStrategy, conds, limit)
 			if err != nil {
 				return err
 			}
@@ -763,7 +764,7 @@ func (r *LinstorSatelliteReconciler) deleteSatellite(ctx context.Context, lsatel
 			return false, err
 		}
 
-		done, err := evacuation.EvacuateSatellite(ctx, r.Client, lc.Client, r.recorder, &lnode, r.MachineClient, machine, &lsatellite.Spec.EvacuationStrategy, conds, limit)
+		done, err := r.evacuator.EvacuateSatellite(ctx, lc.Client, &lnode, machine, &lsatellite.Spec.EvacuationStrategy, conds, limit)
 		if err != nil {
 			return false, err
 		}
@@ -850,6 +851,11 @@ func (r *LinstorSatelliteReconciler) SetupWithManager(mgr ctrl.Manager, opts con
 
 	r.log = mgr.GetLogger().WithName("LinstorSatelliteReconciler")
 	r.recorder = mgr.GetEventRecorderFor("LinstorSatelliteReconciler")
+	r.evacuator = &evacuation.Evacuator{
+		Client:        r.Client,
+		Recorder:      r.recorder,
+		MachineClient: r.MachineClient,
+	}
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&piraeusiov1.LinstorSatellite{}).

--- a/internal/controller/linstorsatellite_controller.go
+++ b/internal/controller/linstorsatellite_controller.go
@@ -127,12 +127,12 @@ func (r *LinstorSatelliteReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	var status piraeusiov1.LinstorSatelliteStatus
 	var deleteErr, stateErr error
 	if lsatellite.GetDeletionTimestamp() != nil {
-		msg, done, err := r.deleteSatellite(ctx, lsatellite, &node, conds)
+		done, err := r.deleteSatellite(ctx, lsatellite, &node, conds)
 		if err != nil {
 			conds.AddError("SatelliteDeleted", err)
 			deleteErr = err
 		} else if !done {
-			conds.AddInProgress("SatelliteDeleted", msg)
+			conds.AddInProgress("SatelliteDeleted", fmt.Sprintf("deletion using '%s' policy in progress", lsatellite.Spec.DeletionPolicy))
 		} else {
 			conds.AddCompleted("SatelliteDeleted", fmt.Sprintf("deletion using '%s' policy complete", lsatellite.Spec.DeletionPolicy))
 		}
@@ -521,13 +521,17 @@ func (r *LinstorSatelliteReconciler) reconcileLinstorSatelliteState(ctx context.
 
 		if clusterapi.ShouldEvacuateNode(machine) && lsatellite.Spec.DeletionPolicy == piraeusiov1.DeletionPolicyEvacuate {
 			r.log.Info("Request to evacuate node from ClusterAPI")
-			msg, done, err := evacuation.EvacuateSatellite(ctx, r.Client, lc.Client, r.recorder, lnode, r.MachineClient, machine, &lsatellite.Spec.EvacuationStrategy)
+			// EvacuateSatellite records its progress (including waiting for a free slot) on the
+			// SatelliteEvacuatedCondition. While the Satellite waits, the Machine pre-drain hook stays in
+			// place, so ClusterAPI keeps the node running until it is admitted.
+			limit, err := r.maxConcurrentEvacuations(ctx, lsatellite)
 			if err != nil {
-				conds.AddError("SatelliteEvacuated", err)
-			} else if !done {
-				conds.AddInProgress("SatelliteEvacuated", msg)
-			} else {
-				conds.AddCompleted("SatelliteEvacuated", "LINSTOR Satellite evacuated")
+				return err
+			}
+
+			_, err = evacuation.EvacuateSatellite(ctx, r.Client, lc.Client, r.recorder, lnode, r.MachineClient, machine, &lsatellite.Spec.EvacuationStrategy, conds, limit)
+			if err != nil {
+				return err
 			}
 		} else if slices.Contains(lnode.Flags, linstor.FlagEvacuate) || slices.Contains(lnode.Flags, linstor.FlagEvicted) {
 			err := lc.Nodes.Restore(ctx, lnode.Name, lapi.NodeRestore{})
@@ -674,20 +678,37 @@ func (r *LinstorSatelliteReconciler) reconcileStoragePools(ctx context.Context, 
 	return errors.Join(errs...)
 }
 
+// maxConcurrentEvacuations returns the cluster-wide limit on simultaneous Satellite evacuations.
+// A value of 0 means no limit.
+func (r *LinstorSatelliteReconciler) maxConcurrentEvacuations(ctx context.Context, lsatellite *piraeusiov1.LinstorSatellite) (int, error) {
+	cluster := &piraeusiov1.LinstorCluster{}
+	err := r.Get(ctx, types.NamespacedName{Name: lsatellite.Spec.ClusterRef.Name}, cluster)
+	if k8serrors.IsNotFound(err) {
+		// No LinstorCluster (e.g. an external controller, or the cluster is being torn down) means there is
+		// no configured limit, so evacuation must not be blocked.
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+
+	return int(cluster.Spec.MaxConcurrentEvacuations), nil
+}
+
 // deleteSatellite tries to reconcile deletion of the satellites.
 //
 // Because this might take some time, and needs several attempts, this method returns
 // * A human-readable message of what is currently preventing satellite removal.
 // * true if the satellite was deleted, false otherwise.
 // * Any errors that prevented further progress.
-func (r *LinstorSatelliteReconciler) deleteSatellite(ctx context.Context, lsatellite *piraeusiov1.LinstorSatellite, node *corev1.Node, conds conditions.Conditions) (string, bool, error) {
+func (r *LinstorSatelliteReconciler) deleteSatellite(ctx context.Context, lsatellite *piraeusiov1.LinstorSatellite, node *corev1.Node, conds conditions.Conditions) (bool, error) {
 	if !controllerutil.ContainsFinalizer(lsatellite, vars.SatelliteFinalizer) {
-		return "", true, nil
+		return true, nil
 	}
 
 	machine, err := r.MachineClient.GetMachineForNode(ctx, node)
 	if err != nil {
-		return "", false, err
+		return false, err
 	}
 
 	lc, err := linstorhelper.NewClientForCluster(
@@ -698,30 +719,30 @@ func (r *LinstorSatelliteReconciler) deleteSatellite(ctx context.Context, lsatel
 		r.LinstorClientOpts...,
 	)
 	if err != nil {
-		return "", false, err
+		return false, err
 	}
 
 	if lc == nil {
 		r.log.Info("Allow Machine to drain for Satellite without cluster")
 		err := r.MachineClient.AllowMachineDrain(ctx, r.recorder, machine)
 		if err != nil {
-			return "", false, err
+			return false, err
 		}
 
 		r.log.Info("Allow Machine to terminate for Satellite without cluster")
 		err = r.MachineClient.AllowMachineTermination(ctx, r.recorder, machine)
 		if err != nil {
-			return "", false, err
+			return false, err
 		}
 
 		r.log.Info("Removing finalizer from Satellite without cluster")
 		controllerutil.RemoveFinalizer(lsatellite, vars.SatelliteFinalizer)
 		err = r.Client.Update(ctx, lsatellite)
 		if err != nil {
-			return "", false, err
+			return false, err
 		}
 
-		return "", true, nil
+		return true, nil
 	}
 
 	r.log.Info("Deleting Satellite", "Policy", lsatellite.Spec.DeletionPolicy)
@@ -734,28 +755,30 @@ func (r *LinstorSatelliteReconciler) deleteSatellite(ctx context.Context, lsatel
 				break
 			}
 
-			return "", false, err
+			return false, err
 		}
 
-		msg, done, err := evacuation.EvacuateSatellite(ctx, r.Client, lc.Client, r.recorder, &lnode, r.MachineClient, machine, &lsatellite.Spec.EvacuationStrategy)
+		limit, err := r.maxConcurrentEvacuations(ctx, lsatellite)
 		if err != nil {
-			conds.AddError("SatelliteEvacuated", err)
-			return "", false, err
-		} else if !done {
-			conds.AddInProgress("SatelliteEvacuated", msg)
-			return msg, done, nil
-		} else {
-			err = lc.Nodes.Delete(ctx, lsatellite.Name)
-			if err != nil && !errors.Is(err, lapi.NotFoundError) {
-				return "", false, err
-			}
+			return false, err
+		}
 
-			conds.AddCompleted("SatelliteEvacuated", "LINSTOR Satellite evacuated")
+		done, err := evacuation.EvacuateSatellite(ctx, r.Client, lc.Client, r.recorder, &lnode, r.MachineClient, machine, &lsatellite.Spec.EvacuationStrategy, conds, limit)
+		if err != nil {
+			return false, err
+		}
+		if !done {
+			return false, nil
+		}
+
+		err = lc.Nodes.Delete(ctx, lsatellite.Name)
+		if err != nil && !errors.Is(err, lapi.NotFoundError) {
+			return false, err
 		}
 	case piraeusiov1.DeletionPolicyDelete:
 		err := lc.Nodes.Lost(ctx, lsatellite.Name)
 		if err != nil && !errors.Is(err, lapi.NotFoundError) {
-			return "", false, err
+			return false, err
 		}
 	case "", piraeusiov1.DeletionPolicyRetain:
 		r.log.Info("Nothing to do for deletion of satellite with 'Retain' deletion policy")
@@ -764,10 +787,10 @@ func (r *LinstorSatelliteReconciler) deleteSatellite(ctx context.Context, lsatel
 	controllerutil.RemoveFinalizer(lsatellite, vars.SatelliteFinalizer)
 	err = r.Client.Update(ctx, lsatellite)
 	if err != nil {
-		return "", false, err
+		return false, err
 	}
 
-	return "", true, nil
+	return true, nil
 }
 
 func (r *LinstorSatelliteReconciler) kustomLabels(uuid types.UID, instance string) []kusttypes.Label {

--- a/internal/controller/linstorsatellite_test.go
+++ b/internal/controller/linstorsatellite_test.go
@@ -392,7 +392,7 @@ var _ = Describe("LinstorSatelliteReconciler", func() {
 
 					GinkgoWriter.Println("checking that Satellite status reports evacuation progress")
 					Eventually(func() *metav1.Condition {
-						return GetSatelliteCondition(ctx, k8sClient, ExampleNodeName, "SatelliteDeleted")
+						return GetSatelliteCondition(ctx, k8sClient, ExampleNodeName, "SatelliteEvacuated")
 					}).Should(And(
 						HaveField("Status", metav1.ConditionFalse),
 						HaveField("Reason", string(conditions.ReasonInProgress)),

--- a/pkg/conditions/conditions.go
+++ b/pkg/conditions/conditions.go
@@ -21,6 +21,7 @@ const (
 	ReasonNotObserved Reason = "NotObserved"
 	ReasonAsExpected  Reason = "AsExpected"
 	ReasonCompleted   Reason = "Completed"
+	ReasonWaiting     Reason = "Waiting"
 	ReasonInProgress  Reason = "InProgress"
 	ReasonUnknown     Reason = "Unknown"
 	ReasonError       Reason = "Error"
@@ -30,9 +31,10 @@ var conditionPriority = map[Reason]int{
 	ReasonNotObserved: 0,
 	ReasonAsExpected:  1,
 	ReasonCompleted:   2,
-	ReasonInProgress:  3,
-	ReasonUnknown:     4,
-	ReasonError:       5,
+	ReasonWaiting:     3,
+	ReasonInProgress:  4,
+	ReasonUnknown:     5,
+	ReasonError:       6,
 }
 
 type condition struct {
@@ -77,6 +79,15 @@ func (c Conditions) AddCompleted(condType CondType, message string) {
 	if conditionPriority[ct.Reason] < conditionPriority[ReasonCompleted] {
 		ct.Status = metav1.ConditionTrue
 		ct.Reason = ReasonCompleted
+	}
+}
+
+func (c Conditions) AddWaiting(condType CondType, message string) {
+	ct := c.get(condType)
+	ct.Message = append(ct.Message, message)
+	if conditionPriority[ct.Reason] < conditionPriority[ReasonWaiting] {
+		ct.Status = metav1.ConditionFalse
+		ct.Reason = ReasonWaiting
 	}
 }
 

--- a/pkg/evacuation/evacuation.go
+++ b/pkg/evacuation/evacuation.go
@@ -40,18 +40,29 @@ const (
 // SatelliteEvacuatedCondition tracks the progress of evacuating volumes off a Satellite.
 const SatelliteEvacuatedCondition = "SatelliteEvacuated"
 
-// admissionMu serializes evacuation admission decisions so concurrent reconciles compute a consistent view
-// of how many Satellites are currently evacuating.
-var admissionMu sync.Mutex
+// Evacuator moves LINSTOR resources off a Satellite that is being removed. It bundles the Kubernetes and
+// ClusterAPI clients, which are stable for the lifetime of the reconciler; the per-cluster LINSTOR client is
+// passed to EvacuateSatellite instead.
+type Evacuator struct {
+	// Client reads and updates PVs, VolumeAttachments and LinstorSatellites.
+	Client client.Client
+	// Recorder records events on the affected PVCs/PVs.
+	Recorder record.EventRecorder
+	// MachineClient releases the ClusterAPI Machine drain/terminate hooks as evacuation progresses.
+	MachineClient *clusterapi.Client
+
+	// admissionMu serializes evacuation admission decisions so concurrent reconciles compute a consistent
+	// view of how many Satellites are currently evacuating.
+	admissionMu sync.Mutex
+}
 
 // EvacuateSatellite ensures all LINSTOR Resources have been moved to other nodes, honoring the cluster-wide
 // evacuation concurrency limit, and records the progress on the SatelliteEvacuatedCondition.
 //
-// Returns a message indicating the current progress and a bool indicating if evacuation is complete. The
-// function should be called repeatedly until completion of the evacuation.
-func EvacuateSatellite(ctx context.Context, cl client.Client, lclient *lapi.Client, recorder record.EventRecorder, node *lapi.Node, machineClient *clusterapi.Client, machine *clusterapi.Machine, evacuationStrategy *piraeusiov1.EvacuationStrategy, conds conditions.Conditions, maxConcurrent int) (bool, error) {
+// Returns true once evacuation is complete. The function should be called repeatedly until then.
+func (e *Evacuator) EvacuateSatellite(ctx context.Context, lclient *lapi.Client, node *lapi.Node, machine *clusterapi.Machine, evacuationStrategy *piraeusiov1.EvacuationStrategy, conds conditions.Conditions, maxConcurrent int) (bool, error) {
 	// Gate evacuation progress on the cluster-wide concurrency limit.
-	admitted, position, total, err := admitEvacuation(ctx, cl, node.Name, maxConcurrent)
+	admitted, position, total, err := e.admitEvacuation(ctx, node.Name, maxConcurrent)
 	if err != nil {
 		conds.AddError(SatelliteEvacuatedCondition, err)
 		return false, err
@@ -63,7 +74,7 @@ func EvacuateSatellite(ctx context.Context, cl client.Client, lclient *lapi.Clie
 		return false, nil
 	}
 
-	msg, done, err := evacuateSatellite(ctx, cl, lclient, recorder, node, machineClient, machine, evacuationStrategy)
+	msg, done, err := e.evacuateSatellite(ctx, lclient, node, machine, evacuationStrategy)
 	switch {
 	case err != nil:
 		conds.AddError(SatelliteEvacuatedCondition, err)
@@ -88,16 +99,16 @@ func EvacuateSatellite(ctx context.Context, cl client.Client, lclient *lapi.Clie
 //
 // Returns whether the Satellite is admitted, its zero-based position in the ordering, and the total number
 // of candidates.
-func admitEvacuation(ctx context.Context, cl client.Client, name string, maxConcurrent int) (bool, int, int, error) {
+func (e *Evacuator) admitEvacuation(ctx context.Context, name string, maxConcurrent int) (bool, int, int, error) {
 	if maxConcurrent <= 0 {
 		return true, 0, 0, nil
 	}
 
-	admissionMu.Lock()
-	defer admissionMu.Unlock()
+	e.admissionMu.Lock()
+	defer e.admissionMu.Unlock()
 
 	var satellites piraeusiov1.LinstorSatelliteList
-	err := cl.List(ctx, &satellites)
+	err := e.Client.List(ctx, &satellites)
 	if err != nil {
 		return false, 0, 0, err
 	}
@@ -163,51 +174,51 @@ func admitEvacuation(ctx context.Context, cl client.Client, name string, maxConc
 //
 // Returns a message indicating the current progress and a bool indicating if evacuation is complete.
 // The function should be called repeatedly until completion of the evacuation.
-func evacuateSatellite(ctx context.Context, cl client.Client, lclient *lapi.Client, recorder record.EventRecorder, node *lapi.Node, machineClient *clusterapi.Client, machine *clusterapi.Machine, evacuationStrategy *piraeusiov1.EvacuationStrategy) (string, bool, error) {
+func (e *Evacuator) evacuateSatellite(ctx context.Context, lclient *lapi.Client, node *lapi.Node, machine *clusterapi.Machine, evacuationStrategy *piraeusiov1.EvacuationStrategy) (string, bool, error) {
 	// Step 1: ensure PVs can be rescheduled to other nodes
-	msg, done, err := preparePVsforEvacuation(ctx, cl, lclient, recorder, node.Name)
+	msg, done, err := e.preparePVsforEvacuation(ctx, lclient, node.Name)
 	if err != nil || !done {
 		return msg, done, err
 	}
 
 	// Step 2: wait for all Satellites to be online, so rescheduled workloads can attach the volumes
-	msg, done, err = waitForConfiguredSatellites(ctx, cl, node.Name)
+	msg, done, err = e.waitForConfiguredSatellites(ctx, node.Name)
 	if err != nil || !done {
 		return msg, done, err
 	}
 
 	// Step 3: Node is now ready to be drained
-	err = machineClient.AllowMachineDrain(ctx, recorder, machine)
+	err = e.MachineClient.AllowMachineDrain(ctx, e.Recorder, machine)
 	if err != nil {
 		return "", false, err
 	}
 
 	// Step 4: Wait for PVs that have been active on this node to be reattached
-	msg, done, err = waitForReattach(ctx, cl, recorder, node.Name, evacuationStrategy)
+	msg, done, err = e.waitForReattach(ctx, node.Name, evacuationStrategy)
 	if err != nil || !done {
 		return msg, done, err
 	}
 
 	// Step 5: Start evacuating the Satellite
-	err = evacuateNode(ctx, lclient, node)
+	err = e.evacuateNode(ctx, lclient, node)
 	if err != nil {
 		return "", false, err
 	}
 
 	// Step 6: Wait for Satellite to be completely evacuated
-	msg, done, err = waitForEvacuation(ctx, lclient, node.Name)
+	msg, done, err = e.waitForEvacuation(ctx, lclient, node.Name)
 	if err != nil || !done {
 		return msg, done, err
 	}
 
 	// Step 7: Remove temporary PV annotations
-	err = cleanPVsAfterEvacuation(ctx, cl, node.Name)
+	err = e.cleanPVsAfterEvacuation(ctx, node.Name)
 	if err != nil {
 		return "", false, err
 	}
 
 	// Step 8: Allow Machine to be terminated
-	err = machineClient.AllowMachineTermination(ctx, recorder, machine)
+	err = e.MachineClient.AllowMachineTermination(ctx, e.Recorder, machine)
 	if err != nil {
 		return "", false, err
 	}
@@ -220,9 +231,9 @@ func evacuateSatellite(ctx context.Context, cl client.Client, lclient *lapi.Clie
 // It checks for PVs that are either only accessible from the local node or are currently attached and:
 // * marks them with annotations so later steps can find them.
 // * ensures that "local" PVs are temporarily reschedulable during evacuation.
-func preparePVsforEvacuation(ctx context.Context, cl client.Client, lclient *lapi.Client, recorder record.EventRecorder, nodeName string) (string, bool, error) {
+func (e *Evacuator) preparePVsforEvacuation(ctx context.Context, lclient *lapi.Client, nodeName string) (string, bool, error) {
 	var volumeAttachmentList storagev1.VolumeAttachmentList
-	err := cl.List(ctx, &volumeAttachmentList)
+	err := e.Client.List(ctx, &volumeAttachmentList)
 	if err != nil {
 		return "", false, err
 	}
@@ -230,13 +241,13 @@ func preparePVsforEvacuation(ctx context.Context, cl client.Client, lclient *lap
 	attachments := AttachmentsByPV(volumeAttachmentList.Items)
 
 	var nodeList corev1.NodeList
-	err = cl.List(ctx, &nodeList)
+	err = e.Client.List(ctx, &nodeList)
 	if err != nil {
 		return "", false, err
 	}
 
 	var persistentVolumeList corev1.PersistentVolumeList
-	err = cl.List(ctx, &persistentVolumeList)
+	err = e.Client.List(ctx, &persistentVolumeList)
 	if err != nil {
 		return "", false, err
 	}
@@ -261,7 +272,7 @@ func preparePVsforEvacuation(ctx context.Context, cl client.Client, lclient *lap
 		rds[rd.Name] = rd.ResourceDefinition
 	}
 
-	resourceList, err := getDiskfulResourcesOnNode(ctx, lclient, nodeName)
+	resourceList, err := e.getDiskfulResourcesOnNode(ctx, lclient, nodeName)
 	if err != nil {
 		return "", false, err
 	}
@@ -292,7 +303,7 @@ func preparePVsforEvacuation(ctx context.Context, cl client.Client, lclient *lap
 				pv.Annotations[vars.PersistentVolumeWaitForReattachAnnotationPrefix+"/"+nodeName] = "false"
 			}
 
-			PVCOrPVEventf(recorder, pv, corev1.EventTypeNormal, VolumeEvacuatingEvent, "Volume is being evacuated from Node '%s'", nodeName)
+			e.pvcOrPVEventf(pv, corev1.EventTypeNormal, VolumeEvacuatingEvent, "Volume is being evacuated from Node '%s'", nodeName)
 		}
 
 		switch evacuationActionForPV(pv, rds, rgs, nodeName, nodeList.Items) {
@@ -304,7 +315,7 @@ func preparePVsforEvacuation(ctx context.Context, cl client.Client, lclient *lap
 				toUpdate = true
 				pv.Annotations[affinity.OverrideAnnotationPrefix+"/"+nodeName] = "true"
 
-				PVCOrPVEventf(recorder, pv, corev1.EventTypeNormal, VolumeTemporarilyMadeReschedulableEvent, "Volume is made reschedulable to attach on replacement node")
+				e.pvcOrPVEventf(pv, corev1.EventTypeNormal, VolumeTemporarilyMadeReschedulableEvent, "Volume is made reschedulable to attach on replacement node")
 			}
 
 			unschedulablePVs = append(unschedulablePVs, pv.Name)
@@ -318,15 +329,15 @@ func preparePVsforEvacuation(ctx context.Context, cl client.Client, lclient *lap
 					},
 				}
 
-				PVCOrPVEventf(recorder, pv, corev1.EventTypeNormal, VolumeDeletedForEvacuationEvent, "Volume deleted on node according to evacuation action")
+				e.pvcOrPVEventf(pv, corev1.EventTypeNormal, VolumeDeletedForEvacuationEvent, "Volume deleted on node according to evacuation action")
 
-				if err := cl.Delete(ctx, pvc, client.Preconditions(*metav1.NewUIDPreconditions(string(pv.Spec.ClaimRef.UID)))); err != nil && !k8serrors.IsNotFound(err) {
+				if err := e.Client.Delete(ctx, pvc, client.Preconditions(*metav1.NewUIDPreconditions(string(pv.Spec.ClaimRef.UID)))); err != nil && !k8serrors.IsNotFound(err) {
 					errs = append(errs, err)
 				}
 			}
 
 			if pv.DeletionTimestamp == nil {
-				if err := cl.Delete(ctx, pv, client.Preconditions(*metav1.NewUIDPreconditions(string(pv.UID)))); err != nil && !k8serrors.IsNotFound(err) {
+				if err := e.Client.Delete(ctx, pv, client.Preconditions(*metav1.NewUIDPreconditions(string(pv.UID)))); err != nil && !k8serrors.IsNotFound(err) {
 					errs = append(errs, err)
 				}
 			}
@@ -335,7 +346,7 @@ func preparePVsforEvacuation(ctx context.Context, cl client.Client, lclient *lap
 		}
 
 		if toUpdate {
-			if err := cl.Update(ctx, pv); err != nil && !k8serrors.IsNotFound(err) {
+			if err := e.Client.Update(ctx, pv); err != nil && !k8serrors.IsNotFound(err) {
 				errs = append(errs, err)
 			}
 		}
@@ -396,9 +407,9 @@ func evacuationActionForPV(pv *corev1.PersistentVolume, rds map[string]lapi.Reso
 	return PVEvacuationActionNone
 }
 
-func waitForConfiguredSatellites(ctx context.Context, cl client.Client, nodeName string) (string, bool, error) {
+func (e *Evacuator) waitForConfiguredSatellites(ctx context.Context, nodeName string) (string, bool, error) {
 	var satellites piraeusiov1.LinstorSatelliteList
-	err := cl.List(ctx, &satellites)
+	err := e.Client.List(ctx, &satellites)
 	if err != nil {
 		return "", false, err
 	}
@@ -439,17 +450,17 @@ func waitForConfiguredSatellites(ctx context.Context, cl client.Client, nodeName
 	return "", true, nil
 }
 
-func waitForReattach(ctx context.Context, cl client.Client, recorder record.EventRecorder, nodeName string, evacuationStrategy *piraeusiov1.EvacuationStrategy) (string, bool, error) {
+func (e *Evacuator) waitForReattach(ctx context.Context, nodeName string, evacuationStrategy *piraeusiov1.EvacuationStrategy) (string, bool, error) {
 	now := time.Now()
 
 	var pvs corev1.PersistentVolumeList
-	err := cl.List(ctx, &pvs)
+	err := e.Client.List(ctx, &pvs)
 	if err != nil {
 		return "", false, err
 	}
 
 	var volumeAttachmentList storagev1.VolumeAttachmentList
-	err = cl.List(ctx, &volumeAttachmentList)
+	err = e.Client.List(ctx, &volumeAttachmentList)
 	if err != nil {
 		return "", false, err
 	}
@@ -469,12 +480,12 @@ func waitForReattach(ctx context.Context, cl client.Client, recorder record.Even
 		switch pv.Annotations[vars.PersistentVolumeWaitForReattachAnnotationPrefix+"/"+nodeName] {
 		case "true":
 			if now.Sub(waitedForReattachSince) >= evacuationStrategy.AttachedVolumeReattachTimeout.Duration {
-				PVCOrPVEventf(recorder, &pv, corev1.EventTypeNormal, VolumeNotAttachedForEvacuationEvent, "Timed out waiting for Volume to reattach (limit: %s), proceeding with evacuation", evacuationStrategy.AttachedVolumeReattachTimeout.Duration)
+				e.pvcOrPVEventf(&pv, corev1.EventTypeNormal, VolumeNotAttachedForEvacuationEvent, "Timed out waiting for Volume to reattach (limit: %s), proceeding with evacuation", evacuationStrategy.AttachedVolumeReattachTimeout.Duration)
 				continue
 			}
 		case "false":
 			if now.Sub(waitedForReattachSince) >= evacuationStrategy.UnattachedVolumeAttachTimeout.Duration {
-				PVCOrPVEventf(recorder, &pv, corev1.EventTypeNormal, VolumeNotAttachedForEvacuationEvent, "Timed out waiting for Volume to attach (limit: %s), proceeding with evacuation", evacuationStrategy.UnattachedVolumeAttachTimeout.Duration)
+				e.pvcOrPVEventf(&pv, corev1.EventTypeNormal, VolumeNotAttachedForEvacuationEvent, "Timed out waiting for Volume to attach (limit: %s), proceeding with evacuation", evacuationStrategy.UnattachedVolumeAttachTimeout.Duration)
 				continue
 			}
 		default:
@@ -491,11 +502,11 @@ func waitForReattach(ctx context.Context, cl client.Client, recorder record.Even
 			delete(pv.Annotations, vars.PersistentVolumeWaitForReattachSinceAnnotationPrefix+"/"+nodeName)
 			delete(pv.Annotations, vars.PersistentVolumeWaitForReattachAnnotationPrefix+"/"+nodeName)
 
-			if err := cl.Update(ctx, &pv); err != nil {
+			if err := e.Client.Update(ctx, &pv); err != nil {
 				return "", false, err
 			}
 
-			PVCOrPVEventf(recorder, &pv, corev1.EventTypeNormal, VolumeAttachedForEvacuationEvent, "Volume successfully attached on Node(s) [%s], proceeding with evacuation", strings.Join(attachedNodes, ", "))
+			e.pvcOrPVEventf(&pv, corev1.EventTypeNormal, VolumeAttachedForEvacuationEvent, "Volume successfully attached on Node(s) [%s], proceeding with evacuation", strings.Join(attachedNodes, ", "))
 		}
 	}
 
@@ -506,7 +517,7 @@ func waitForReattach(ctx context.Context, cl client.Client, recorder record.Even
 				// NB: pv.Annotations cannot be null, as only PVs with the "wait-for-reattach" annotation are considered
 				pv.Annotations[vars.PersistentVolumeWaitForReattachSinceAnnotationPrefix+"/"+nodeName] = now.Format(time.RFC3339)
 
-				if err := cl.Update(ctx, pv); err != nil {
+				if err := e.Client.Update(ctx, pv); err != nil {
 					return "", false, err
 				}
 			}
@@ -520,7 +531,7 @@ func waitForReattach(ctx context.Context, cl client.Client, recorder record.Even
 	return "", true, nil
 }
 
-func evacuateNode(ctx context.Context, lclient *lapi.Client, node *lapi.Node) error {
+func (e *Evacuator) evacuateNode(ctx context.Context, lclient *lapi.Client, node *lapi.Node) error {
 	ress, err := lclient.Resources.GetResourceView(ctx, &lapi.ListOpts{Node: []string{node.Name}})
 	if err != nil && !errors.Is(err, lapi.NotFoundError) {
 		return err
@@ -560,7 +571,7 @@ func evacuateNode(ctx context.Context, lclient *lapi.Client, node *lapi.Node) er
 	return nil
 }
 
-func waitForEvacuation(ctx context.Context, lclient *lapi.Client, nodeName string) (string, bool, error) {
+func (e *Evacuator) waitForEvacuation(ctx context.Context, lclient *lapi.Client, nodeName string) (string, bool, error) {
 	ress, err := lclient.Resources.GetResourceView(ctx, &lapi.ListOpts{Node: []string{nodeName}})
 	if err != nil && !errors.Is(err, lapi.NotFoundError) {
 		return "", false, err
@@ -588,9 +599,9 @@ func waitForEvacuation(ctx context.Context, lclient *lapi.Client, nodeName strin
 	return "", true, nil
 }
 
-func cleanPVsAfterEvacuation(ctx context.Context, cl client.Client, nodeName string) error {
+func (e *Evacuator) cleanPVsAfterEvacuation(ctx context.Context, nodeName string) error {
 	var pvs corev1.PersistentVolumeList
-	err := cl.List(ctx, &pvs)
+	err := e.Client.List(ctx, &pvs)
 	if err != nil {
 		return err
 	}
@@ -605,14 +616,14 @@ func cleanPVsAfterEvacuation(ctx context.Context, cl client.Client, nodeName str
 			delete(pv.Annotations, vars.PersistentVolumeWaitForReattachSinceAnnotationPrefix+"/"+nodeName)
 			delete(pv.Annotations, vars.PersistentVolumeWaitForReattachAnnotationPrefix+"/"+nodeName)
 			delete(pv.Annotations, affinity.OverrideAnnotationPrefix+"/"+nodeName)
-			errs = append(errs, cl.Update(ctx, &pv))
+			errs = append(errs, e.Client.Update(ctx, &pv))
 		}
 	}
 
 	return errors.Join(errs...)
 }
 
-func getDiskfulResourcesOnNode(ctx context.Context, lclient *lapi.Client, nodeName string) ([]string, error) {
+func (e *Evacuator) getDiskfulResourcesOnNode(ctx context.Context, lclient *lapi.Client, nodeName string) ([]string, error) {
 	ress, err := lclient.Resources.GetResourceView(ctx, &lapi.ListOpts{Node: []string{nodeName}})
 	if err != nil && !errors.Is(err, lapi.NotFoundError) {
 		return nil, err
@@ -709,11 +720,11 @@ func isAttachableOnOtherNode(pv *corev1.PersistentVolume, currentNodeName string
 	return false
 }
 
-// PVCOrPVEventf records an event, either for the PVC or for the PV, if no PVC is currently bound.
-func PVCOrPVEventf(recorder record.EventRecorder, pv *corev1.PersistentVolume, eventtype, reason, message string, args ...interface{}) {
+// pvcOrPVEventf records an event, either for the PVC or for the PV, if no PVC is currently bound.
+func (e *Evacuator) pvcOrPVEventf(pv *corev1.PersistentVolume, eventtype, reason, message string, args ...interface{}) {
 	if pv.Spec.ClaimRef != nil {
-		recorder.Eventf(pv.Spec.ClaimRef, eventtype, reason, message, args...)
+		e.Recorder.Eventf(pv.Spec.ClaimRef, eventtype, reason, message, args...)
 	} else {
-		recorder.Eventf(pv, eventtype, reason, message, args...)
+		e.Recorder.Eventf(pv, eventtype, reason, message, args...)
 	}
 }

--- a/pkg/evacuation/evacuation.go
+++ b/pkg/evacuation/evacuation.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	linstor "github.com/LINBIT/golinstor"
@@ -36,11 +37,133 @@ const (
 	VolumeAttachedForEvacuationEvent        = "VolumeAttachedForEvacuation"
 )
 
-// EvacuateSatellite by ensuring all LINSTOR Resource have been moved to other nodes.
+// SatelliteEvacuatedCondition tracks the progress of evacuating volumes off a Satellite.
+const SatelliteEvacuatedCondition = "SatelliteEvacuated"
+
+// admissionMu serializes evacuation admission decisions so concurrent reconciles compute a consistent view
+// of how many Satellites are currently evacuating.
+var admissionMu sync.Mutex
+
+// EvacuateSatellite ensures all LINSTOR Resources have been moved to other nodes, honoring the cluster-wide
+// evacuation concurrency limit, and records the progress on the SatelliteEvacuatedCondition.
+//
+// Returns a message indicating the current progress and a bool indicating if evacuation is complete. The
+// function should be called repeatedly until completion of the evacuation.
+func EvacuateSatellite(ctx context.Context, cl client.Client, lclient *lapi.Client, recorder record.EventRecorder, node *lapi.Node, machineClient *clusterapi.Client, machine *clusterapi.Machine, evacuationStrategy *piraeusiov1.EvacuationStrategy, conds conditions.Conditions, maxConcurrent int) (bool, error) {
+	// Gate evacuation progress on the cluster-wide concurrency limit.
+	admitted, position, total, err := admitEvacuation(ctx, cl, node.Name, maxConcurrent)
+	if err != nil {
+		conds.AddError(SatelliteEvacuatedCondition, err)
+		return false, err
+	}
+
+	if !admitted {
+		msg := fmt.Sprintf("Waiting for a free evacuation slot (position %d of %d candidates, limit %d)", position+1, total, maxConcurrent)
+		conds.AddWaiting(SatelliteEvacuatedCondition, msg)
+		return false, nil
+	}
+
+	msg, done, err := evacuateSatellite(ctx, cl, lclient, recorder, node, machineClient, machine, evacuationStrategy)
+	switch {
+	case err != nil:
+		conds.AddError(SatelliteEvacuatedCondition, err)
+		return false, err
+	case !done:
+		conds.AddInProgress(SatelliteEvacuatedCondition, msg)
+		return false, nil
+	default:
+		conds.AddCompleted(SatelliteEvacuatedCondition, "LINSTOR Satellite evacuated")
+		return true, nil
+	}
+}
+
+// admitEvacuation decides whether the Satellite with the given name may start (or continue) evacuating,
+// honoring the cluster-wide maxConcurrent budget.
+//
+// Admission is derived from the cluster state on every call: all Satellites currently evacuating or waiting
+// for a slot are ordered deterministically - already in-progress evacuations first (so started work is never
+// interrupted), then waiting Satellites by the time they started waiting, then by name - and the first
+// maxConcurrent are admitted. Because every call computes the same order, Satellites converge on the same
+// admitted set without a central lock. A limit of 0 means unlimited.
+//
+// Returns whether the Satellite is admitted, its zero-based position in the ordering, and the total number
+// of candidates.
+func admitEvacuation(ctx context.Context, cl client.Client, name string, maxConcurrent int) (bool, int, int, error) {
+	if maxConcurrent <= 0 {
+		return true, 0, 0, nil
+	}
+
+	admissionMu.Lock()
+	defer admissionMu.Unlock()
+
+	var satellites piraeusiov1.LinstorSatelliteList
+	err := cl.List(ctx, &satellites)
+	if err != nil {
+		return false, 0, 0, err
+	}
+
+	type candidate struct {
+		name       string
+		inProgress bool
+		since      time.Time
+	}
+
+	now := time.Now()
+	var candidates []candidate
+	seenSelf := false
+	for i := range satellites.Items {
+		sat := &satellites.Items[i]
+
+		cond := meta.FindStatusCondition(sat.Status.Conditions, SatelliteEvacuatedCondition)
+		inProgress := cond != nil && cond.Reason == string(conditions.ReasonInProgress)
+		waiting := cond != nil && cond.Reason == string(conditions.ReasonWaiting)
+
+		// Only Satellites that are actively evacuating or already waiting for a slot consume budget. The
+		// Satellite being evacuated is always included, even before it has recorded a condition.
+		if !inProgress && !waiting && sat.Name != name {
+			continue
+		}
+
+		since := now
+		if cond != nil {
+			since = cond.LastTransitionTime.Time
+		}
+
+		candidates = append(candidates, candidate{name: sat.Name, inProgress: inProgress, since: since})
+		if sat.Name == name {
+			seenSelf = true
+		}
+	}
+
+	if !seenSelf {
+		candidates = append(candidates, candidate{name: name, since: now})
+	}
+
+	slices.SortFunc(candidates, func(a, b candidate) int {
+		if a.inProgress != b.inProgress {
+			if a.inProgress {
+				return -1
+			}
+			return 1
+		}
+		if !a.since.Equal(b.since) {
+			return a.since.Compare(b.since)
+		}
+		return strings.Compare(a.name, b.name)
+	})
+
+	position := slices.IndexFunc(candidates, func(c candidate) bool {
+		return c.name == name
+	})
+
+	return position < maxConcurrent, position, len(candidates), nil
+}
+
+// evacuateSatellite runs the evacuation steps, ensuring all LINSTOR Resources have been moved to other nodes.
 //
 // Returns a message indicating the current progress and a bool indicating if evacuation is complete.
 // The function should be called repeatedly until completion of the evacuation.
-func EvacuateSatellite(ctx context.Context, cl client.Client, lclient *lapi.Client, recorder record.EventRecorder, node *lapi.Node, machineClient *clusterapi.Client, machine *clusterapi.Machine, evacuationStrategy *piraeusiov1.EvacuationStrategy) (string, bool, error) {
+func evacuateSatellite(ctx context.Context, cl client.Client, lclient *lapi.Client, recorder record.EventRecorder, node *lapi.Node, machineClient *clusterapi.Client, machine *clusterapi.Machine, evacuationStrategy *piraeusiov1.EvacuationStrategy) (string, bool, error) {
 	// Step 1: ensure PVs can be rescheduled to other nodes
 	msg, done, err := preparePVsforEvacuation(ctx, cl, lclient, recorder, node.Name)
 	if err != nil || !done {

--- a/pkg/evacuation/evacuation_test.go
+++ b/pkg/evacuation/evacuation_test.go
@@ -599,7 +599,12 @@ func runEvacuateSatellite(t *testing.T, cl client.Client, lc *lapi.Client, conds
 	machine, err := machineCl.GetMachineForNode(t.Context(), &node)
 	assert.NoError(t, err)
 
-	done, err := evacuation.EvacuateSatellite(t.Context(), cl, lc, &record.FakeRecorder{}, &satellite, machineCl, machine, &piraeusv1.EvacuationStrategy{
+	evac := &evacuation.Evacuator{
+		Client:        cl,
+		Recorder:      &record.FakeRecorder{},
+		MachineClient: machineCl,
+	}
+	done, err := evac.EvacuateSatellite(t.Context(), lc, &satellite, machine, &piraeusv1.EvacuationStrategy{
 		AttachedVolumeReattachTimeout: metav1.Duration{Duration: 5 * time.Second},
 		UnattachedVolumeAttachTimeout: metav1.Duration{Duration: 10 * time.Second},
 	}, conds, limit)

--- a/pkg/evacuation/evacuation_test.go
+++ b/pkg/evacuation/evacuation_test.go
@@ -85,7 +85,7 @@ func TestEvacuateEmptySatellite(t *testing.T) {
 	cl, lc := setupTestCluster(t, TestNodeA, TestNodeB, MachineA, MachineB)
 
 	// Satellite has no resources, no PVs, no nothing, so evacuation should just complete
-	msg, cont, err := runEvacuateSatellite(t, cl, lc)
+	msg, cont, err := runEvacuateSatellite(t, cl, lc, conditions.New(), 0)
 	assert.NoError(t, err)
 	assert.True(t, cont)
 	assert.Equal(t, "", msg)
@@ -116,7 +116,7 @@ func TestEvacuateSatelliteWithLocalPVs(t *testing.T) {
 	createResource(t, lc, "remote-pv-unattached", "rg1", nil, TestNodeA.Name, TestNodeB.Name)
 
 	// Satellite still has a local-only PV
-	msg, cont, err := runEvacuateSatellite(t, cl, lc)
+	msg, cont, err := runEvacuateSatellite(t, cl, lc, conditions.New(), 0)
 	assert.NoError(t, err)
 	assert.False(t, cont)
 	assert.Contains(t, msg, "Waiting for PVs to be schedulable on other nodes")
@@ -215,7 +215,7 @@ func TestEvacuateSatelliteWithEvacuationActionPVs(t *testing.T) {
 	createResource(t, lc, "local-pv-action-delete-on-rg", "test-rg-delete", nil, TestNodeA.Name)
 
 	// Satellite still has a local-only PV
-	msg, cont, err := runEvacuateSatellite(t, cl, lc)
+	msg, cont, err := runEvacuateSatellite(t, cl, lc, conditions.New(), 0)
 	assert.NoError(t, err)
 	assert.False(t, cont)
 	assert.Contains(t, msg, "Waiting for PVs to be schedulable on other nodes")
@@ -259,7 +259,7 @@ func TestEvacuateSatelliteWaitForOtherSatellites(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Satellite still has a local-only PV
-	msg, cont, err := runEvacuateSatellite(t, cl, lc)
+	msg, cont, err := runEvacuateSatellite(t, cl, lc, conditions.New(), 0)
 	assert.NoError(t, err)
 	assert.False(t, cont)
 	assert.Contains(t, msg, "Waiting for LinstorSatellites to become ready")
@@ -296,7 +296,7 @@ func TestEvacuateSatelliteWaitForReattach(t *testing.T) {
 	)
 
 	// Node A still has a local-only PV attached
-	msg, cont, err := runEvacuateSatellite(t, cl, lc)
+	msg, cont, err := runEvacuateSatellite(t, cl, lc, conditions.New(), 0)
 	assert.NoError(t, err)
 	assert.False(t, cont)
 	assert.Contains(t, msg, "Waiting for PVs to reattach on other nodes")
@@ -346,7 +346,7 @@ func TestEvacuateSatelliteWaitForLinstorEvacuation(t *testing.T) {
 	createResource(t, lc, "remote-pv-unattached", "rg1", nil, TestNodeA.Name)
 
 	// PVs already attached on other Nodes, now waiting for LINSTOR to clear the resource
-	msg, cont, err := runEvacuateSatellite(t, cl, lc)
+	msg, cont, err := runEvacuateSatellite(t, cl, lc, conditions.New(), 0)
 	assert.NoError(t, err)
 	assert.False(t, cont)
 	assert.Contains(t, msg, "Waiting on remaining resources and snapshots: resources")
@@ -390,7 +390,7 @@ func TestEvacuateSatelliteComplete(t *testing.T) {
 	createResource(t, lc, "remote-pv-unattached", "rg1", nil, TestNodeB.Name)
 
 	// PVs already attached on other Nodes, LINSTOR resources cleaned up
-	msg, cont, err := runEvacuateSatellite(t, cl, lc)
+	msg, cont, err := runEvacuateSatellite(t, cl, lc, conditions.New(), 0)
 	assert.NoError(t, err)
 	assert.True(t, cont)
 	assert.Equal(t, "", msg)
@@ -405,6 +405,55 @@ func TestEvacuateSatelliteComplete(t *testing.T) {
 	assert.Contains(t, getSatellite(t, lc, "node-a").Flags, linstor.FlagEvacuate)
 	assert.NotContains(t, getMachine(t, cl, "machine-a").Annotations, vars.MachinePreDrainHookAnnotation)
 	assert.NotContains(t, getMachine(t, cl, "machine-a").Annotations, vars.MachinePreTerminateHookAnnotation)
+}
+
+func TestEvacuateSatelliteUnderLimitProceeds(t *testing.T) {
+	t.Parallel()
+	cl, lc := setupTestCluster(t, TestNodeA, TestNodeB, MachineA, MachineB)
+
+	// node-a is the only candidate, so a limit of 1 still admits it and evacuation completes.
+	conds := conditions.New()
+	msg, cont, err := runEvacuateSatellite(t, cl, lc, conds, 1)
+	assert.NoError(t, err)
+	assert.True(t, cont)
+	assert.Equal(t, "", msg)
+	assert.Contains(t, getSatellite(t, lc, "node-a").Flags, linstor.FlagEvacuate)
+}
+
+func TestEvacuateSatelliteAtLimitWaits(t *testing.T) {
+	t.Parallel()
+	// node-b is already evacuating and the limit is 1, so node-a must wait for a free slot.
+	cl, lc := setupTestCluster(t,
+		TestNodeA, TestNodeB, MachineA, MachineB,
+		createEvacuatingSatellite("node-b", conditions.ReasonInProgress, time.Now()),
+	)
+
+	conds := conditions.New()
+	msg, cont, err := runEvacuateSatellite(t, cl, lc, conds, 1)
+	assert.NoError(t, err)
+	assert.False(t, cont)
+	assert.Contains(t, msg, "Waiting for a free evacuation slot")
+	assert.Equal(t, string(conditions.ReasonWaiting), evacuatedConditionReason(conds))
+
+	// No evacuation step ran: the node is not flagged for evacuation and the Machine keeps its drain hook.
+	assert.NotContains(t, getSatellite(t, lc, "node-a").Flags, linstor.FlagEvacuate)
+	assert.Contains(t, getMachine(t, cl, "machine-a").Annotations, vars.MachinePreDrainHookAnnotation)
+}
+
+func TestEvacuateSatelliteBelowLimitWithOtherInProgress(t *testing.T) {
+	t.Parallel()
+	// node-b is evacuating but the limit is 2, so node-a is also admitted and completes.
+	cl, lc := setupTestCluster(t,
+		TestNodeA, TestNodeB, MachineA, MachineB,
+		createEvacuatingSatellite("node-b", conditions.ReasonInProgress, time.Now()),
+	)
+
+	conds := conditions.New()
+	msg, cont, err := runEvacuateSatellite(t, cl, lc, conds, 2)
+	assert.NoError(t, err)
+	assert.True(t, cont)
+	assert.Equal(t, "", msg)
+	assert.Contains(t, getSatellite(t, lc, "node-a").Flags, linstor.FlagEvacuate)
 }
 
 func createPV(name, accessPolicy string, annotations map[string]string, nodes ...string) *corev1.PersistentVolume {
@@ -537,7 +586,7 @@ func createResource(t *testing.T, lc *lapi.Client, name, resourceGroup string, p
 	}
 }
 
-func runEvacuateSatellite(t *testing.T, cl client.Client, lc *lapi.Client) (string, bool, error) {
+func runEvacuateSatellite(t *testing.T, cl client.Client, lc *lapi.Client, conds conditions.Conditions, limit int) (string, bool, error) {
 	machineCl := clusterapi.NewClient(cl)
 
 	var node corev1.Node
@@ -550,10 +599,66 @@ func runEvacuateSatellite(t *testing.T, cl client.Client, lc *lapi.Client) (stri
 	machine, err := machineCl.GetMachineForNode(t.Context(), &node)
 	assert.NoError(t, err)
 
-	return evacuation.EvacuateSatellite(t.Context(), cl, lc, &record.FakeRecorder{}, &satellite, machineCl, machine, &piraeusv1.EvacuationStrategy{
+	done, err := evacuation.EvacuateSatellite(t.Context(), cl, lc, &record.FakeRecorder{}, &satellite, machineCl, machine, &piraeusv1.EvacuationStrategy{
 		AttachedVolumeReattachTimeout: metav1.Duration{Duration: 5 * time.Second},
 		UnattachedVolumeAttachTimeout: metav1.Duration{Duration: 10 * time.Second},
-	})
+	}, conds, limit)
+
+	// EvacuateSatellite now reports progress on the condition; surface it as the message while evacuation is
+	// still ongoing so the tests can assert on it.
+	var msg string
+	if !done && err == nil {
+		msg = evacuatedConditionMessage(conds)
+	}
+
+	return msg, done, err
+}
+
+// createEvacuatingSatellite builds a LinstorSatellite that already carries a SatelliteEvacuated condition,
+// as if it were mid-evacuation (or queued), so it counts against the concurrency budget. It is still
+// reported as Configured so it does not block other Satellites waiting for peers to become ready.
+func createEvacuatingSatellite(name string, reason conditions.Reason, since time.Time) *piraeusv1.LinstorSatellite {
+	return &piraeusv1.LinstorSatellite{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Generation: 1},
+		Spec:       piraeusv1.LinstorSatelliteSpec{DeletionPolicy: piraeusv1.DeletionPolicyEvacuate},
+		Status: piraeusv1.LinstorSatelliteStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(conditions.Configured),
+					Status:             metav1.ConditionTrue,
+					Reason:             string(conditions.ReasonAsExpected),
+					Message:            "configured",
+					ObservedGeneration: 1,
+				},
+				{
+					Type:               evacuation.SatelliteEvacuatedCondition,
+					Status:             metav1.ConditionFalse,
+					Reason:             string(reason),
+					Message:            "evacuating",
+					LastTransitionTime: metav1.NewTime(since),
+					ObservedGeneration: 1,
+				},
+			},
+		},
+	}
+}
+
+func evacuatedConditionReason(conds conditions.Conditions) string {
+	for _, c := range conds.ToConditions(1) {
+		if c.Type == evacuation.SatelliteEvacuatedCondition {
+			return c.Reason
+		}
+	}
+	return ""
+}
+
+func evacuatedConditionMessage(conds conditions.Conditions) string {
+	for _, c := range conds.ToConditions(1) {
+		if c.Type == evacuation.SatelliteEvacuatedCondition {
+			return c.Message
+		}
+	}
+	return ""
 }
 
 func getSatellite(t *testing.T, lc *lapi.Client, name string) *lapi.Node {


### PR DESCRIPTION
Add LinstorCluster.spec.maxConcurrentEvacuations to cap how many Satellites evacuate at the same time when using the Evacuate deletion policy. A value of 0 (the default) keeps the previous unlimited behavior.

Admission runs as the first step of EvacuateSatellite, which now owns the SatelliteEvacuated condition. Candidates are derived from that condition across all Satellites, so the same gate applies to both direct LinstorSatellite removals and ClusterAPI-driven node removals. Candidates are ordered in-progress first, then oldest waiter, then by name, and the first N are admitted; the rest report a Waiting condition without starting any evacuation step. For ClusterAPI nodes this keeps the pre-drain hook in place, so a waiting node stays running until a slot frees.

A missing LinstorCluster (external controller or teardown) is treated as no limit, so evacuation is never blocked.