### PR TITLE
Certificate rotation for LINSTOR components

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shared between nodes, optionally using an external lock manager such as lvmlockd (`lvmPool.externalLocking`).
 - Support rotation of Satellite TLS certificates: with `internalTLS` enabled, the Satellite container will restart
   to pick up a rotated certificate.
+- Support rotation of Controller TLS certificates: with `internalTLS` or `apiTLS` enabled, restarting the Controller
+  container to pick up a rotated certificate.
 
 ### Changed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support shared LVM storage pools: setting `lvmPool.sharedSpace` registers the storage pool as backed by storage
   shared between nodes, optionally using an external lock manager such as lvmlockd (`lvmPool.externalLocking`).
+- Support rotation of Satellite TLS certificates: with `internalTLS` enabled, the Satellite container will restart
+  to pick up a rotated certificate.
 
 ### Changed
 

--- a/docs/how-to/api-tls.md
+++ b/docs/how-to/api-tls.md
@@ -172,5 +172,12 @@ curl: (60) SSL: no alternative certificate subject name matches target host name
 
 In this case, make sure you have specified the right subject names when provisioning the certificates.
 
+## Certificate Rotation
+
+The LINSTOR Controller only reads the API TLS certificates during start-up. To ensure rotated certificates are picked
+up, the Operator deploys the Controller with a liveness probe that compares the certificates used during container start-up,
+which is what the Controller loads, with the certificates on disk. When the certificates no longer match, for example after
+cert-manager renewed the certificate, the probe fails and the Controller container is restarted, loading the new certificate.
+
 All available options are documented in the reference for
 [`LinstorCluster`](../reference/linstorcluster.md#specapitls).

--- a/docs/how-to/internal-tls.md
+++ b/docs/how-to/internal-tls.md
@@ -174,6 +174,15 @@ k8s_secret_trusted_by satellite-tls controller-tls
 # satellite-tls.tls.crt: OK
 ```
 
+## Certificate Rotation
+
+LINSTOR only reads certificates during start-up. To ensure rotated certificates are picked up, for example after
+cert-manager renewed a certificate, the Operator deploys the Satellite with a liveness probe that detects
+stale certificates. When the probe fails, the container is restarted, loading the new certificates.
+
+The restart does not interrupt replication: DRBD® connections are handled entirely in the kernel and remain up while
+the Satellite container restarts.
+
 All available options are documented in the reference for
 [`LinstorCluster`](../reference/linstorcluster.md#specinternaltls) and
 [`LinstorSatelliteConfiguration`](../reference/linstorsatelliteconfiguration.md#specinternaltls).

--- a/docs/how-to/internal-tls.md
+++ b/docs/how-to/internal-tls.md
@@ -177,8 +177,8 @@ k8s_secret_trusted_by satellite-tls controller-tls
 ## Certificate Rotation
 
 LINSTOR only reads certificates during start-up. To ensure rotated certificates are picked up, for example after
-cert-manager renewed a certificate, the Operator deploys the Satellite with a liveness probe that detects
-stale certificates. When the probe fails, the container is restarted, loading the new certificates.
+cert-manager renewed a certificate, the Operator deploys the Satellite and Controller with liveness probes that detect
+stale certificates. When a probe fails, the container is restarted, loading the new certificates.
 
 The restart does not interrupt replication: DRBD® connections are handled entirely in the kernel and remain up while
 the Satellite container restarts.

--- a/internal/controller/linstorcluster_controller.go
+++ b/internal/controller/linstorcluster_controller.go
@@ -462,6 +462,15 @@ func (r *LinstorClusterReconciler) kustomizeControllerResources(lcluster *piraeu
 		}
 	}
 
+	if lcluster.Spec.InternalTLS != nil || lcluster.Spec.ApiTLS != nil {
+		p, err := ClusterControllerCertRotationPatch()
+		if err != nil {
+			return nil, err
+		}
+
+		patches = append(patches, p...)
+	}
+
 	if lcluster.Spec.Controller.GetTemplate() != nil {
 		p, err := ComponentPodTemplate("Deployment", "linstor-controller", lcluster.Spec.Controller.GetTemplate())
 		if err != nil {

--- a/internal/controller/linstorcluster_test.go
+++ b/internal/controller/linstorcluster_test.go
@@ -581,6 +581,13 @@ var _ = Describe("LinstorCluster controller", func() {
 			err := k8sClient.Get(ctx, types.NamespacedName{Name: "linstor-controller", Namespace: Namespace}, &controllerDeployment)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(controllerDeployment.Spec.Template.Spec.Volumes).To(ContainElement(HaveField("Projected.Sources", ContainElement(HaveField("Secret.Name", "my-controller-internal-tls")))))
+
+			container := GetContainer(controllerDeployment.Spec.Template.Spec.Containers, "linstor-controller")
+			g.Expect(container).NotTo(BeNil())
+			g.Expect(container.LivenessProbe).NotTo(BeNil())
+			g.Expect(container.LivenessProbe.HTTPGet).To(BeNil())
+			g.Expect(container.LivenessProbe.Exec).NotTo(BeNil())
+			g.Expect(container.LivenessProbe.Exec.Command).To(ContainElement(ContainSubstring("/etc/linstor/ssl-pem")))
 		}).Should(Succeed())
 	})
 
@@ -661,6 +668,13 @@ var _ = Describe("LinstorCluster controller", func() {
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(controllerDeployment.Spec.Template.Spec.Volumes).To(ContainElement(HaveField("Projected.Sources", ContainElement(HaveField("Secret.Name", "my-api-tls")))))
 			g.Expect(controllerDeployment.Spec.Template.Spec.Volumes).To(ContainElement(HaveField("Projected.Sources", ContainElement(HaveField("Secret.Name", "my-client-tls")))))
+
+			container := GetContainer(controllerDeployment.Spec.Template.Spec.Containers, "linstor-controller")
+			g.Expect(container).NotTo(BeNil())
+			g.Expect(container.LivenessProbe).NotTo(BeNil())
+			g.Expect(container.LivenessProbe.HTTPGet).To(BeNil())
+			g.Expect(container.LivenessProbe.Exec).NotTo(BeNil())
+			g.Expect(container.LivenessProbe.Exec.Command).To(ContainElement(ContainSubstring("/etc/linstor/https-pem")))
 		}).Should(Succeed())
 
 		envCheck := func(g Gomega, container *corev1.Container, secretName string) {

--- a/internal/controller/linstorsatellite_test.go
+++ b/internal/controller/linstorsatellite_test.go
@@ -126,6 +126,12 @@ var _ = Describe("LinstorSatelliteReconciler", func() {
 			Expect(ds.Spec.Template.Spec.Containers[0].Ports).To(HaveLen(1))
 			Expect(ds.Spec.Template.Spec.Containers[0].Ports[0].Name).To(Equal("linstor"))
 			Expect(ds.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort).To(Equal(int32(3367)))
+
+			Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe).NotTo(BeNil())
+			Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe.TCPSocket).To(BeNil())
+			Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe.Exec).NotTo(BeNil())
+			Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe.Exec.Command).To(ContainElement(ContainSubstring("/etc/linstor/ssl/keystore.jks")))
+			Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe.Exec.Command).To(ContainElement(ContainSubstring("/etc/linstor/ssl-pem/tls.crt")))
 		})
 
 		It("should use the configured resource name suffix separator", func(ctx context.Context) {

--- a/internal/controller/patches.go
+++ b/internal/controller/patches.go
@@ -169,6 +169,14 @@ func ClusterApiTLSPatch(apiSecretName, clientSecretName string, caRef *piraeusio
 		})
 }
 
+func ClusterControllerCertRotationPatch() ([]kusttypes.Patch, error) {
+	return render(
+		cluster.Resources,
+		"patches/controller-cert-rotation.yaml",
+		nil,
+	)
+}
+
 func ClusterApiTLSCertManagerPatch(secretName string, issuer *cmmetav1.IssuerReference, dnsNames []string) ([]kusttypes.Patch, error) {
 	return render(
 		cluster.Resources,

--- a/pkg/resources/cluster/patches/controller-cert-rotation.yaml
+++ b/pkg/resources/cluster/patches/controller-cert-rotation.yaml
@@ -1,0 +1,44 @@
+---
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: linstor-controller
+  patch: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: linstor-controller
+    spec:
+      template:
+        spec:
+          containers:
+            - name: linstor-controller
+              livenessProbe:
+                httpGet: null
+                periodSeconds: 30
+                timeoutSeconds: 10
+                exec:
+                  command:
+                    - /bin/sh
+                    - -ec
+                    # The controller only loads certificates on startup: the container
+                    # entrypoint converts the PEM certificates into Java keystores,
+                    # which the JVM reads once. Comparing the keystores with the PEM
+                    # files detects rotated certificates, failing the probe so the
+                    # restarted container picks them up. Unlike a TLS handshake check,
+                    # this also covers the internal TLS certificate, which is only used
+                    # as a client certificate for connections to the satellites.
+                    - |
+                      compare_cert() {
+                        [ -d "$1" ] || return 0
+                        ON_DISK="$(openssl x509 -in "$1/tls.crt" -noout -fingerprint -sha256)"
+                        IN_USE="$(keytool -exportcert -rfc -alias linstor -keystore "$2" -storepass linstor | openssl x509 -noout -fingerprint -sha256)"
+                        if [ "$IN_USE" != "$ON_DISK" ]; then
+                          echo "TLS certificate $1/tls.crt was rotated (loaded: $IN_USE, on disk: $ON_DISK), restarting to load the new certificate"
+                          return 1
+                        fi
+                      }
+                      curl -fsS -o /dev/null http://localhost:3370/health
+                      compare_cert /etc/linstor/ssl-pem /etc/linstor/ssl/keystore.jks
+                      compare_cert /etc/linstor/https-pem /etc/linstor/https/keystore.jks

--- a/pkg/resources/satellite/patches/internal-tls.yaml
+++ b/pkg/resources/satellite/patches/internal-tls.yaml
@@ -30,6 +30,28 @@
                 - containerPort: 3367
                   name: linstor
                   protocol: TCP
+              livenessProbe:
+                tcpSocket: null
+                periodSeconds: 30
+                timeoutSeconds: 10
+                exec:
+                  command:
+                    - /bin/sh
+                    - -ec
+                    # The satellite only loads certificates on startup: the container
+                    # entrypoint converts the PEM certificates into a Java keystore,
+                    # which the JVM reads once. Comparing the keystore with the PEM
+                    # file detects rotated certificates, failing the probe so the
+                    # restarted container picks them up. The socat call keeps the
+                    # connectivity check of the replaced tcpSocket probe.
+                    - |
+                      socat -u OPEN:/dev/null TCP:localhost:3367
+                      IN_USE="$(keytool -exportcert -rfc -alias linstor -keystore /etc/linstor/ssl/keystore.jks -storepass linstor | openssl x509 -noout -fingerprint -sha256)"
+                      ON_DISK="$(openssl x509 -in /etc/linstor/ssl-pem/tls.crt -noout -fingerprint -sha256)"
+                      if [ "$IN_USE" != "$ON_DISK" ]; then
+                        echo "TLS certificate /etc/linstor/ssl-pem/tls.crt was rotated (loaded: $IN_USE, on disk: $ON_DISK), restarting to load the new certificate"
+                        exit 1
+                      fi
               volumeMounts:
                 - name: internal-tls
                   mountPath: /etc/linstor/ssl-pem


### PR DESCRIPTION
Adds liveness probes for LINSTOR Controller and Satellites, that ensure the containers get restarted once Certificates rotate.

To this end, we compare the k8s managed `*.pem/*.crt` files with what gets imported into the java keystore. 