### PR TITLE
Remove cluster-wide Secret RBAC, document S3 backups

### DIFF
--- a/charts/piraeus/templates/rbac.yaml
+++ b/charts/piraeus/templates/rbac.yaml
@@ -15,7 +15,6 @@ rules:
     - events
     - persistentvolumes
     - pods
-    - secrets
     - serviceaccounts
     - services
   verbs:
@@ -317,6 +316,27 @@ rules:
     - volumeattachments/status
   verbs:
     - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "piraeus-operator.fullname" . }}-controller-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "piraeus-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - secrets
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/piraeus/templates/rolebindings.yaml
+++ b/charts/piraeus/templates/rolebindings.yaml
@@ -17,6 +17,22 @@ subjects:
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "piraeus-operator.fullname" . }}-controller-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "piraeus-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "piraeus-operator.fullname" . }}-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: {{ include "piraeus-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "piraeus-operator.fullname" . }}-controller-manager

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - service_account.yaml
 - role.yaml
 - role_binding.yaml
+- namespaced_role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
 # Comment the following 4 lines if you want to disable

--- a/config/rbac/namespaced_role_binding.yaml
+++ b/config/rbac/namespaced_role_binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: manager-namespaced-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: controller-manager
+subjects:
+- kind: ServiceAccount
+  name: controller-manager

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -11,7 +11,6 @@ rules:
   - events
   - persistentvolumes
   - pods
-  - secrets
   - serviceaccounts
   - services
   verbs:
@@ -313,3 +312,22 @@ rules:
   - volumeattachments/status
   verbs:
   - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: controller-manager
+  namespace: system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Removed the cluster-wide permission to read Secrets from the CSI controller: access to Secrets referenced in a `VolumeSnapshotClass`, such as S3 credentials, now needs to be [granted explicitly](./how-to/s3-backup.md).
+- Removed the cluster-wide permission to read and modify Secrets from the Operator: it now manages Secrets only in its own namespace, using a namespaced Role.
 - Removed the deprecated `csi-health-monitor` sidecar (csi-external-health-monitor-controller) from the CSI controller
   deployment, along with its RBAC rules and default image.
 

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -110,6 +110,10 @@ These guides show you how to configure a specific aspect or achieve a specific t
 
     [:octicons-arrow-right-24: Guide](./consistency-groups.md)
 
+*   Back Up Volumes to S3
+
+    [:octicons-arrow-right-24: Guide](./s3-backup.md)
+
 </div>
 
 ## Maintenance Tasks

