### PR TITLE
Fix SPDY fallback for exec on older Kubernetes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	k8s.io/client-go v0.36.2
 	k8s.io/component-helpers v0.36.2
 	k8s.io/klog/v2 v2.140.0
+	k8s.io/streaming v0.36.2
 	k8s.io/utils v0.0.0-20260626114624-be93311217bd
 	sigs.k8s.io/cluster-api v1.13.4
 	sigs.k8s.io/controller-runtime v0.24.1
@@ -110,7 +111,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.36.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20260520065146-aa012df4f4af // indirect
 	k8s.io/mount-utils v0.36.2 // indirect
-	k8s.io/streaming v0.36.2 // indirect
 	moul.io/http2curl/v2 v2.3.0 // indirect
 	sigs.k8s.io/gateway-api v1.6.1 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect

--- a/pkg/podexec/podexec.go
+++ b/pkg/podexec/podexec.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/streaming/pkg/httpstream"
 )
 
 // Executor runs a command in a container of a Pod and returns its standard output and standard error. The error


### PR DESCRIPTION
client-go 0.36 moved the streaming helpers into the new k8s.io/streaming staging module: the WebSocket transport now returns UpgradeFailureError from k8s.io/streaming/pkg/httpstream. The apimachinery copy of IsUpgradeFailure only matches its own, now distinct, error type, so the fallback to SPDY never triggered and pod exec failed against API servers without WebSocket exec support, breaking storage pool probing.

Detect the upgrade failure using k8s.io/streaming/pkg/httpstream, the same package client-go reports it from.