### PR TITLE
Set fsGroupPolicy File on CSIDriver

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set `fsGroupPolicy: File` on the CSIDriver, so `fsGroup` is also applied to `ReadWriteMany` volumes in `Filesystem`
+  mode.
+
 ## [v2.12.0-rc.1] - 2026-09-02
 
 ### Added

--- a/docs/upgrade/README.md
+++ b/docs/upgrade/README.md
@@ -16,6 +16,12 @@ $ kubectl wait pod --for=condition=Ready -n piraeus-datastore --all
 
 # Upgrades from v2.11 to v2.12
 
+The CSIDriver now uses `fsGroupPolicy: File`. Previously, a Pod's `fsGroup` was only applied to `ReadWriteOnce`
+volumes. Now it is also applied to `ReadWriteMany` volumes in `Filesystem` mode, changing the ownership of all files on
+the NFS export when a Pod with `fsGroup` starts. For large volumes, set `fsGroupChangePolicy: OnRootMismatch` in the
+Pod's `securityContext` to skip the recursive ownership change when the root directory already has the expected owner.
+Applying `fsGroup` requires the default `no_root_squash` NFS export setting.
+
 The CSI controller no longer has cluster-wide permission to read Secrets. This permission was only used by the
 `csi-snapshotter` sidecar to read the Secrets referenced in a `VolumeSnapshotClass`, for example S3 credentials
 for [backups to S3](../how-to/s3-backup.md).

--- a/pkg/resources/cluster/csi-controller/csi-driver.yaml
+++ b/pkg/resources/cluster/csi-controller/csi-driver.yaml
@@ -5,7 +5,7 @@ metadata:
   name: linstor.csi.linbit.com
 spec:
   attachRequired: true
-  fsGroupPolicy: ReadWriteOnceWithFSType
+  fsGroupPolicy: File
   podInfoOnMount: true
   volumeLifecycleModes:
     - Persistent


### PR DESCRIPTION
With ReadWriteOnceWithFSType, Kubernetes only applies a Pod's fsGroup to ReadWriteOnce volumes. Switch to File so fsGroup is also applied to ReadWriteMany volumes in Filesystem mode, which are served over NFS with no_root_squash by default.

Document the behaviour change in the upgrade notes, including the recommendation to use fsGroupChangePolicy OnRootMismatch for large volumes.

Fixes https://github.com/piraeusdatastore/linstor-csi/issues/456