### PR TITLE
Merge host LVM config into satellite lvm.conf

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The minimum supported Kubernetes version is now v1.30.
 
+### Fixed
+
+- Actually merge the host's `lvm.conf` and `lvmlocal.conf` into the LVM configuration used by the satellite, and copy over LVM profiles from the host.
+
 ## [v2.11.0] - 2026-08-04
 
 ### Added

--- a/pkg/resources/satellite/satellite/daemonset.yaml
+++ b/pkg/resources/satellite/satellite/daemonset.yaml
@@ -74,7 +74,12 @@ spec:
               # Looks like the host has LVM configured:
               # * disable monitoring via dmeventd
               # * do not look at DRBD devices
-              lvmconfig --type current --mergedconfig --config 'activation { monitoring = 0 } devices { global_filter = [ "r|^/dev/drbd|" ] }' > /etc/lvm/lvm.conf
+              # lvmconfig merges the hosts lvm.conf and lvmlocal.conf into the
+              # generated config; profiles are separate files, so copy them.
+              if [ -d /host/etc/lvm/profile ]; then
+                cp -r /host/etc/lvm/profile /etc/lvm/
+              fi
+              LVM_SYSTEM_DIR=/host/etc/lvm lvmconfig --type current --mergedconfig --config 'activation { monitoring = 0 } devices { global_filter = [ "r|^/dev/drbd|" ] }' > /etc/lvm/lvm.conf
             else
               # Most likely, no LVM installed, which also means no udev rules
               # * disable udev sync and rules


### PR DESCRIPTION
The setup-lvm-configuration init container mounts the host LVM configuration at /host/etc/lvm, but lvmconfig read its base config from /etc/lvm, which at that point is an empty emptyDir. The generated config was merged from the compiled-in defaults instead of the host settings.

Point lvmconfig at the host configuration via LVM_SYSTEM_DIR, which also picks up lvmlocal.conf. Profiles are separate files not covered by the merge, so copy them over as well.