### PR TITLE
controller: fix detection of volume group snapshots

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix detection of VolumeGroupSnapshots API.
+
 ## [v2.11.0-rc.1] - 2026-07-24
 
 ### Added

--- a/internal/controller/linstorcluster_controller.go
+++ b/internal/controller/linstorcluster_controller.go
@@ -1384,7 +1384,7 @@ func (r *LinstorClusterReconciler) SetupWithManager(mgr ctrl.Manager, opts contr
 	r.APIVersion = apiDiscovery.ServerVersion()
 	r.SupportsVolumeGroupSnapshots = apiDiscovery.HasGroupVersionResource(schema.GroupVersionResource{
 		Group:    "groupsnapshot.storage.k8s.io",
-		Version:  "v1beta2",
+		Version:  "v1",
 		Resource: "volumegroupsnapshots",
 	})
 


### PR DESCRIPTION
The current csi-snapshotter sidecar uses the "v1" API for Volume Group Snapshots. However, we detected only the "v1beta2". This causes issues in clusters where only v1beta2 and no v1 is available: the CSI snapshotter hangs indefinitely as it cannot watch the Volume Group Snapshot API.

The fix is to align the check with current API.