--- a/docs/how-to/s3-backup.md
+++ b/docs/how-to/s3-backup.md
@@ -1,0 +1,230 @@
+# How to Back Up Volumes to S3
+
+This guide shows you how to store snapshots of your volumes in S3 compatible object storage, and how to restore
+them.
+
+LINSTOR® can upload snapshots to an S3 compatible bucket, registered as a "remote" in LINSTOR. In Kubernetes,
+this is triggered by creating a `VolumeSnapshot` using a specially configured `VolumeSnapshotClass`: in addition
+to creating the snapshot in the storage pool, LINSTOR uploads the snapshot content to the bucket. Because the
+uploaded data is stored outside the cluster, it remains available even if a volume, a node, or the whole cluster
+is lost, making it suitable for backups and disaster recovery.
+
+To follow the steps in this guide, you should be familiar with creating and restoring snapshots of single
+volumes. Learn about them in the [snapshots tutorial](../tutorial/snapshots.md).
+
+## Prerequisites
+
+* An installed and configured Piraeus Datastore. Learn how to get started in our
+  [introduction tutorial](../tutorial/get-started.md).
+* A storage pool supporting snapshots. LINSTOR supports snapshots for `LVM_THIN`, `FILE_THIN`, `ZFS` and
+  `ZFS_THIN` pools.
+* A cluster with the [`snapshot-controller`](https://github.com/kubernetes-csi/external-snapshotter/) deployed.
+  The [snapshots tutorial](../tutorial/snapshots.md#prerequisites) shows how to check for and deploy it.
+* A LINSTOR passphrase, configured through
+  [`LinstorCluster.spec.linstorPassphraseSecret`](../reference/linstorcluster.md#speclinstorpassphrasesecret).
+  LINSTOR uses the passphrase to encrypt the S3 credentials before storing them in its database.
+* An S3 compatible bucket, for example on Amazon S3, Ceph Object Gateway or MinIO, along with an access key and
+  secret key that allow reading and writing the bucket content.
+
+## Storing the S3 Credentials
+
+The access key and secret key for the bucket are stored in a Secret. The Secret can be placed in any namespace:
+in this guide, it is placed alongside the other Piraeus Datastore resources in the `piraeus-datastore`
+namespace.
+
+```
+$ kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: s3-backup-credentials
+  namespace: piraeus-datastore
+type: linstor.csi.linbit.com/s3-credentials.v1
+immutable: true
+stringData:
+  access-key: ACCESS_KEY
+  secret-key: SECRET_KEY
+EOF
+```
+
+## Granting Access to the Credentials
+
+Backups are created by the LINSTOR CSI driver, which receives the credentials from the `csi-snapshotter` sidecar
+of the `linstor-csi-controller` Deployment. As a security precaution, the sidecar is deployed **without** any
+permission to read Secrets: you choose which Secrets it can read by explicitly granting access.
+
+Create a Role in the namespace containing the Secret, allowing read access to only this Secret, and bind it to
+the `linstor-csi-controller` ServiceAccount:
+
+```
+$ kubectl apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: read-s3-backup-credentials
+  # Must be the namespace containing the Secret.
+  namespace: piraeus-datastore
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "secrets" ]
+    resourceNames: [ "s3-backup-credentials" ]
+    verbs: [ "get" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: read-s3-backup-credentials
+  # Must be the namespace containing the Secret.
+  namespace: piraeus-datastore
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: read-s3-backup-credentials
+subjects:
+  - kind: ServiceAccount
+    name: linstor-csi-controller
+    # Must be the namespace of the Piraeus Datastore deployment.
+    namespace: piraeus-datastore
+EOF
+```
+
+The credentials are used when creating a backup, and again when deleting it. Keep the Secret and this grant in
+place for as long as any backup created with these credentials exists.
+
+## Creating the VolumeSnapshotClass
+
+A `VolumeSnapshotClass` configures where and how snapshots are shipped, using parameters prefixed with
+`snap.linstor.csi.linbit.com/`, and references the credentials Secret created above:
+
+```
+$ kubectl apply -f - <<EOF
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: piraeus-s3-backup
+driver: linstor.csi.linbit.com
+deletionPolicy: Delete
+parameters:
+  snap.linstor.csi.linbit.com/type: S3
+  snap.linstor.csi.linbit.com/remote-name: backup-remote
+  snap.linstor.csi.linbit.com/allow-incremental: "false"
+  snap.linstor.csi.linbit.com/s3-bucket: my-piraeus-backups
+  snap.linstor.csi.linbit.com/s3-endpoint: s3.us-west-1.amazonaws.com
+  snap.linstor.csi.linbit.com/s3-signing-region: us-west-1
+  snap.linstor.csi.linbit.com/s3-use-path-style: "false"
+  csi.storage.k8s.io/snapshotter-secret-name: s3-backup-credentials
+  csi.storage.k8s.io/snapshotter-secret-namespace: piraeus-datastore
+EOF
+```
+
+The parameters control the following behavior:
+
+* `type: S3` uploads every snapshot created with this class to the S3 remote.
+* `remote-name` sets the name under which the remote is registered in LINSTOR. The LINSTOR CSI driver registers
+  the remote automatically, using the endpoint, bucket, region and credentials from the remaining parameters.
+* `allow-incremental` chooses between full backups for every snapshot, or uploading only the changes since the
+  previous snapshot. Incremental backups form a chain: use `max-increments` or `full-snapshot-after` to bound
+  the chain, so that older backups eventually become reclaimable.
+* `delete-local: "true"` optionally removes the snapshot from the local storage pool once the upload completes,
+  keeping only the copy in the bucket.
+* `s3-bucket`, `s3-endpoint`, `s3-signing-region` and `s3-use-path-style` describe the S3 endpoint. Learn more
+  about them in the
+  [LINSTOR User's Guide](https://linbit.com/drbd-user-guide/linstor-guide-1_0-en/#s-shipping_snapshots).
+* `csi.storage.k8s.io/snapshotter-secret-name` and `csi.storage.k8s.io/snapshotter-secret-namespace` reference
+  the Secret created above. These parameters support
+  [templating](https://kubernetes-csi.github.io/docs/secrets-and-credentials-volume-snapshot-class.html), for
+  example to choose a Secret based on the namespace of the `VolumeSnapshot`. When using templated names, widen
+  the Role from the previous section to cover the expected Secrets.
+
+## Creating a Backup
+
+We use the same example workload as the [snapshots tutorial](../tutorial/snapshots.md#creating-an-example-workload),
+which logs a message to the `data-volume` PersistentVolumeClaim. Creating a backup works exactly like creating a
+regular snapshot, only using the `VolumeSnapshotClass` created above:
+
+```
+$ kubectl apply -f - <<EOF
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: data-volume-backup-1
+spec:
+  volumeSnapshotClassName: piraeus-s3-backup
+  source:
+    persistentVolumeClaimName: data-volume
+EOF
+```
+
+The snapshot becomes ready once the upload to the bucket is complete:
+
+```
+$ kubectl wait volumesnapshot --for=jsonpath='{.status.readyToUse}'=true data-volume-backup-1
+volumesnapshot.snapshot.storage.k8s.io/data-volume-backup-1 condition met
+```
+
+In LINSTOR, we can verify that the remote was registered and the backup uploaded:
+
+```
+$ kubectl -n piraeus-datastore exec deploy/linstor-controller -- linstor remote list
++-------------------------------------------------------------------------+
+| Name          | Type | Info                                             |
+|=========================================================================|
+| backup-remote | S3   | us-west-1.s3.us-west-1.amazonaws.com/my-piraeus- |
+|               |      | backups                                          |
++-------------------------------------------------------------------------+
+$ kubectl -n piraeus-datastore exec deploy/linstor-controller -- linstor backup list backup-remote
++------------------------------------------------------------------------------------------------------------------------+
+| Resource                                 | Snapshot                                      | Finished at         | Status |
+|==========================================================================================================================|
+| pvc-9c04b307-d22d-454f-8f24-ed5837fe4426 | snapshot-a8757c1d-cd37-42d2-9557-a24b1222d118 | 2026-08-27 09:15:41 | Success |
++------------------------------------------------------------------------------------------------------------------------+
+```
+
+## Restoring a Backup
+
+Within the same cluster, restoring a backup works exactly like restoring a regular snapshot: create a new
+PersistentVolumeClaim referencing the `VolumeSnapshot` as its data source, as shown in the
+[snapshots tutorial](../tutorial/snapshots.md#restoring-from-a-snapshot). If the local snapshot was removed with
+`delete-local`, LINSTOR automatically downloads the snapshot data from the bucket.
+
+Because the bucket content is independent of the cluster, backups can also be restored into a **different**
+LINSTOR cluster, for example when recovering from the loss of the original cluster. This requires registering
+the remote and restoring the backup using the LINSTOR client, as described in the
+[LINSTOR User's Guide](https://linbit.com/drbd-user-guide/linstor-guide-1_0-en/#s-shipping_snapshots).
+
+## Backing Up Consistency Groups
+
+Volumes in a [consistency group](./consistency-groups.md) are backed up with a `VolumeGroupSnapshotClass` using
+the same `snap.linstor.csi.linbit.com/` parameters as above. Only the parameters referencing the credentials
+Secret are named differently:
+
+```yaml
+  csi.storage.k8s.io/group-snapshotter-secret-name: s3-backup-credentials
+  csi.storage.k8s.io/group-snapshotter-secret-namespace: piraeus-datastore
+```
+
+The Secret is read by the same ServiceAccount, so the grant from
+[Granting Access to the Credentials](#granting-access-to-the-credentials) applies without changes.
+
+Uploading a `VolumeGroupSnapshot` to S3 works only for members of a consistency group: they share a single
+LINSTOR resource, which is uploaded as one backup. A `VolumeGroupSnapshot` of volumes that are not in a
+consistency group spans multiple LINSTOR resources and can not be uploaded to a remote.
+
+## Troubleshooting
+
+If access to the credentials Secret is missing, the `VolumeSnapshot` never becomes ready, and describing it
+shows an error event similar to:
+
+```
+$ kubectl describe volumesnapshot data-volume-backup-1
+...
+Events:
+  Type     Reason                  Age   From                 Message
+  ----     ------                  ----  ----                 -------
+  Warning  SnapshotContentCheckandUpdateFailed  10s  snapshot-controller  Failed to check and update snapshot content: error getting secret s3-backup-credentials in namespace piraeus-datastore: secrets "s3-backup-credentials" is forbidden: User "system:serviceaccount:piraeus-datastore:linstor-csi-controller" cannot get resource "secrets" in API group "" in the namespace "piraeus-datastore"
+```
+
+Verify that the Role and RoleBinding from [Granting Access to the Credentials](#granting-access-to-the-credentials)
+exist in the namespace containing the Secret, that the Role names the Secret in `resourceNames`, and that the
+RoleBinding subject references the `linstor-csi-controller` ServiceAccount in the namespace of the Piraeus
+Datastore deployment.

--- a/docs/upgrade/README.md
+++ b/docs/upgrade/README.md
@@ -14,6 +14,76 @@ $ kubectl apply --server-side -f "https://github.com/piraeusdatastore/piraeus-op
 $ kubectl wait pod --for=condition=Ready -n piraeus-datastore --all
 ```
 
+# Upgrades from v2.11 to v2.12
+
+The CSI controller no longer has cluster-wide permission to read Secrets. This permission was only used by the
+`csi-snapshotter` sidecar to read the Secrets referenced in a `VolumeSnapshotClass`, for example S3 credentials
+for [backups to S3](../how-to/s3-backup.md).
+
+To list all `VolumeSnapshotClass` resources along with the Secrets they reference, run:
+
+```
+$ kubectl get volumesnapshotclasses -o custom-columns='NAME:.metadata.name,SECRET-NAMESPACE:.parameters.csi\.storage\.k8s\.io/snapshotter-secret-namespace,SECRET-NAME:.parameters.csi\.storage\.k8s\.io/snapshotter-secret-name'
+NAME                SECRET-NAMESPACE    SECRET-NAME
+piraeus-s3-backup   piraeus-datastore   s3-backup-credentials
+piraeus-snapshots   <none>              <none>
+```
+
+If any Secret is referenced, grant the `linstor-csi-controller` ServiceAccount access to it **before**
+upgrading, otherwise creating new snapshots and deleting existing ones will fail. Create the following
+resources, replacing `NAMESPACE` with the namespace containing the Secret and `SECRET-NAME` with the name of
+the Secret:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: read-snapshot-secret
+  namespace: NAMESPACE
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "secrets" ]
+    resourceNames: [ SECRET-NAME ]
+    verbs: [ "get" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: read-snapshot-secret
+  namespace: NAMESPACE
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: read-snapshot-secret
+subjects:
+  - kind: ServiceAccount
+    name: linstor-csi-controller
+    # Must be the namespace of the Piraeus Datastore deployment.
+    namespace: piraeus-datastore
+```
+
+Alternatively, restore the previous cluster-wide access by patching the ClusterRole through the
+`LinstorCluster` resource:
+
+```yaml
+apiVersion: piraeus.io/v1
+kind: LinstorCluster
+metadata:
+  name: linstorcluster
+spec:
+  patches:
+    - target:
+        kind: ClusterRole
+        name: linstor-csi-controller
+      patch: |-
+        - op: add
+          path: /rules/-
+          value:
+            apiGroups: [ "" ]
+            resources: [ "secrets" ]
+            verbs: [ "get" ]
+```
+
 # Upgrades from v2.8 to v2.9
 
 Generally, no special steps required.

--- a/internal/controller/linstorcluster_controller.go
+++ b/internal/controller/linstorcluster_controller.go
@@ -90,7 +90,8 @@ type LinstorClusterReconciler struct {
 //+kubebuilder:rbac:groups=piraeus.io,resources=linstorsatellites,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=piraeus.io,resources=linstorsatelliteconfigurations,verbs=get;list;watch
 //+kubebuilder:rbac:groups=piraeus.io,resources=linstorsatelliteconfigurations/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups="",resources=persistentvolumes;events;configmaps;secrets;services;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=persistentvolumes;events;configmaps;services;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete,namespace=system
 //+kubebuilder:rbac:groups="",resources=pods,verbs=list;watch;delete
 //+kubebuilder:rbac:groups="",resources=pods/eviction,verbs=create
 //+kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=get;list;watch;create;update;patch

--- a/internal/controller/linstorsatellite_controller.go
+++ b/internal/controller/linstorsatellite_controller.go
@@ -85,7 +85,8 @@ type LinstorSatelliteReconciler struct {
 //+kubebuilder:rbac:groups=piraeus.io,resources=linstorsatellites,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=piraeus.io,resources=linstorsatellites/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=piraeus.io,resources=linstorsatellites/finalizers,verbs=update
-//+kubebuilder:rbac:groups="",resources=pods;configmaps;secrets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=pods;configmaps,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete,namespace=system
 //+kubebuilder:rbac:groups="",resources=pods/exec,verbs=create;get
 //+kubebuilder:rbac:groups="apps",resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
       - Use the Host Network for DRBD Replication: how-to/drbd-host-networking.md
     - Volumes and Snapshots:
       - Use Consistency Groups: how-to/consistency-groups.md
+      - Back Up Volumes to S3: how-to/s3-backup.md
     - Maintenance Tasks:
       - Troubleshoot Piraeus Datastore: how-to/troubleshooting.md
       - Monitor Piraeus Datastore with Prometheus Operator: how-to/monitoring.md

--- a/pkg/resources/cluster/csi-controller/csi-controller-service-account.yaml
+++ b/pkg/resources/cluster/csi-controller/csi-controller-service-account.yaml
@@ -72,12 +72,11 @@ rules:
     resources: [ "volumeattachments" ]
     verbs: [ "get", "list", "watch" ]
 # csi-snapshotter rules
+# NB: no rule for "secrets": access to snapshot secrets (such as S3 credentials for remote
+# snapshot shipping) must be granted explicitly by the user, see docs/how-to/s3-backup.md.
   - apiGroups: [ "" ]
     resources: [ "events" ]
     verbs: [ "list", "watch", "create", "update", "patch" ]
-  - apiGroups: [ "" ]
-    resources: [ "secrets" ]
-    verbs: [ "get", "list" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotclasses" ]
     verbs: [ "get", "list", "watch" ]

--- a/tools/copy-rbac-config-to-chart.sh
+++ b/tools/copy-rbac-config-to-chart.sh
@@ -25,6 +25,20 @@ EOF
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  name: {{ include "piraeus-operator.fullname" . }}-controller-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "piraeus-operator.labels" . | nindent 4 }}
+rules:
+EOF
+
+	${KUSTOMIZE} build config/default | ${YQ} eval 'select(.kind=="Role" and .metadata.name=="piraeus-operator-controller-manager").rules'
+
+	cat <<EOF
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   name: {{ include "piraeus-operator.fullname" . }}-leader-election
   namespace: {{ .Release.Namespace }}
   labels:


### PR DESCRIPTION
The CSI controller ServiceAccount had cluster-wide permission to read all Secrets, only used by the csi-snapshotter sidecar to fetch Secrets referenced in a VolumeSnapshotClass. Drop the rule and require users to grant access to the specific Secret instead, matching the upstream external-snapshotter default.

With no deployed ClusterRole granting Secret access anymore, the Operator itself no longer needs cluster-wide Secret permissions either: move them to a namespaced Role, as the Operator only manages Secrets in its own namespace.

Add a how-to guide for S3 backups, covering the new explicit grant, and upgrade notes for existing users of snapshot secrets.