### PR TITLE
Bump golinstor to v0.64.0 and use errors.Is

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/piraeusdatastore/piraeus-operator/v2
 go 1.26.1
 
 require (
-	github.com/LINBIT/golinstor v0.63.0
+	github.com/LINBIT/golinstor v0.64.0
 	github.com/cert-manager/cert-manager v1.20.3
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/LINBIT/golinstor v0.63.0 h1:UyMWCg45p8bk/uBAaN+Oki6jkmzEnLh7TA5KhevAkj0=
-github.com/LINBIT/golinstor v0.63.0/go.mod h1:XrBZ/is88K8Bw3QDZaxlwJDSgeMkiiATpv81dlZEOIk=
+github.com/LINBIT/golinstor v0.64.0 h1:WFrpnlGru56gsvLVrJOXmeC2DiVlyUbBemycWcrAr/I=
+github.com/LINBIT/golinstor v0.64.0/go.mod h1:XrBZ/is88K8Bw3QDZaxlwJDSgeMkiiATpv81dlZEOIk=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=

--- a/pkg/linstorhelper/client.go
+++ b/pkg/linstorhelper/client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -18,7 +19,7 @@ import (
 	lapi "github.com/LINBIT/golinstor/client"
 	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -203,7 +204,7 @@ func caReferenceToCert(ctx context.Context, caRef *piraeusv1.CAReference, namesp
 		var secret corev1.Secret
 		err := cl.Get(ctx, types.NamespacedName{Namespace: namespace, Name: caRef.Name}, &secret)
 		if err != nil {
-			if errors.IsNotFound(err) && caRef.Optional != nil && *caRef.Optional {
+			if apierrors.IsNotFound(err) && caRef.Optional != nil && *caRef.Optional {
 				return nil, nil
 			}
 
@@ -215,7 +216,7 @@ func caReferenceToCert(ctx context.Context, caRef *piraeusv1.CAReference, namesp
 		var cm corev1.ConfigMap
 		err := cl.Get(ctx, types.NamespacedName{Namespace: namespace, Name: caRef.Name}, &cm)
 		if err != nil {
-			if errors.IsNotFound(err) && caRef.Optional != nil && *caRef.Optional {
+			if apierrors.IsNotFound(err) && caRef.Optional != nil && *caRef.Optional {
 				return nil, nil
 			}
 
@@ -240,7 +241,7 @@ func (c *Client) CreateOrUpdateNode(ctx context.Context, node lapi.Node) (*lapi.
 	existingNode, err := c.Nodes.Get(ctx, node.Name)
 	if err != nil {
 		// For 404
-		if err != lapi.NotFoundError {
+		if !errors.Is(err, lapi.NotFoundError) {
 			return nil, fmt.Errorf("unable to get node %s: %w", node.Name, err)
 		}
 


### PR DESCRIPTION
golinstor v0.64.0 reworks ApiCallError so it satisfies the standard errors.Is contract (via the new ApiCallRcErr target type).

Convert the last remaining direct sentinel comparison in CreateOrUpdateNode from `err != lapi.NotFoundError` to `!errors.Is(err, lapi.NotFoundError)`, matching how every other call site already tests for NotFoundError.