### PR TITLE
Support shared LVM storage pools

### DIFF
--- a/api/v1/storagepool.go
+++ b/api/v1/storagepool.go
@@ -128,6 +128,20 @@ func (p *LinstorStoragePool) VgCreateArguments() []string {
 	}
 }
 
+// SharedSpace returns the name of the shared space this storage pool belongs to, if any.
+func (p *LinstorStoragePool) SharedSpace() string {
+	if p.LvmPool != nil {
+		return p.LvmPool.SharedSpace
+	}
+
+	return ""
+}
+
+// ExternalLocking reports whether locking of the shared backing storage is managed outside of LINSTOR.
+func (p *LinstorStoragePool) ExternalLocking() bool {
+	return p.LvmPool != nil && p.LvmPool.ExternalLocking
+}
+
 func (p *LinstorStoragePool) LvCreateArguments() []string {
 	switch {
 	case p.LvmThinPool != nil:
@@ -186,6 +200,17 @@ type LinstorStoragePoolLvm struct {
 	// This has no effect on an existing VG, it only applies when the VG initially gets created.
 	// +kubebuilder:validation:Optional
 	VolumeGroupCreateArguments []string `json:"volumeGroupCreateArguments,omitempty"`
+
+	// SharedSpace marks the VG as shared between multiple nodes, identified by the given name.
+	// All storage pools backed by the same physical storage must use the same shared space name.
+	// A shared VG must be set up manually on the hosts, it cannot be created from source devices.
+	// +kubebuilder:validation:Optional
+	SharedSpace string `json:"sharedSpace,omitempty"`
+
+	// ExternalLocking skips LINSTOR's internal locking for the shared VG, relying on an external
+	// lock manager such as lvmlockd on the hosts instead.
+	// +kubebuilder:validation:Optional
+	ExternalLocking bool `json:"externalLocking,omitempty"`
 }
 
 type LinstorStoragePoolLvmThin struct {

--- a/charts/piraeus/templates/crds.yaml
+++ b/charts/piraeus/templates/crds.yaml
@@ -1381,6 +1381,11 @@ spec:
                     lvmPool:
                       description: Configures a LVM Volume Group as storage pool.
                       properties:
+                        externalLocking:
+                          description: |-
+                            ExternalLocking skips LINSTOR's internal locking for the shared VG, relying on an external
+                            lock manager such as lvmlockd on the hosts instead.
+                          type: boolean
                         physicalVolumeCreateArguments:
                           description: |-
                             PhysicalVolumeCreateArguments are arguments to pass to "pvcreate".
@@ -1388,6 +1393,12 @@ spec:
                           items:
                             type: string
                           type: array
+                        sharedSpace:
+                          description: |-
+                            SharedSpace marks the VG as shared between multiple nodes, identified by the given name.
+                            All storage pools backed by the same physical storage must use the same shared space name.
+                            A shared VG must be set up manually on the hosts, it cannot be created from source devices.
+                          type: string
                         volumeGroup:
                           description: VolumeGroup is the name of the Volume Group
                             (VG) to use.
@@ -2055,6 +2066,11 @@ spec:
                     lvmPool:
                       description: Configures a LVM Volume Group as storage pool.
                       properties:
+                        externalLocking:
+                          description: |-
+                            ExternalLocking skips LINSTOR's internal locking for the shared VG, relying on an external
+                            lock manager such as lvmlockd on the hosts instead.
+                          type: boolean
                         physicalVolumeCreateArguments:
                           description: |-
                             PhysicalVolumeCreateArguments are arguments to pass to "pvcreate".
@@ -2062,6 +2078,12 @@ spec:
                           items:
                             type: string
                           type: array
+                        sharedSpace:
+                          description: |-
+                            SharedSpace marks the VG as shared between multiple nodes, identified by the given name.
+                            All storage pools backed by the same physical storage must use the same shared space name.
+                            A shared VG must be set up manually on the hosts, it cannot be created from source devices.
+                          type: string
                         volumeGroup:
                           description: VolumeGroup is the name of the Volume Group
                             (VG) to use.

--- a/config/crd/bases/piraeus.io_linstorsatelliteconfigurations.yaml
+++ b/config/crd/bases/piraeus.io_linstorsatelliteconfigurations.yaml
@@ -452,6 +452,11 @@ spec:
                     lvmPool:
                       description: Configures a LVM Volume Group as storage pool.
                       properties:
+                        externalLocking:
+                          description: |-
+                            ExternalLocking skips LINSTOR's internal locking for the shared VG, relying on an external
+                            lock manager such as lvmlockd on the hosts instead.
+                          type: boolean
                         physicalVolumeCreateArguments:
                           description: |-
                             PhysicalVolumeCreateArguments are arguments to pass to "pvcreate".
@@ -459,6 +464,12 @@ spec:
                           items:
                             type: string
                           type: array
+                        sharedSpace:
+                          description: |-
+                            SharedSpace marks the VG as shared between multiple nodes, identified by the given name.
+                            All storage pools backed by the same physical storage must use the same shared space name.
+                            A shared VG must be set up manually on the hosts, it cannot be created from source devices.
+                          type: string
                         volumeGroup:
                           description: VolumeGroup is the name of the Volume Group
                             (VG) to use.

--- a/config/crd/bases/piraeus.io_linstorsatellites.yaml
+++ b/config/crd/bases/piraeus.io_linstorsatellites.yaml
@@ -421,6 +421,11 @@ spec:
                     lvmPool:
                       description: Configures a LVM Volume Group as storage pool.
                       properties:
+                        externalLocking:
+                          description: |-
+                            ExternalLocking skips LINSTOR's internal locking for the shared VG, relying on an external
+                            lock manager such as lvmlockd on the hosts instead.
+                          type: boolean
                         physicalVolumeCreateArguments:
                           description: |-
                             PhysicalVolumeCreateArguments are arguments to pass to "pvcreate".
@@ -428,6 +433,12 @@ spec:
                           items:
                             type: string
                           type: array
+                        sharedSpace:
+                          description: |-
+                            SharedSpace marks the VG as shared between multiple nodes, identified by the given name.
+                            All storage pools backed by the same physical storage must use the same shared space name.
+                            A shared VG must be set up manually on the hosts, it cannot be created from source devices.
+                          type: string
                         volumeGroup:
                           description: VolumeGroup is the name of the Volume Group
                             (VG) to use.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support shared LVM storage pools: setting `lvmPool.sharedSpace` registers the storage pool as backed by storage
+  shared between nodes, optionally using an external lock manager such as lvmlockd (`lvmPool.externalLocking`).
+
 ### Changed
 
 - The minimum supported Kubernetes version is now v1.30.

--- a/docs/reference/linstorsatelliteconfiguration.md
+++ b/docs/reference/linstorsatelliteconfiguration.md
@@ -159,6 +159,14 @@ the matching key. Available types are:
       pool is first set up from a `source`.
     * `volumeGroupCreateArguments`: Additional arguments to pass to the `vgcreate` command. Only applies when the
       pool is first set up from a `source`.
+    * `sharedSpace`: Mark the Volume Group as shared between multiple nodes, for example when backed by a SAN.
+      The given name identifies the shared space in LINSTOR: all storage pools backed by the same physical storage
+      must use the same shared space name. A shared VG must be set up manually on the hosts, it cannot be created
+      from a `source`.
+    * `externalLocking`: Skip LINSTOR's internal locking for the shared VG, relying on an external lock manager
+      such as [`lvmlockd`](https://man7.org/linux/man-pages/man8/lvmlockd.8.html) running on the hosts instead.
+      The Operator mounts the host's lvmlockd pid file and sockets into the satellite container, so the pod only
+      starts once `lvmlockd` is running on the host. Requires `sharedSpace` to be set.
 *   `lvmThinPool`: Configures a [LVM Thin Pool](https://man7.org/linux/man-pages/man7/lvmthin.7.html) as storage pool.
 
     Arguments:

--- a/internal/controller/linstorsatellite_controller.go
+++ b/internal/controller/linstorsatellite_controller.go
@@ -259,8 +259,11 @@ func (r *LinstorSatelliteReconciler) kustomizeNodeResources(ctx context.Context,
 	}
 
 	var bindMountPaths []string
+	externalLocking := false
 	for i := range lsatellite.Spec.StoragePools {
 		pool := &lsatellite.Spec.StoragePools[i]
+
+		externalLocking = externalLocking || pool.ExternalLocking()
 
 		if pool.FilePool == nil && pool.FileThinPool == nil {
 			continue
@@ -282,6 +285,15 @@ func (r *LinstorSatelliteReconciler) kustomizeNodeResources(ctx context.Context,
 
 	if len(bindMountPaths) > 0 {
 		p, err := SatelliteHostPathVolumeEnvPatch(bindMountPaths)
+		if err != nil {
+			return nil, err
+		}
+
+		patches = append(patches, p...)
+	}
+
+	if externalLocking {
+		p, err := SatelliteLvmlockdPatch()
 		if err != nil {
 			return nil, err
 		}
@@ -598,6 +610,11 @@ func (r *LinstorSatelliteReconciler) reconcileStoragePools(ctx context.Context, 
 					StoragePoolName: pool.Name,
 					ProviderKind:    pool.ProviderKind(),
 					Props:           linstorhelper.UpdateLastApplyProperty(expectedProperties),
+					// LINSTOR only honors the free space manager name when creating a storage pool,
+					// it ignores the dedicated shared_space field on this endpoint.
+					FreeSpaceMgrName: pool.SharedSpace(),
+					SharedSpace:      pool.SharedSpace(),
+					ExternalLocking:  pool.ExternalLocking(),
 				})
 				if err != nil {
 					errs = append(errs, fmt.Errorf("failed to create storage pool %q: %w", pool.Name, err))

--- a/internal/controller/linstorsatellite_test.go
+++ b/internal/controller/linstorsatellite_test.go
@@ -194,6 +194,32 @@ var _ = Describe("LinstorSatelliteReconciler", func() {
 			}).Should(Succeed())
 		})
 
+		It("should mount lvmlockd files for shared storage pools with external locking", func(ctx context.Context) {
+			err := k8sClient.Patch(ctx, &piraeusiov1.LinstorSatellite{
+				TypeMeta:   TypeMeta,
+				ObjectMeta: metav1.ObjectMeta{Name: ExampleNodeName},
+				Spec: piraeusiov1.LinstorSatelliteSpec{
+					StoragePools: []piraeusiov1.LinstorStoragePool{
+						{
+							Name:    "shared-pool",
+							LvmPool: &piraeusiov1.LinstorStoragePoolLvm{VolumeGroup: "vg1", SharedSpace: "space1", ExternalLocking: true},
+						},
+					},
+				},
+			}, client.Apply, client.FieldOwner("test"), client.ForceOwnership)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				var ds appsv1.DaemonSet
+				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: Namespace, Name: "linstor-satellite." + ExampleNodeName}, &ds)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(ds.Spec.Template.Spec.Volumes).To(ContainElement(HaveField("HostPath.Path", "/run/lvmlockd.pid")))
+				container := GetContainer(ds.Spec.Template.Spec.Containers, "linstor-satellite")
+				g.Expect(container).NotTo(BeNil())
+				g.Expect(container.VolumeMounts).To(ContainElement(HaveField("Name", "run-lvmlockd-pid")))
+			}).Should(Succeed())
+		})
+
 		It("should convert bare pod patches to daemonset patches", func(ctx context.Context) {
 			err := k8sClient.Patch(ctx, &piraeusiov1.LinstorSatellite{
 				TypeMeta:   TypeMeta,

--- a/internal/controller/patches.go
+++ b/internal/controller/patches.go
@@ -313,6 +313,18 @@ func SatellitePrecompiledModulePatch() ([]kusttypes.Patch, error) {
 	)
 }
 
+// SatelliteLvmlockdPatch mounts the host's lvmlockd pid file into the satellite container.
+// The lvmlockd sockets are covered by the /run/lvm mount in the base resources, which LVM
+// always requires. The pid file lives directly in /run; it is patched in separately so we
+// don't have to expose the host's entire /run tmpfs just for this one optional file.
+func SatelliteLvmlockdPatch() ([]kusttypes.Patch, error) {
+	return render(
+		satellite.Resources,
+		"patches/lvmlockd.yaml",
+		nil,
+	)
+}
+
 func SatelliteHostPathVolumePatch(volumeName, hostPath string) ([]kusttypes.Patch, error) {
 	return render(
 		satellite.Resources,

--- a/internal/controller/storagepool_probe_test.go
+++ b/internal/controller/storagepool_probe_test.go
@@ -295,3 +295,61 @@ func TestReconcileStoragePools(t *testing.T) {
 		})
 	}
 }
+
+func TestReconcileStoragePoolsSharedSpace(t *testing.T) {
+	t.Parallel()
+
+	fake := fakelinstor.New()
+	defer fake.Server.Close()
+
+	u, err := url.Parse(fake.Server.URL)
+	if err != nil {
+		t.Fatalf("failed to parse fake server URL: %v", err)
+	}
+
+	lapiClient, err := lapi.NewClient(lapi.BaseURL(u))
+	if err != nil {
+		t.Fatalf("failed to create LINSTOR client: %v", err)
+	}
+
+	r := &LinstorSatelliteReconciler{
+		Namespace:   "ns",
+		log:         logr.Discard(),
+		PodExecutor: &fakeExecutor{fn: constExecutor("  vg1\n", nil)},
+	}
+
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns"}}
+	lsatellite := &piraeusiov1.LinstorSatellite{
+		ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+		Spec: piraeusiov1.LinstorSatelliteSpec{
+			StoragePools: []piraeusiov1.LinstorStoragePool{{
+				Name:    "pool1",
+				LvmPool: &piraeusiov1.LinstorStoragePoolLvm{VolumeGroup: "vg1", SharedSpace: "shared", ExternalLocking: true},
+			}},
+		},
+	}
+
+	err = r.reconcileStoragePools(context.Background(), &linstorhelper.Client{Client: lapiClient}, lsatellite, node, pod)
+	if err != nil {
+		t.Fatalf("reconcileStoragePools() err = %v", err)
+	}
+
+	var registered *lapi.StoragePool
+	for _, sp := range fake.StoragePools() {
+		if sp.StoragePoolName == "pool1" && sp.NodeName == "node1" {
+			registered = &sp
+			break
+		}
+	}
+	if registered == nil {
+		t.Fatalf("storage pool not registered")
+	}
+
+	if registered.FreeSpaceMgrName != "shared" {
+		t.Errorf("free space manager = %q, want %q", registered.FreeSpaceMgrName, "shared")
+	}
+	if !registered.ExternalLocking {
+		t.Errorf("external locking not set on registered storage pool")
+	}
+}

--- a/internal/webhook/v1/linstorsatelliteconfiguration_webhook_test.go
+++ b/internal/webhook/v1/linstorsatelliteconfiguration_webhook_test.go
@@ -280,6 +280,72 @@ var _ = Describe("LinstorSatelliteConfiguration webhook", func() {
 		Expect(statusErr.ErrStatus.Details.Causes[3].Field).To(Equal("spec.properties.3.expandFrom"))
 	})
 
+	It("should reject invalid shared storage pools", func(ctx context.Context) {
+		satelliteConfig := &piraeusv1.LinstorSatelliteConfiguration{
+			TypeMeta:   typeMeta,
+			ObjectMeta: metav1.ObjectMeta{Name: "shared-storage-pools"},
+			Spec: piraeusv1.LinstorSatelliteConfigurationSpec{
+				StoragePools: []piraeusv1.LinstorStoragePool{
+					{
+						Name:    "invalid-name",
+						LvmPool: &piraeusv1.LinstorStoragePoolLvm{VolumeGroup: "vg1", SharedSpace: "not;a;valid;name"},
+					},
+					{
+						Name:    "locking-without-shared",
+						LvmPool: &piraeusv1.LinstorStoragePoolLvm{VolumeGroup: "vg2", ExternalLocking: true},
+					},
+					{
+						Name:    "shared-with-source",
+						LvmPool: &piraeusv1.LinstorStoragePoolLvm{VolumeGroup: "vg3", SharedSpace: "space3"},
+						Source:  &piraeusv1.LinstorStoragePoolSource{HostDevices: []string{"/dev/vdc"}},
+					},
+				},
+			},
+		}
+		err := k8sClient.Patch(ctx, satelliteConfig, client.Apply, client.FieldOwner("test"), client.ForceOwnership)
+		Expect(err).To(HaveOccurred())
+		var statusErr *k8serrors.StatusError
+		errors.As(err, &statusErr)
+		Expect(statusErr).NotTo(BeNil())
+		Expect(statusErr.ErrStatus.Details).NotTo(BeNil())
+		Expect(statusErr.ErrStatus.Details.Causes).To(ConsistOf(
+			HaveField("Field", Equal("spec.storagePools.0.lvmPool.sharedSpace")),
+			HaveField("Field", Equal("spec.storagePools.1.lvmPool.externalLocking")),
+			HaveField("Field", Equal("spec.storagePools.2.lvmPool.sharedSpace")),
+		))
+	})
+
+	It("should reject changing shared storage pool settings", func(ctx context.Context) {
+		satelliteConfig := &piraeusv1.LinstorSatelliteConfiguration{
+			TypeMeta:   typeMeta,
+			ObjectMeta: metav1.ObjectMeta{Name: "shared-storage-pools"},
+			Spec: piraeusv1.LinstorSatelliteConfigurationSpec{
+				StoragePools: []piraeusv1.LinstorStoragePool{
+					{
+						Name:    "shared-pool",
+						LvmPool: &piraeusv1.LinstorStoragePoolLvm{VolumeGroup: "vg1", SharedSpace: "space1", ExternalLocking: true},
+					},
+				},
+			},
+		}
+		err := k8sClient.Patch(ctx, satelliteConfig.DeepCopy(), client.Apply, client.FieldOwner("test"), client.ForceOwnership)
+		Expect(err).NotTo(HaveOccurred())
+
+		satelliteConfigCopy := satelliteConfig.DeepCopy()
+		satelliteConfigCopy.Spec.StoragePools[0].LvmPool.SharedSpace = "space2"
+		satelliteConfigCopy.Spec.StoragePools[0].LvmPool.ExternalLocking = false
+		err = k8sClient.Patch(ctx, satelliteConfigCopy, client.Apply, client.FieldOwner("test"), client.ForceOwnership)
+		Expect(err).To(HaveOccurred())
+		var statusErr *k8serrors.StatusError
+		errors.As(err, &statusErr)
+		Expect(statusErr).NotTo(BeNil())
+		Expect(statusErr.ErrStatus.Details).NotTo(BeNil())
+		Expect(statusErr.ErrStatus.Details.Causes).To(ConsistOf(
+			HaveField("Field", Equal("spec.storagePools.0.lvmPool.sharedSpace")),
+			HaveField("Field", Equal("spec.storagePools.0.lvmPool.externalLocking")),
+		))
+	})
+
 	It("should reject storage pool changes", func(ctx context.Context) {
 		err := k8sClient.Patch(ctx, complexSatelliteConfig.DeepCopy(), client.Apply, client.FieldOwner("test"), client.ForceOwnership)
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/webhook/v1/storagepool.go
+++ b/internal/webhook/v1/storagepool.go
@@ -17,6 +17,10 @@ import (
 var (
 	SPRegexp = regexp.MustCompile("^[A-Za-z0-9][A-Za-z0-9_-]{1,46}[A-Za-z0-9]$")
 	VGRegexp = regexp.MustCompile("^[A-Za-z0-9.+_-]+$")
+	// SharedSpaceRegexp matches valid LINSTOR shared storage pool names, which additionally
+	// must contain at least one letter (see SharedSpaceLetterRegexp).
+	SharedSpaceRegexp       = regexp.MustCompile("^[A-Za-z0-9_][A-Za-z0-9._-]{0,47}$")
+	SharedSpaceLetterRegexp = regexp.MustCompile("[A-Za-z]")
 )
 
 func ValidateStoragePools(curSPs, oldSPs []piraeusv1.LinstorStoragePool, fieldPrefix *field.Path) (admission.Warnings, field.ErrorList) {
@@ -216,6 +220,42 @@ func validateLinstorStoragePoolLvm(newSP *piraeusv1.LinstorStoragePoolLvm, oldSP
 		errs = append(errs, field.Forbidden(
 			fieldPrefix.Child("volumeGroup"),
 			"Cannot change VG name",
+		))
+	}
+
+	if newSP.SharedSpace != "" && (!SharedSpaceRegexp.MatchString(newSP.SharedSpace) || !SharedSpaceLetterRegexp.MatchString(newSP.SharedSpace)) {
+		errs = append(errs, field.Invalid(
+			fieldPrefix.Child("sharedSpace"),
+			newSP.SharedSpace,
+			"Not a valid shared storage pool name",
+		))
+	}
+
+	if newSP.SharedSpace != "" && src != nil {
+		errs = append(errs, field.Forbidden(
+			fieldPrefix.Child("sharedSpace"),
+			"Cannot create a shared VG from source devices, it must be set up manually",
+		))
+	}
+
+	if newSP.ExternalLocking && newSP.SharedSpace == "" {
+		errs = append(errs, field.Forbidden(
+			fieldPrefix.Child("externalLocking"),
+			"External locking requires a shared VG",
+		))
+	}
+
+	if oldSP != nil && oldSP.LvmPool != nil && newSP.SharedSpace != oldSP.LvmPool.SharedSpace {
+		errs = append(errs, field.Forbidden(
+			fieldPrefix.Child("sharedSpace"),
+			"Cannot change shared space name",
+		))
+	}
+
+	if oldSP != nil && oldSP.LvmPool != nil && newSP.ExternalLocking != oldSP.LvmPool.ExternalLocking {
+		errs = append(errs, field.Forbidden(
+			fieldPrefix.Child("externalLocking"),
+			"Cannot change external locking",
 		))
 	}
 

--- a/pkg/fakelinstor/fakelinstor.go
+++ b/pkg/fakelinstor/fakelinstor.go
@@ -389,6 +389,14 @@ func (f *FakeLinstor) createStoragePool(r *http.Request) (any, error) {
 
 	sp.NodeName = r.PathValue("node")
 
+	// Mirror the LINSTOR controller: only the free space manager name is honored when creating a
+	// storage pool, the shared_space field is ignored and never set in responses. Without an
+	// explicit shared space, the pool gets the reserved per-node "<node>;<pool>" name.
+	sp.SharedSpace = ""
+	if sp.FreeSpaceMgrName == "" {
+		sp.FreeSpaceMgrName = sp.NodeName + ";" + sp.StoragePoolName
+	}
+
 	f.mu.Lock()
 	defer f.mu.Unlock()
 

--- a/pkg/resources/satellite/patches/lvmlockd.yaml
+++ b/pkg/resources/satellite/patches/lvmlockd.yaml
@@ -1,0 +1,25 @@
+---
+- target:
+    group: apps
+    version: v1
+    kind: DaemonSet
+    name: linstor-satellite
+  patch: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: linstor-satellite
+    spec:
+      template:
+        spec:
+          volumes:
+            - name: run-lvmlockd-pid
+              hostPath:
+                path: /run/lvmlockd.pid
+                type: File
+          containers:
+            - name: linstor-satellite
+              volumeMounts:
+                - name: run-lvmlockd-pid
+                  mountPath: /run/lvmlockd.pid
+                  readOnly: true


### PR DESCRIPTION
Allow marking a LVM storage pool as backed by storage shared between nodes, such as a SAN. Setting the new "lvmPool.sharedSpace" field registers the pool with the given shared space name in LINSTOR. Shared VGs must be set up manually by the user, they cannot be created from source devices. LINSTOR only supports shared pools for plain LVM, not LVM thin.

Optionally, "lvmPool.externalLocking" skips LINSTOR's internal locking in favor of an external lock manager such as lvmlockd. In that case the satellite pod is patched to mount the host's /run/lvmlockd.pid; the lvmlockd sockets in /run/lvm are already part of the base satellite mounts.

The webhook validates the shared space name against LINSTOR's rules, rejects sources on shared pools, requires a shared space for external locking, and forbids changing either field on an existing pool.